### PR TITLE
Remove hard-coded default branch names in tests

### DIFF
--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -38,7 +38,7 @@ namespace NGitLab.Mock
 
         public string Description { get; set; }
 
-        public string DefaultBranch { get; set; } = "master";
+        public string DefaultBranch { get; set; } = "main";
 
         public string WebUrl => Server.MakeUrl(PathWithNamespace);
 

--- a/NGitLab.Tests/BranchClientTests.cs
+++ b/NGitLab.Tests/BranchClientTests.cs
@@ -15,7 +15,7 @@ namespace NGitLab.Tests
             var branchClient = context.Client.GetRepository(project.Id).Branches;
             var currentUser = context.Client.Users.Current;
 
-            var masterBranch = branchClient["master"];
+            var masterBranch = branchClient[project.DefaultBranch];
             Assert.NotNull(masterBranch);
 
             var commit = masterBranch.Commit;

--- a/NGitLab.Tests/CommitStatusTests.cs
+++ b/NGitLab.Tests/CommitStatusTests.cs
@@ -42,7 +42,7 @@ namespace NGitLab.Tests
                     RawContent = "test",
                     CommitMessage = "Commit for CommitStatusTests",
                     Path = "CommitStatusTests.txt",
-                    Branch = "master",
+                    Branch = project.DefaultBranch,
                 };
                 context.Client.GetRepository(project.Id).Files.Create(upsert);
                 var commit = context.Client.GetCommits(project.Id).GetCommit(upsert.Branch);
@@ -71,7 +71,7 @@ namespace NGitLab.Tests
             {
                 return new CommitStatusCreate
                 {
-                    Ref = "master",
+                    Ref = Project.DefaultBranch,
                     CommitSha = Commit.Id.ToString(),
                     Name = "Commit for CommitStatusTests",
                     State = state,

--- a/NGitLab.Tests/CommitsTests.cs
+++ b/NGitLab.Tests/CommitsTests.cs
@@ -13,7 +13,7 @@ namespace NGitLab.Tests
             using var context = await GitLabTestContext.CreateAsync();
             var project = context.CreateProject(initializeWithCommits: true);
 
-            var commit = context.Client.GetCommits(project.Id).GetCommit("master");
+            var commit = context.Client.GetCommits(project.Id).GetCommit(project.DefaultBranch);
             Assert.IsNotNull(commit.Message);
             Assert.IsNotNull(commit.ShortId);
         }
@@ -25,7 +25,7 @@ namespace NGitLab.Tests
             var project = context.CreateProject(initializeWithCommits: true);
             context.Client.GetRepository(project.Id).Files.Create(new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "file to be updated",
                 Path = "CommitStats.txt",
                 RawContent = "I'm defective and i need to be fixeddddddddddddddd",
@@ -33,13 +33,13 @@ namespace NGitLab.Tests
 
             context.Client.GetRepository(project.Id).Files.Update(new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "fixing the file",
                 Path = "CommitStats.txt",
                 RawContent = "I'm no longer defective and i have been fixed\n\n\r\n\r\rEnjoy",
             });
 
-            var commit = context.Client.GetCommits(project.Id).GetCommit("master");
+            var commit = context.Client.GetCommits(project.Id).GetCommit(project.DefaultBranch);
             Assert.AreEqual(4, commit.Stats.Additions);
             Assert.AreEqual(1, commit.Stats.Deletions);
             Assert.AreEqual(5, commit.Stats.Total);

--- a/NGitLab.Tests/ContributorsTests.cs
+++ b/NGitLab.Tests/ContributorsTests.cs
@@ -50,13 +50,13 @@ namespace NGitLab.Tests
                 WebsiteURL = "wp.pl",
             };
 
-            User user = context.AdminClient.Users.Create(userUpsert);
+            var user = context.AdminClient.Users.Create(userUpsert);
             context.Client.GetCommits(project.Id).Create(new CommitCreate()
             {
                 AuthorName = userUpsert.Name,
                 AuthorEmail = userUpsert.Email,
-                Branch = "master",
-                StartBranch = "master",
+                Branch = project.DefaultBranch,
+                StartBranch = project.DefaultBranch,
                 ProjectId = project.Id,
                 CommitMessage = "test",
             });

--- a/NGitLab.Tests/FilesTests.cs
+++ b/NGitLab.Tests/FilesTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests
             var fileName = "test.md";
             var fileUpsert = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Add SonarQube badges to README.md",
                 RawContent = "test",
                 Encoding = "base64",
@@ -27,7 +27,7 @@ namespace NGitLab.Tests
             };
             filesClient.Create(fileUpsert);
 
-            var file = filesClient.Get(fileName, "master");
+            var file = filesClient.Get(fileName, project.DefaultBranch);
             Assert.IsNotNull(file);
             Assert.AreEqual(fileName, file.Name);
             Assert.AreEqual("test", file.DecodedContent);
@@ -35,19 +35,19 @@ namespace NGitLab.Tests
             fileUpsert.RawContent = "test2";
             filesClient.Update(fileUpsert);
 
-            file = filesClient.Get(fileName, "master");
+            file = filesClient.Get(fileName, project.DefaultBranch);
             Assert.IsNotNull(file);
             Assert.AreEqual("test2", file.DecodedContent);
 
             var fileDelete = new FileDelete()
             {
                 Path = fileName,
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Delete file",
             };
             filesClient.Delete(fileDelete);
 
-            Assert.Throws(Is.InstanceOf<GitLabException>(), () => filesClient.Get("testDelete.md", "master"));
+            Assert.Throws(Is.InstanceOf<GitLabException>(), () => filesClient.Get("testDelete.md", project.DefaultBranch));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace NGitLab.Tests
             var content1 = "test";
             var fileUpsert1 = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Add SonarQube badges to README.md",
                 RawContent = $"{content1}{Environment.NewLine}",
                 Encoding = "base64",
@@ -69,7 +69,7 @@ namespace NGitLab.Tests
             };
             filesClient.Create(fileUpsert1);
 
-            var blameArray1 = filesClient.Blame(fileName, "master");
+            var blameArray1 = filesClient.Blame(fileName, project.DefaultBranch);
 
             Assert.AreEqual(1, blameArray1.Length);
             Assert.IsNotNull(blameArray1);
@@ -88,7 +88,7 @@ namespace NGitLab.Tests
             var content2 = "second line";
             var fileUpsert2 = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "SecondCommit",
                 RawContent = $"{content1}{Environment.NewLine}{content2}",
                 Encoding = "base64",
@@ -96,7 +96,7 @@ namespace NGitLab.Tests
             };
             filesClient.Update(fileUpsert2);
 
-            var blameArray2 = filesClient.Blame(fileName, "master");
+            var blameArray2 = filesClient.Blame(fileName, project.DefaultBranch);
 
             Assert.AreEqual(2, blameArray2.Length);
             Assert.AreEqual(firstBlameInfo, blameArray2[0]);
@@ -115,7 +115,7 @@ namespace NGitLab.Tests
             var fileDelete = new FileDelete()
             {
                 Path = fileName,
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Delete file",
             };
             filesClient.Delete(fileDelete);
@@ -132,7 +132,7 @@ namespace NGitLab.Tests
             var content1 = $"test{Environment.NewLine}";
             var fileUpsert1 = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Add SonarQube badges to README.md",
                 RawContent = content1,
                 Encoding = "base64",
@@ -140,7 +140,7 @@ namespace NGitLab.Tests
             };
             filesClient.Create(fileUpsert1);
 
-            var initialBlame = filesClient.Blame(fileName, "master");
+            var initialBlame = filesClient.Blame(fileName, project.DefaultBranch);
 
             Assert.IsNotNull(initialBlame);
             Assert.AreEqual(1, initialBlame.Length);
@@ -150,7 +150,7 @@ namespace NGitLab.Tests
             var content2 = "second line";
             var fileUpsert2 = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = $"SecondCommit{Environment.NewLine}",
                 RawContent = $"{content1}{content2}",
                 Encoding = "base64",
@@ -166,7 +166,7 @@ namespace NGitLab.Tests
             var fileDelete = new FileDelete()
             {
                 Path = fileName,
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Delete file",
             };
             filesClient.Delete(fileDelete);
@@ -183,7 +183,7 @@ namespace NGitLab.Tests
             var content1 = $"test{Environment.NewLine}";
             var fileUpsert1 = new FileUpsert
             {
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Add SonarQube badges to README.md",
                 RawContent = content1,
                 Encoding = "base64",
@@ -191,7 +191,7 @@ namespace NGitLab.Tests
             };
             filesClient.Create(fileUpsert1);
 
-            var realBlame = filesClient.Blame(fileName, "master");
+            var realBlame = filesClient.Blame(fileName, project.DefaultBranch);
 
             Assert.IsNotNull(realBlame);
             Assert.AreEqual(1, realBlame.Length);
@@ -209,7 +209,7 @@ namespace NGitLab.Tests
             var fileDelete = new FileDelete()
             {
                 Path = fileName,
-                Branch = "master",
+                Branch = project.DefaultBranch,
                 CommitMessage = "Delete file",
             };
             filesClient.Delete(fileDelete);

--- a/NGitLab.Tests/JobTests.cs
+++ b/NGitLab.Tests/JobTests.cs
@@ -39,7 +39,7 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
 
             client.GetRepository(project.Id).Files.Create(new FileUpsert
             {
-                Branch = "main",
+                Branch = project.DefaultBranch,
                 CommitMessage = "test",
                 Path = ".gitlab-ci.yml",
                 Content = content,

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -64,8 +64,8 @@ namespace NGitLab.Tests
                 mergeRequestClient.Create(new MergeRequestCreate
                 {
                     Title = "ErrorRequest",
-                    SourceBranch = "master",
-                    TargetBranch = "master",
+                    SourceBranch = project.DefaultBranch,
+                    TargetBranch = project.DefaultBranch,
                 });
             });
 
@@ -160,7 +160,7 @@ namespace NGitLab.Tests
                 Description = "New description",
                 Labels = "a,b",
                 SourceBranch = "my-super-feature",
-                TargetBranch = "master",
+                TargetBranch = request.TargetBranch,
             });
 
             Assert.AreEqual("New title", updatedMergeRequest.Title);
@@ -188,7 +188,7 @@ namespace NGitLab.Tests
                 mergeRequestIid: request.Iid,
                 message: new MergeRequestMerge
                 {
-                    MergeCommitMessage = "Merge my-super-feature into master",
+                    MergeCommitMessage = $"Merge my-super-feature into {request.TargetBranch}",
                     ShouldRemoveSourceBranch = true,
                     MergeWhenPipelineSucceeds = false,
                     Squash = false,

--- a/NGitLab.Tests/PipelineTests.cs
+++ b/NGitLab.Tests/PipelineTests.cs
@@ -46,7 +46,7 @@ namespace NGitLab.Tests
 
             var query = new PipelineQuery
             {
-                Ref = "main",
+                Ref = project.DefaultBranch,
             };
             var pipelinesFromQuery = await GitLabTestContext.RetryUntilAsync(() => pipelineClient.Search(query).ToList(), p => p.Any(), TimeSpan.FromSeconds(120));
 
@@ -77,7 +77,7 @@ namespace NGitLab.Tests
             // Arrange/Act
             var pipeline = pipelineClient.Create(new PipelineCreate()
             {
-                Ref = "main",
+                Ref = project.DefaultBranch,
                 Variables =
                 {
                     { "Var1", "Value1" },
@@ -110,7 +110,7 @@ namespace NGitLab.Tests
             var trigger = triggers.Create("Test Trigger");
             var ciJobToken = trigger.Token;
 
-            var pipeline = pipelineClient.CreatePipelineWithTrigger(ciJobToken, "main", new Dictionary<string, string>(StringComparer.InvariantCulture) { { "Test", "HelloWorld" } });
+            var pipeline = pipelineClient.CreatePipelineWithTrigger(ciJobToken, project.DefaultBranch, new Dictionary<string, string>(StringComparer.InvariantCulture) { { "Test", "HelloWorld" } });
 
             var variables = pipelineClient.GetVariables(pipeline.Id);
 

--- a/NGitLab.Tests/RepositoryClient/BranchClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/BranchClientTests.cs
@@ -28,7 +28,7 @@ namespace NGitLab.Tests.RepositoryClient
             var project = context.CreateProject(initializeWithCommits: true);
             var branches = context.Client.GetRepository(project.Id).Branches;
 
-            var branch = branches["master"];
+            var branch = branches[project.DefaultBranch];
 
             Assert.IsNotNull(branch);
             Assert.IsNotNull(branch.Name);
@@ -42,12 +42,12 @@ namespace NGitLab.Tests.RepositoryClient
             var project = context.CreateProject(initializeWithCommits: true);
             var branches = context.Client.GetRepository(project.Id).Branches;
 
-            var branchName = $"merge-me-to-master_{Path.GetRandomFileName()}";
+            var branchName = $"merge-me-to-{project.DefaultBranch}_{Path.GetRandomFileName()}";
 
             branches.Create(new BranchCreate
             {
                 Name = branchName,
-                Ref = "master",
+                Ref = project.DefaultBranch,
             });
 
             var branch = branches[branchName];
@@ -75,7 +75,7 @@ namespace NGitLab.Tests.RepositoryClient
             branches.Create(new BranchCreate
             {
                 Name = branchName,
-                Ref = "master",
+                Ref = project.DefaultBranch,
             });
 
             Assert.IsNotNull(branches[branchName]);

--- a/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
@@ -43,7 +43,7 @@ namespace NGitLab.Tests.RepositoryClient
                 {
                     commits[i] = context.Client.GetCommits(project.Id).Create(new CommitCreate
                     {
-                        Branch = "master",
+                        Branch = project.DefaultBranch,
                         CommitMessage = context.GetUniqueRandomString(),
                         AuthorEmail = "a@example.com",
                         AuthorName = "a",
@@ -78,11 +78,12 @@ namespace NGitLab.Tests.RepositoryClient
         public async Task GetCommitByBranchName()
         {
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
+            var defaultBranch = context.Project.DefaultBranch;
 
-            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits("master"));
-            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits("master", -1));
+            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits(defaultBranch));
+            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits(defaultBranch, -1));
 
-            var commits = context.RepositoryClient.GetCommits("master", 1).ToArray();
+            var commits = context.RepositoryClient.GetCommits(defaultBranch, 1).ToArray();
             Assert.AreEqual(1, commits.Length);
             Assert.AreEqual(context.Commits[1].Message, commits[0].Message);
         }
@@ -146,7 +147,7 @@ namespace NGitLab.Tests.RepositoryClient
         {
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
 
-            var tree = context.RepositoryClient.GetTree(string.Empty, "master", recursive: false);
+            var tree = context.RepositoryClient.GetTree(string.Empty, context.Project.DefaultBranch, recursive: false);
             Assert.IsNotEmpty(tree);
         }
 

--- a/NGitLab.Tests/TagsTests.cs
+++ b/NGitLab.Tests/TagsTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests
             {
                 Name = "v0.5",
                 Message = "Test message",
-                Ref = "master",
+                Ref = project.DefaultBranch,
                 ReleaseDescription = "Test description",
             });
 
@@ -41,7 +41,7 @@ namespace NGitLab.Tests
             var result = tagsClient.Create(new TagCreate
             {
                 Name = "0.7",
-                Ref = "master",
+                Ref = project.DefaultBranch,
             });
 
             var release = tagsClient.CreateRelease("0.7", new ReleaseCreate() { Description = "test" });

--- a/NGitLab.Tests/UsersTests.cs
+++ b/NGitLab.Tests/UsersTests.cs
@@ -137,7 +137,7 @@ namespace NGitLab.Tests
             });
         }
 
-        // Comes from https://github.com/meziantou/Meziantou.GitLabClient/blob/master/Meziantou.GitLabClient.Tests/Internals/RsaSshKey.cs
+        // Comes from https://github.com/meziantou/Meziantou.GitLabClient/blob/main/test/Meziantou.GitLabClient.Tests/Internals/RsaSshKey.cs
         private sealed class RsaSshKey
         {
             private const int PrefixSize = 4;

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -16,6 +16,9 @@ namespace NGitLab.Models
         [DataMember(Name = "namespace_id")]
         public string NamespaceId;
 
+        [DataMember(Name = "default_branch")]
+        public string DefaultBranch;
+
         [DataMember(Name = "description")]
         public string Description;
 
@@ -23,31 +26,31 @@ namespace NGitLab.Models
         public string Path;
 
         [DataMember(Name = "issues_enabled")]
-        [Obsolete("Deprecated by Gitlab. Use IssuesAccessLevel instead")]
+        [Obsolete("Deprecated by GitLab. Use IssuesAccessLevel instead")]
         public bool IssuesEnabled;
 
         [DataMember(Name = "issues_access_level")]
         public string IssuesAccessLevel;
 
-        [Obsolete("Does not exist anymore in gitlab api")]
+        [Obsolete("Deprecated by GitLab.")]
         public bool WallEnabled;
 
         [DataMember(Name = "merge_requests_enabled")]
-        [Obsolete("Deprecated by Gitlab. Use MergeRequestsAccessLevel instead")]
+        [Obsolete("Deprecated by GitLab. Use MergeRequestsAccessLevel instead")]
         public bool MergeRequestsEnabled;
 
         [DataMember(Name = "merge_requests_access_level")]
         public string MergeRequestsAccessLevel;
 
         [DataMember(Name = "snippets_enabled")]
-        [Obsolete("Deprecated by Gitlab. Use SnippetsAccessLevel instead")]
+        [Obsolete("Deprecated by GitLab. Use SnippetsAccessLevel instead")]
         public bool SnippetsEnabled;
 
         [DataMember(Name = "snippets_access_level")]
         public string SnippetsAccessLevel;
 
         [DataMember(Name = "wiki_enabled")]
-        [Obsolete("Deprecated by Gitlab. Use WikiAccessLevel instead")]
+        [Obsolete("Deprecated by GitLab. Use WikiAccessLevel instead")]
         public bool WikiEnabled;
 
         [DataMember(Name = "wiki_access_level")]


### PR DESCRIPTION
As GitLab is migrating the default branch from "master" to "main", and has been offering a means of specifying such value during project creation/update for a while now, it made sense to revisit the use of hard-coded branch names.

- Add possibility to specify the default branch when creating a project
- GitLabTestContext.CreateProject uses a default branch = "main4tests" and sets it in the returned Project object (because GitLab will not)
- Mock Project now has a default branch set to "main" rather than "master"