### PR TITLE
Fix mock - main as initial branch

### DIFF
--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -12,6 +12,8 @@ namespace NGitLab.Mock
     /// </summary>
     public sealed class GitLabServer : GitLabObject, IDisposable
     {
+        public const string DefaultBranch = "main";
+
         private int _lastProjectId;
         private int _lastGroupId;
         private int _lastMergeRequestId;

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -12,7 +12,7 @@ namespace NGitLab.Mock
     /// </summary>
     public sealed class GitLabServer : GitLabObject, IDisposable
     {
-        public const string DefaultBranch = "main";
+        public static string DefaultBranchName { get; set; } = "main";
 
         private int _lastProjectId;
         private int _lastGroupId;

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -12,7 +12,7 @@ namespace NGitLab.Mock
     /// </summary>
     public sealed class GitLabServer : GitLabObject, IDisposable
     {
-        public static string DefaultBranchName { get; set; } = "main";
+        public string DefaultBranchName { get; set; } = "main";
 
         private int _lastProjectId;
         private int _lastGroupId;

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -12,8 +12,6 @@ namespace NGitLab.Mock
     /// </summary>
     public sealed class GitLabServer : GitLabObject, IDisposable
     {
-        public string DefaultBranchName { get; set; } = "main";
-
         private int _lastProjectId;
         private int _lastGroupId;
         private int _lastMergeRequestId;
@@ -30,6 +28,8 @@ namespace NGitLab.Mock
             Users = new UserCollection(this);
             SystemHooks = new SystemHookCollection(this);
         }
+
+        public string DefaultBranchName { get; set; } = "main";
 
         public Uri Url { get; set; } = new Uri("https://gitlab.example.com/", UriKind.Absolute);
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -38,7 +38,7 @@ namespace NGitLab.Mock
 
         public string Description { get; set; }
 
-        public string DefaultBranch { get; set; } = GitLabServer.DefaultBranch;
+        public string DefaultBranch { get; set; } = GitLabServer.DefaultBranchName;
 
         public string WebUrl => Server.MakeUrl(PathWithNamespace);
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -38,7 +38,7 @@ namespace NGitLab.Mock
 
         public string Description { get; set; }
 
-        public string DefaultBranch { get; set; } = "main";
+        public string DefaultBranch { get; set; } = Repository.DefaultBranch
 
         public string WebUrl => Server.MakeUrl(PathWithNamespace);
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -38,7 +38,7 @@ namespace NGitLab.Mock
 
         public string Description { get; set; }
 
-        public string DefaultBranch { get; set; } = Repository.DefaultBranch
+        public string DefaultBranch { get; set; } = GitLabServer.DefaultBranch;
 
         public string WebUrl => Server.MakeUrl(PathWithNamespace);
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -38,7 +38,22 @@ namespace NGitLab.Mock
 
         public string Description { get; set; }
 
-        public string DefaultBranch { get; set; } = GitLabServer.DefaultBranchName;
+        private string _defaultBranch;
+
+        public string DefaultBranch
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_defaultBranch))
+                {
+                    _defaultBranch = Parent.Server.DefaultBranchName;
+                }
+
+                return _defaultBranch;
+            }
+
+            set => _defaultBranch = value;
+        }
 
         public string WebUrl => Server.MakeUrl(PathWithNamespace);
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -46,7 +46,7 @@ namespace NGitLab.Mock
             {
                 if (string.IsNullOrEmpty(_defaultBranch))
                 {
-                    _defaultBranch = Parent.Server.DefaultBranchName;
+                    _defaultBranch = Parent.Server?.DefaultBranchName ?? throw new InvalidOperationException("Project is not added to a Server");
                 }
 
                 return _defaultBranch;

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -12,7 +12,6 @@ namespace NGitLab.Mock
 {
     public sealed class Repository : GitLabObject, IDisposable
     {
-        public const string DefaultBranch = "main";
         private static int _tempBranchName;
 
         private readonly object _lock = new();
@@ -52,7 +51,7 @@ namespace NGitLab.Mock
                         if (Project.ForkedFrom == null)
                         {
                             // libgit2sharp cannot init with a branch other than master
-                            using var process = Process.Start("git", $"init --initial-branch {DefaultBranch} \"{directory.FullPath}\"");
+                            using var process = Process.Start("git", $"init --initial-branch {GitLabServer.DefaultBranch} \"{directory.FullPath}\"");
                             process.WaitForExit();
                             if (process.ExitCode != 0)
                                 throw new GitLabException($"Cannot init repository in '{directory.FullPath}'");

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -51,7 +51,7 @@ namespace NGitLab.Mock
                         if (Project.ForkedFrom == null)
                         {
                             // libgit2sharp cannot init with a branch other than master
-                            using var process = Process.Start("git", $"init --initial-branch {GitLabServer.DefaultBranchName } \"{directory.FullPath}\"");
+                            using var process = Process.Start("git", $"init --initial-branch \"{Project.DefaultBranch}\" \"{directory.FullPath}\"");
                             process.WaitForExit();
                             if (process.ExitCode != 0)
                                 throw new GitLabException($"Cannot init repository in '{directory.FullPath}'");

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -55,7 +55,7 @@ namespace NGitLab.Mock
                             using var process = Process.Start("git", $"init --initial-branch {DefaultBranch} \"{directory.FullPath}\"");
                             process.WaitForExit();
                             if (process.ExitCode != 0)
-                                throw new GitLabException("Cannot init repository");
+                                throw new GitLabException($"Cannot init repository in '{directory.FullPath}'");
                         }
                         else
                         {

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -51,7 +51,7 @@ namespace NGitLab.Mock
                         if (Project.ForkedFrom == null)
                         {
                             // libgit2sharp cannot init with a branch other than master
-                            using var process = Process.Start("git", $"init --initial-branch {GitLabServer.DefaultBranch} \"{directory.FullPath}\"");
+                            using var process = Process.Start("git", $"init --initial-branch {GitLabServer.DefaultBranchName } \"{directory.FullPath}\"");
                             process.WaitForExit();
                             if (process.ExitCode != 0)
                                 throw new GitLabException($"Cannot init repository in '{directory.FullPath}'");

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -12,6 +12,7 @@ namespace NGitLab.Mock
 {
     public sealed class Repository : GitLabObject, IDisposable
     {
+        public const string DefaultBranch = "main";
         private static int _tempBranchName;
 
         private readonly object _lock = new();
@@ -50,7 +51,11 @@ namespace NGitLab.Mock
                         var directory = TemporaryDirectory.Create();
                         if (Project.ForkedFrom == null)
                         {
-                            LibGit2Sharp.Repository.Init(directory.FullPath);
+                            // libgit2sharp cannot init with a branch other than master
+                            using var process = Process.Start("git", $"init --initial-branch {DefaultBranch} \"{directory.FullPath}\"");
+                            process.WaitForExit();
+                            if (process.ExitCode != 0)
+                                throw new GitLabException("Cannot init repository");
                         }
                         else
                         {


### PR DESCRIPTION
Following the change @ https://github.com/ubisoft/NGitLab/commit/b2566a1ec8cd0dec90f6147665a291688800998d, mocked repository was still initialized on "master" branch.

As libgit2sharp doesn't have the option to provide an initial branch, replaced the Init action with a direct git call
