### PR TITLE
Improve internal retry scheme

### DIFF
--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -29,7 +29,7 @@ namespace NGitLab.Tests
                     TimeSpan.FromSeconds(120))
                 .ConfigureAwait(false);
 
-            Assert.IsFalse(context.Client.GetRepository(project.Id).Branches[mergeRequest.SourceBranch].Protected, "The source branch is protected, but is should not");
+            Assert.IsFalse(context.Client.GetRepository(project.Id).Branches[mergeRequest.SourceBranch].Protected, "The source branch is protected but should not be");
 
             TestContext.Out.WriteLine("MR is ready to be merged");
             AcceptMergeRequest(mergeRequestClient, mergeRequest);

--- a/NGitLab.Tests/SetUpFixture.cs
+++ b/NGitLab.Tests/SetUpFixture.cs
@@ -1,0 +1,15 @@
+﻿using NGitLab.Extensions;
+using NUnit.Framework;
+
+namespace NGitLab.Tests
+{
+    [SetUpFixture]
+    public sealed class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void RunBeforeAnyTests()
+        {
+            FunctionRetryExtensions.Logger = (msg) => TestContext.WriteLine($"[{TestContext.CurrentContext.Test.FullName}] {msg}");
+        }
+    }
+}

--- a/NGitLab/Extensions/FunctionRetryExtensions.cs
+++ b/NGitLab/Extensions/FunctionRetryExtensions.cs
@@ -22,7 +22,7 @@ namespace NGitLab.Extensions
                 {
                     return action();
                 }
-                catch (Exception ex) when (predicate(ex, retriesLeft))
+                catch (Exception ex) when (retriesLeft > 0 && predicate(ex, retriesLeft))
                 {
                     Logger?.Invoke($"{ex.Message} -> Internal Retry in {waitTime.TotalMilliseconds} ms ({maxRetryCount - retriesLeft + 1} of {maxRetryCount})...");
 

--- a/NGitLab/Extensions/FunctionRetryExtensions.cs
+++ b/NGitLab/Extensions/FunctionRetryExtensions.cs
@@ -8,6 +8,8 @@ namespace NGitLab.Extensions
     /// </summary>
     internal static class FunctionRetryExtensions
     {
+        public static Action<string> Logger { get; set; }
+
         /// <summary>
         /// Do a retry a number of time on the received action if it fails
         /// </summary>
@@ -19,6 +21,8 @@ namespace NGitLab.Extensions
             }
             catch (Exception ex) when (retryWhen(ex, retryNumber))
             {
+                Logger?.Invoke($"{ex.Message} -> Internal Retry ({retryNumber - 1} attempts left)...");
+
                 Thread.Sleep(interval);
 
                 var nextInterval = isIncremental ? interval.Add(interval) : interval;

--- a/NGitLab/Extensions/FunctionRetryExtensions.cs
+++ b/NGitLab/Extensions/FunctionRetryExtensions.cs
@@ -29,7 +29,9 @@ namespace NGitLab.Extensions
                     Thread.Sleep(waitTime);
 
                     if (useExponentialBackoff)
+                    {
                         waitTime = waitTime.Add(waitTime);
+                    }
 
                     retriesLeft--;
                 }

--- a/NGitLab/GitLabException.cs
+++ b/NGitLab/GitLabException.cs
@@ -48,5 +48,10 @@ namespace NGitLab
         /// The call that triggerred the error.
         /// </summary>
         public Uri OriginalCall { get; set; }
+
+        /// <summary>
+        /// Underlying HTTP method that triggered this exception, if any
+        /// </summary>
+        public MethodType? MethodType { get; set; }
     }
 }

--- a/NGitLab/GitLabException.cs
+++ b/NGitLab/GitLabException.cs
@@ -50,7 +50,7 @@ namespace NGitLab
         public Uri OriginalCall { get; set; }
 
         /// <summary>
-        /// Underlying HTTP method that triggered this exception, if any
+        /// HTTP request method, if any, that triggered this exception
         /// </summary>
         public MethodType? MethodType { get; set; }
     }

--- a/NGitLab/Impl/API.cs
+++ b/NGitLab/Impl/API.cs
@@ -65,6 +65,7 @@ namespace NGitLab.Impl
                     OriginalCall = new Uri(ex.OriginalCall.OriginalString.Replace(_credentials.Password, hiddenPassword)),
                     StatusCode = ex.StatusCode,
                     ErrorObject = ex.ErrorObject,
+                    MethodType = ex.MethodType,
                 };
 
                 throw securedException;

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -58,11 +58,6 @@ namespace NGitLab.Impl
 
             public WebResponse GetResponse(RequestOptions options)
             {
-                // For requests that are potentially not safe/idempotent, send only once
-                if (options.RetrySafeRequestsOnly && Method != MethodType.Get && Method != MethodType.Head)
-                    return GetResponseImpl(options);
-
-                // Otherwise, allow retries
                 Func<WebResponse> getResponseImpl = () => GetResponseImpl(options);
 
                 return getResponseImpl.Retry(options.ShouldRetry,
@@ -108,6 +103,7 @@ namespace NGitLab.Impl
                         ErrorObject = parsedError,
                         StatusCode = errorResponse.StatusCode,
                         ErrorMessage = errorMessage,
+                        MethodType = Method,
                     };
                 }
             }

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -58,11 +58,11 @@ namespace NGitLab.Impl
 
             public WebResponse GetResponse(RequestOptions options)
             {
-                // For any requests that are POTENTIALLY NOT idempotent, send only once
-                if (Method != MethodType.Get)
+                // For requests that are potentially not safe/idempotent, send only once
+                if (options.RetrySafeRequestsOnly && Method != MethodType.Get && Method != MethodType.Head)
                     return GetResponseImpl(options);
 
-                // For presumably idempotent requests, allow retries
+                // Otherwise, allow retries
                 Func<WebResponse> getResponseImpl = () => GetResponseImpl(options);
 
                 return getResponseImpl.Retry(options.ShouldRetry,

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -58,6 +58,11 @@ namespace NGitLab.Impl
 
             public WebResponse GetResponse(RequestOptions options)
             {
+                // For any requests that are POTENTIALLY NOT idempotent, send only once
+                if (Method != MethodType.Get)
+                    return GetResponseImpl(options);
+
+                // For presumably idempotent requests, allow retries
                 Func<WebResponse> getResponseImpl = () => GetResponseImpl(options);
 
                 return getResponseImpl.Retry(options.ShouldRetry,

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -42,9 +42,6 @@ namespace NGitLab
         /// <returns>Whether the request should be retried</returns>
         public virtual bool ShouldRetry(Exception ex, int retryNumber)
         {
-            if (retryNumber < 1)
-                return false;
-
             if (ex is not GitLabException gitLabException)
                 return false;
 

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -16,6 +16,12 @@ namespace NGitLab
         public bool IsIncremental { get; set; }
 
         /// <summary>
+        /// Limits retries to safe HTTP requests (i.e. read-only and thus idempotent), such as GET and HEAD.
+        /// </summary>
+        /// <see href="https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP"/>
+        public bool RetrySafeRequestsOnly { get; set; } = true;
+
+        /// <summary>
         /// ID or case-insensitive username of the user to impersonate, if any
         /// </summary>
         public string Sudo { get; set; }

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -35,19 +35,22 @@ namespace NGitLab
         }
 
         /// <summary>
-        /// By default, true if there is still retries left.
+        /// Predicate indicating, after a request has failed, if a new attempt should occur
         /// </summary>
+        /// <param name="ex">Exception thrown by the failed request</param>
+        /// <param name="retryNumber">Number of retries left</param>
+        /// <returns>Whether the request should be retried</returns>
         public virtual bool ShouldRetry(Exception ex, int retryNumber)
         {
             if (retryNumber < 1)
                 return false;
 
-            if (!(ex is GitLabException gitLabException))
+            if (ex is not GitLabException gitLabException)
                 return false;
 
             // For requests that are potentially NOT Safe/Idempotent, do not retry
             // See https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP
-            // If there is no HTTP request method specified, carry on to the next condition below.
+            // If there is no HTTP request method specified, carry on the predicate assessment.
             if (gitLabException.MethodType.HasValue &&
                 gitLabException.MethodType != Impl.MethodType.Get &&
                 gitLabException.MethodType != Impl.MethodType.Head)

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -47,13 +47,13 @@ namespace NGitLab
 
             // For requests that are potentially NOT Safe/Idempotent, do not retry
             // See https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP
-            // If there is no HTTP method info, carry on to the next condition below.
+            // If there is no HTTP request method specified, carry on to the next condition below.
             if (gitLabException.MethodType.HasValue &&
                 gitLabException.MethodType != Impl.MethodType.Get &&
                 gitLabException.MethodType != Impl.MethodType.Head)
                 return false;
 
-            // Same as what are considered Transient HTTP StatusCodes in Polly's HttpPolicyExtensions
+            // Use the same Transient HTTP StatusCodes as Polly's HttpPolicyExtensions
             // https://github.com/App-vNext/Polly.Extensions.Http/blob/69fd292bc603cb3032e57b028522737255f03a49/src/Polly.Extensions.Http/HttpPolicyExtensions.cs#L14
             return gitLabException.StatusCode >= HttpStatusCode.InternalServerError ||
                    gitLabException.StatusCode == HttpStatusCode.RequestTimeout;

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -53,7 +53,8 @@ namespace NGitLab
             // If there is no HTTP request method specified, carry on the predicate assessment.
             if (gitLabException.MethodType.HasValue &&
                 gitLabException.MethodType != Impl.MethodType.Get &&
-                gitLabException.MethodType != Impl.MethodType.Head)
+                gitLabException.MethodType != Impl.MethodType.Head &&
+                gitLabException.MethodType != Impl.MethodType.Options)
                 return false;
 
             // Use the same Transient HTTP StatusCodes as Polly's HttpPolicyExtensions


### PR DESCRIPTION
- Disable internal retry scheme for non-idempotent HTTP requests
- Convert `FunctionRetryExtensionsTests.Retry` from recursive to iterative
- Log debug info about internal retries during tests