### PR TITLE
Use symbolic-ref instead on initial-branch for Git repo init in Mock

### DIFF
--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -59,8 +59,9 @@ namespace NGitLab.Mock
                                 StartInfo = new ProcessStartInfo
                                 {
                                     FileName = "git",
-                                    Arguments = $"-C \"{directory.FullPath}\" symbolic-ref HEAD refs/heads/{Project.DefaultBranch}",
+                                    Arguments = $"symbolic-ref HEAD \"refs/heads/{Project.DefaultBranch}\"",
                                     RedirectStandardError = true,
+                                    WorkingDirectory = directory.FullPath,
                                 },
                             };
 


### PR DESCRIPTION
- `--initial-branch` is only available on recent version of Git
- stable version in debian 10 is older and doesn't have the option
- Add errors details for easier debug  