### PR TITLE
Fix repository mock for .NET Framework

### DIFF
--- a/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
+++ b/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NGitLab.Mock\NGitLab.Mock.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+</Project>

--- a/NGitLab.Mock.Tests/RepositoryMockTests.cs
+++ b/NGitLab.Mock.Tests/RepositoryMockTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NGitLab.Models;
+﻿using NGitLab.Models;
 using NUnit.Framework;
 
 namespace NGitLab.Mock.Tests

--- a/NGitLab.Mock.Tests/RepositoryMockTests.cs
+++ b/NGitLab.Mock.Tests/RepositoryMockTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NGitLab.Models;
+using NUnit.Framework;
+
+namespace NGitLab.Mock.Tests
+{
+    public class RepositoryMockTests
+    {
+        [Test]
+        public void Test_project_can_be_mocked()
+        {
+            using var gitLabServer = new GitLabServer();
+            var group = new Group("TestGroup");
+            gitLabServer.Groups.Add(group);
+            var project = new Project("Test") { Visibility = VisibilityLevel.Internal };
+            group.Projects.Add(project);
+
+            var modelProject = project.ToClientProject();
+            Assert.IsNotNull(modelProject);
+            Assert.AreEqual("Test", modelProject.Name);
+            Assert.AreEqual("testgroup", modelProject.Namespace.FullPath);
+        }
+    }
+}

--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\NGitLab\NGitLab.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'net461'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -61,6 +61,7 @@ namespace NGitLab.Mock
                                     FileName = "git",
                                     Arguments = $"symbolic-ref HEAD \"refs/heads/{Project.DefaultBranch}\"",
                                     RedirectStandardError = true,
+                                    UseShellExecute = false,
                                     WorkingDirectory = directory.FullPath,
                                 },
                             };

--- a/NGitLab.sln
+++ b/NGitLab.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NGitLab.Mock.Tests", "NGitLab.Mock.Tests\NGitLab.Mock.Tests.csproj", "{581CCEF5-376E-4E70-8A96-682E714AE862}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{B1C9D8F6-22BC-4401-BD7B-E99C62A8E685}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1C9D8F6-22BC-4401-BD7B-E99C62A8E685}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1C9D8F6-22BC-4401-BD7B-E99C62A8E685}.Release|Any CPU.Build.0 = Release|Any CPU
+		{581CCEF5-376E-4E70-8A96-682E714AE862}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{581CCEF5-376E-4E70-8A96-682E714AE862}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{581CCEF5-376E-4E70-8A96-682E714AE862}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{581CCEF5-376E-4E70-8A96-682E714AE862}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
`UseShellExecute` is true by default on .NET Framework and it was throwing (see See https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput?view=net-5.0#remarks)  