### PR TITLE
Suppress NuGet warning for mock project

### DIFF
--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -4,6 +4,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NGitLab\NGitLab.csproj" />


### PR DESCRIPTION
Suppress the following message when publishing the mock package:

> error NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "LibGit2Sharp [0.27.0-preview-0096, )" or update the version field in the nuspec. [/home/runner/work/NGitLab/NGitLab/NGitLab.Mock/NGitLab.Mock.csproj]