### PR TITLE
Set "rollForward": "latestFeature" in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "5.0.202",
-        "rollForward": "patch"
+        "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
For a .NET SDK version `x.y.znn`, we have
- x: major version
- y: minor version
- z: feature band
- nn: patch version

By setting rollForward to latestFeature, we'll get the following behavior:

> Uses the highest installed feature band and patch level that matches the requested major and minor with a feature band and patch level that is greater or equal than the specified value.
If not found, fails.

See https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward