### PR TITLE
Additional functionality for ReleaseClient + ReleaseLinksClient for release links API

### DIFF
--- a/NGitLab.Mock/Clients/GitLabClient.cs
+++ b/NGitLab.Mock/Clients/GitLabClient.cs
@@ -59,6 +59,8 @@
 
         public IMilestoneClient GetMilestone(int projectId) => new MilestoneClient(Context, projectId);
 
+        public IReleaseClient GetReleases(int projectId) => new ReleaseClient(Context, projectId);
+
         public IPipelineClient GetPipelines(int projectId) => new PipelineClient(Context, jobClient: GetJobs(projectId), projectId: projectId);
 
         public IProjectBadgeClient GetProjectBadgeClient(int projectId) => new ProjectBadgeClient(Context, projectId);

--- a/NGitLab.Mock/Clients/ReleaseClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NGitLab.Models;
 
@@ -14,43 +15,88 @@ namespace NGitLab.Mock.Clients
             _projectId = projectId;
         }
 
-        public IEnumerable<ReleaseInfo> All
+        public IEnumerable<Models.ReleaseInfo> All
         {
             get
             {
                 using (Context.BeginOperationScope())
                 {
-                    var project = GetProject(_projectId, ProjectPermission.Contribute);
-                    return project.Repository.GetReleases();
+                    var project = GetProject(_projectId, ProjectPermission.View);
+                    return project.Releases.Select(r => r.ToReleaseClient());
                 }
             }
         }
 
-        public ReleaseInfo Create(ReleaseCreate data)
+        public Models.ReleaseInfo this[string tagName]
         {
-            using (Context.BeginOperationScope())
+            get
             {
-                var project = GetProject(_projectId, ProjectPermission.Contribute);
-                return project.Repository.CreateRelease(data.Name, data.Description);
+                using (Context.BeginOperationScope())
+                {
+                    var project = GetProject(_projectId, ProjectPermission.View);
+                    var release = project.Releases.FirstOrDefault(r => r.TagName.Equals(tagName));
+
+                    return release.ToReleaseClient();
+                }
             }
         }
 
-        public void Delete(string name)
+        public Models.ReleaseInfo Create(Models.ReleaseCreate data)
         {
             using (Context.BeginOperationScope())
             {
-                var project = GetProject(_projectId, ProjectPermission.Contribute);
-                project.Repository.DeleteRelease(name);
+                var project = GetProject(_projectId, ProjectPermission.View);
+                var release = project.Releases.Add(data.TagName, data.Name, data.Description, Context.User);
+                return release.ToReleaseClient();
             }
         }
 
-        public ReleaseInfo Update(ReleaseUpdate data)
+        public Models.ReleaseInfo Update(ReleaseUpdate data)
         {
             using (Context.BeginOperationScope())
             {
-                var project = GetProject(_projectId, ProjectPermission.Contribute);
-                return project.Repository.UpdateRelease(data.Name, data.Description);
+                var project = GetProject(_projectId, ProjectPermission.View);
+                var release = project.Releases.GetByTagName(data.TagName);
+                if (release == null)
+                {
+                    throw new GitLabNotFoundException();
+                }
+
+                if (data.Name != null)
+                {
+                    release.Name = data.Name;
+                }
+
+                if (data.Description != null)
+                {
+                    release.Description = data.Description;
+                }
+
+                if (data.ReleasedAt.HasValue)
+                {
+                    release.ReleasedAt = data.ReleasedAt.Value;
+                }
+
+                return release.ToReleaseClient();
             }
+        }
+
+        public void Delete(string tagName)
+        {
+            using (Context.BeginOperationScope())
+            {
+                var project = GetProject(_projectId, ProjectPermission.View);
+                var release = project.Releases.FirstOrDefault(r => r.TagName.Equals(tagName));
+                if (release == null)
+                    throw new GitLabNotFoundException();
+
+                project.Releases.Remove(release);
+            }
+        }
+
+        public IReleaseLinkClient ReleaseLinks(string tagName)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/NGitLab.Mock/Clients/ReleaseLinkClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseLinkClient.cs
@@ -35,7 +35,5 @@ namespace NGitLab.Mock.Clients
         {
             throw new NotImplementedException();
         }
-
-       // private MergeRequest GetRelease() => GetMergeRequest(_projectId, _mergeRequestIid);
     }
 }

--- a/NGitLab.Mock/Clients/ReleaseLinkClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseLinkClient.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NGitLab.Models;
+
+namespace NGitLab.Mock.Clients
+{
+    internal sealed class ReleaseLinkClient : ClientBase, IReleaseLinkClient
+    {
+        private readonly int _projectId;
+        private readonly string _tagName;
+
+        public ReleaseLinkClient(ClientContext context, int projectId, string tagName)
+            : base(context)
+        {
+            _projectId = projectId;
+            _tagName = tagName;
+        }
+
+        public ReleaseLink this[int id] => throw new NotImplementedException();
+
+        public IEnumerable<ReleaseLink> All => throw new NotImplementedException();
+
+        public ReleaseLink Create(ReleaseLinkCreate data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Delete(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ReleaseLink Update(int id, ReleaseLinkUpdate data)
+        {
+            throw new NotImplementedException();
+        }
+
+       // private MergeRequest GetRelease() => GetMergeRequest(_projectId, _mergeRequestIid);
+    }
+}

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -18,8 +18,6 @@ namespace NGitLab.Mock.Clients
 
         public ITagClient Tags => new TagClient(Context, _projectId);
 
-        public IReleaseClient Releases => new ReleaseClient(Context, _projectId);
-
         public IFilesClient Files => new FileClient(Context, _projectId);
 
         public IBranchClient Branches => new BranchClient(Context, _projectId);

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -55,7 +55,7 @@ namespace NGitLab.Mock.Clients
             {
                 Commit = commit.ToCommitInfo(),
                 Name = tag.FriendlyName,
-                Release = new ReleaseInfo
+                Release = new Models.ReleaseInfo
                 {
                     Description = project.Repository.GetReleaseTag(tag.FriendlyName)?.ReleaseNotes,
                     TagName = tag.FriendlyName,

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NGitLab.Models;
 
@@ -36,41 +37,12 @@ namespace NGitLab.Mock.Clients
             }
         }
 
-        public ReleaseInfo CreateRelease(string name, ReleaseCreate data)
-        {
-            using (Context.BeginOperationScope())
-            {
-                var project = GetProject(_projectId, ProjectPermission.Contribute);
-                var tag = project.Repository.CreateReleaseTag(name, data.Description);
-                return new ReleaseInfo
-                {
-                    TagName = tag.Name,
-                    Description = tag.ReleaseNotes,
-                };
-            }
-        }
-
         public void Delete(string name)
         {
             using (Context.BeginOperationScope())
             {
                 var project = GetProject(_projectId, ProjectPermission.Contribute);
                 project.Repository.DeleteTag(name);
-            }
-        }
-
-        public ReleaseInfo UpdateRelease(string name, ReleaseUpdate data)
-        {
-            using (Context.BeginOperationScope())
-            {
-                var project = GetProject(_projectId, ProjectPermission.Contribute);
-                var tag = project.Repository.UpdateReleaseTag(name, data.Description);
-
-                return new ReleaseInfo
-                {
-                    TagName = tag.Name,
-                    Description = tag.ReleaseNotes,
-                };
             }
         }
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -29,6 +29,7 @@ namespace NGitLab.Mock
             Badges = new BadgeCollection(this);
             CommitInfos = new CommitInfoCollection(this);
             CommitStatuses = new CommitStatusCollection(this);
+            Releases = new ReleaseCollection(this);
             ApprovalsBeforeMerge = 0;
         }
 
@@ -88,6 +89,8 @@ namespace NGitLab.Mock
         public CommitInfoCollection CommitInfos { get; }
 
         public CommitStatusCollection CommitStatuses { get; }
+
+        public ReleaseCollection Releases { get; }
 
         public Group Group => (Group)Parent;
 

--- a/NGitLab.Mock/Release.cs
+++ b/NGitLab.Mock/Release.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using NGitLab.Models;
+
+namespace NGitLab.Mock
+{
+    public sealed class Release : GitLabObject
+    {
+        public Release()
+        {
+        }
+
+        public Project Project => (Project)Parent;
+
+        public string TagName;
+
+        public string Description;
+
+        public string Name;
+
+        public DateTime CreatedAt = DateTime.UtcNow;
+
+        public DateTime ReleasedAt = DateTime.UtcNow;
+
+        public UserRef Author;
+
+        public Commit Commit;
+
+        public string CommitPath;
+
+        public string TagPath;
+
+        internal Models.ReleaseInfo ToReleaseClient()
+        {
+            return new Models.ReleaseInfo
+            {
+                TagName = TagName,
+                Name = Name,
+                Description = Description,
+                CreatedAt = CreatedAt,
+                ReleasedAt = ReleasedAt,
+                Author = Author.ToClientAuthor(),
+                Commit = Commit,
+                CommitPath = CommitPath,
+                TagPath = TagPath,
+            };
+        }
+    }
+}

--- a/NGitLab.Mock/ReleaseCollection.cs
+++ b/NGitLab.Mock/ReleaseCollection.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace NGitLab.Mock
 {
-    public class ReleaseCollection : Collection<Release>
+    public class ReleaseCollection : Collection<ReleaseInfo>
     {
         private Project Project => (Project)Parent;
 
@@ -12,12 +12,12 @@ namespace NGitLab.Mock
         {
         }
 
-        public Release GetByTagName(string tagName)
+        public ReleaseInfo GetByTagName(string tagName)
         {
             return this.FirstOrDefault(r => r.TagName.Equals(tagName));
         }
 
-        public override void Add(Release release)
+        public override void Add(ReleaseInfo release)
         {
             if (release is null)
                 throw new ArgumentNullException(nameof(release));
@@ -40,14 +40,14 @@ namespace NGitLab.Mock
             base.Add(release);
         }
 
-        public Release Add(string tagName, string name, string description, User user)
+        public ReleaseInfo Add(string tagName, string name, string description, User user)
         {
             if (tagName is null)
                 throw new ArgumentNullException(nameof(tagName));
             if (user is null)
                 throw new ArgumentNullException(nameof(user));
 
-            var release = new Release
+            var release = new ReleaseInfo
             {
                 TagName = tagName,
                 Name = name,

--- a/NGitLab.Mock/ReleaseCollection.cs
+++ b/NGitLab.Mock/ReleaseCollection.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+
+namespace NGitLab.Mock
+{
+    public class ReleaseCollection : Collection<Release>
+    {
+        private Project Project => (Project)Parent;
+
+        public ReleaseCollection(GitLabObject parent)
+            : base(parent)
+        {
+        }
+
+        public Release GetByTagName(string tagName)
+        {
+            return this.FirstOrDefault(r => r.TagName.Equals(tagName));
+        }
+
+        public override void Add(Release release)
+        {
+            if (release is null)
+                throw new ArgumentNullException(nameof(release));
+
+            if (release.TagName == default || Project.Repository.GetTags().FirstOrDefault(t => t.FriendlyName.Equals(release.TagName)) == null)
+            {
+                throw new ArgumentException(nameof(release));
+            }
+
+            if (release.Name == default)
+            {
+                release.Name = release.TagName;
+            }
+
+            if (GetByTagName(release.TagName) != null)
+            {
+                throw new GitLabException("Release already exists");
+            }
+
+            base.Add(release);
+        }
+
+        public Release Add(string tagName, string name, string description, User user)
+        {
+            if (tagName is null)
+                throw new ArgumentNullException(nameof(tagName));
+            if (user is null)
+                throw new ArgumentNullException(nameof(user));
+
+            var release = new Release
+            {
+                TagName = tagName,
+                Name = name,
+                Description = description,
+                Author = user,
+            };
+
+            Add(release);
+            return release;
+        }
+    }
+}

--- a/NGitLab.Mock/ReleaseInfo.cs
+++ b/NGitLab.Mock/ReleaseInfo.cs
@@ -6,31 +6,31 @@ using NGitLab.Models;
 
 namespace NGitLab.Mock
 {
-    public sealed class Release : GitLabObject
+    public sealed class ReleaseInfo : GitLabObject
     {
-        public Release()
+        public ReleaseInfo()
         {
         }
 
         public Project Project => (Project)Parent;
 
-        public string TagName;
+        public string TagName { get; set; }
 
-        public string Description;
+        public string Description { get; set; }
 
-        public string Name;
+        public string Name { get; set; }
 
-        public DateTime CreatedAt = DateTime.UtcNow;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-        public DateTime ReleasedAt = DateTime.UtcNow;
+        public DateTime ReleasedAt { get; set; } = DateTime.UtcNow;
 
-        public UserRef Author;
+        public UserRef Author { get; set; }
 
-        public Commit Commit;
+        public Commit Commit { get; set; }
 
-        public string CommitPath;
+        public string CommitPath { get; set; }
 
-        public string TagPath;
+        public string TagPath { get; set; }
 
         internal Models.ReleaseInfo ToReleaseClient()
         {

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using LibGit2Sharp;
 using NGitLab.Mock.Clients;
-using ReleaseInfo = NGitLab.Models.ReleaseInfo;
 
 namespace NGitLab.Mock
 {
@@ -18,7 +17,6 @@ namespace NGitLab.Mock
         private readonly object _lock = new();
         private TemporaryDirectory _directory;
         private LibGit2Sharp.Repository _repository;
-        private readonly IList<ReleaseInfo> _releases = new List<ReleaseInfo>();
         private readonly IList<ReleaseTag> _releaseTags = new List<ReleaseTag>();
 
         public Project Project => (Project)Parent;
@@ -239,49 +237,6 @@ namespace NGitLab.Mock
             }
 
             return tag;
-        }
-
-        public IList<ReleaseInfo> GetReleases()
-        {
-            return _releases;
-        }
-
-        public ReleaseInfo GetRelease(string tagName)
-        {
-            return _releases.FirstOrDefault(r => string.Equals(r.TagName, tagName, StringComparison.Ordinal));
-        }
-
-        public ReleaseInfo CreateRelease(string tagName, string releaseNotes)
-        {
-            if (_releases.Any(r => string.Equals(r.TagName, tagName, StringComparison.Ordinal)))
-            {
-                throw new GitLabBadRequestException();
-            }
-
-            var release = new ReleaseInfo() { TagName = tagName, Description = releaseNotes };
-            _releases.Add(release);
-            return release;
-        }
-
-        public ReleaseInfo UpdateRelease(string tagName, string releaseNotes)
-        {
-            if (!_releaseTags.Any(r => string.Equals(r.Name, tagName, StringComparison.Ordinal)))
-            {
-                throw new GitLabBadRequestException();
-            }
-
-            var release = _releases.First(r => string.Equals(r.TagName, tagName, StringComparison.Ordinal));
-            release.Description = releaseNotes;
-            return release;
-        }
-
-        public void DeleteRelease(string tagName)
-        {
-            var repository = GetGitRepository();
-            if (_releases.Any(r => string.Equals(r.TagName, tagName, StringComparison.Ordinal)))
-            {
-                _releases.Remove(_releases.First(r => string.Equals(r.TagName, tagName, StringComparison.Ordinal)));
-            }
         }
 
         public ReleaseTag GetReleaseTag(string tagName)

--- a/NGitLab.Tests/ReleaseClientTests.cs
+++ b/NGitLab.Tests/ReleaseClientTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NGitLab.Tests.Docker;
+using NUnit.Framework;
+using Polly;
+
+namespace NGitLab.Tests.Release
+{
+    public class ReleaseClientTests
+    {
+        [Test]
+        public async Task Test_release_api()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject(initializeWithCommits: true);
+            var releaseClient = context.Client.GetReleases(project.Id);
+            var tagsClient = context.Client.GetRepository(project.Id).Tags;
+
+            var tag = tagsClient.Create(new TagCreate
+            {
+                Name = "0.7",
+                Ref = project.DefaultBranch,
+            });
+
+            var release = releaseClient.Create(new ReleaseCreate
+            {
+                TagName = tag.Name,
+                Description = "test",
+            });
+
+            Assert.That(release.TagName, Is.EqualTo("0.7"));
+            Assert.That(release.Name, Is.EqualTo("0.7"));
+            Assert.That(release.Description, Is.EqualTo("test"));
+
+            release = releaseClient[tag.Name];
+            Assert.That(release.TagName, Is.EqualTo("0.7"));
+            Assert.That(release.Name, Is.EqualTo("0.7"));
+            Assert.That(release.Description, Is.EqualTo("test"));
+
+            release = releaseClient.Update(new ReleaseUpdate
+            {
+                TagName = "0.7",
+                Description = "test updated",
+            });
+            Assert.That(release.TagName, Is.EqualTo("0.7"));
+            Assert.That(release.Name, Is.EqualTo("0.7"));
+            Assert.That(release.Description, Is.EqualTo("test updated"));
+
+            tagsClient.Delete("0.7");
+            Assert.IsNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", System.StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public async Task Test_release_links()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject(initializeWithCommits: true);
+            var tagsClient = context.Client.GetRepository(project.Id).Tags;
+            var releaseClient = context.Client.GetReleases(project.Id);
+
+            var tag = tagsClient.Create(new TagCreate
+            {
+                Name = "0.7",
+                Ref = project.DefaultBranch,
+            });
+
+            var release = releaseClient.Create(new ReleaseCreate
+            {
+                TagName = tag.Name,
+                Description = "test",
+            });
+            Assert.That(release.TagName, Is.EqualTo("0.7"));
+            Assert.That(release.Name, Is.EqualTo("0.7"));
+            Assert.That(release.Description, Is.EqualTo("test"));
+
+            var linksClient = releaseClient.ReleaseLinks(tag.Name);
+
+            var link = linksClient.Create(new ReleaseLinkCreate
+            {
+                Name = "test link",
+                Filepath = "/bin/test",
+                Url = "https://www.example.com",
+            });
+            Assert.That(link.Name, Is.EqualTo("test link"));
+            Assert.That(link.Url, Is.EqualTo("https://www.example.com"));
+            Assert.IsTrue(link.External);
+
+            link = linksClient[link.Id.Value];
+            Assert.That(link.Name, Is.EqualTo("test link"));
+            Assert.That(link.Url, Is.EqualTo("https://www.example.com"));
+            Assert.IsTrue(link.External);
+
+            linksClient.Delete(link.Id.Value);
+            Assert.IsNull(linksClient.All.FirstOrDefault(x => string.Equals(x.Name, "test link", System.StringComparison.Ordinal)));
+
+            tagsClient.Delete("0.7");
+            Assert.IsNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", System.StringComparison.Ordinal)));
+        }
+    }
+}

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -147,6 +147,11 @@ namespace NGitLab
             return new MilestoneClient(_api, projectId);
         }
 
+        public IReleaseClient GetReleases(int projectId)
+        {
+            return new ReleaseClient(_api, projectId);
+        }
+
         public IProjectIssueNoteClient GetProjectIssueNoteClient(int projectId)
         {
             return new ProjectIssueNoteClient(_api, projectId);

--- a/NGitLab/IGitLabClient.cs
+++ b/NGitLab/IGitLabClient.cs
@@ -48,6 +48,8 @@
 
         IMilestoneClient GetMilestone(int projectId);
 
+        IReleaseClient GetReleases(int projectId);
+
         IMembersClient Members { get; }
 
         IVersionClient Version { get; }

--- a/NGitLab/IReleaseClient.cs
+++ b/NGitLab/IReleaseClient.cs
@@ -1,16 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NGitLab.Models;
 
 namespace NGitLab
 {
     public interface IReleaseClient
     {
-        ReleaseInfo Create(ReleaseCreate release);
-
-        ReleaseInfo Update(ReleaseUpdate release);
-
-        void Delete(string name);
-
         IEnumerable<ReleaseInfo> All { get; }
+
+        ReleaseInfo this[string tagName] { get; }
+
+        ReleaseInfo Create(ReleaseCreate data);
+
+        ReleaseInfo Update(ReleaseUpdate data);
+
+        void Delete(string tagName);
+
+        IReleaseLinkClient ReleaseLinks(string tagName);
     }
 }

--- a/NGitLab/IReleaseLinkClient.cs
+++ b/NGitLab/IReleaseLinkClient.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using NGitLab.Models;
+
+namespace NGitLab
+{
+    public interface IReleaseLinkClient
+    {
+        IEnumerable<ReleaseLink> All { get; }
+
+        ReleaseLink this[int id] { get; }
+
+        ReleaseLink Create(ReleaseLinkCreate data);
+
+        ReleaseLink Update(int id, ReleaseLinkUpdate data);
+
+        void Delete(int id);
+    }
+}

--- a/NGitLab/IRepositoryClient.cs
+++ b/NGitLab/IRepositoryClient.cs
@@ -46,7 +46,5 @@ namespace NGitLab
         IBranchClient Branches { get; }
 
         IProjectHooksClient ProjectHooks { get; }
-
-        IReleaseClient Releases { get; }
     }
 }

--- a/NGitLab/ITagClient.cs
+++ b/NGitLab/ITagClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NGitLab.Models;
 
 namespace NGitLab

--- a/NGitLab/Impl/ReleaseClient.cs
+++ b/NGitLab/Impl/ReleaseClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Impl
 {
     // Handles interacting with Releases.
     // Documentation: https://docs.gitlab.com/ee/api/releases/
-    public class ReleaseClient : IReleaseClient
+    internal class ReleaseClient : IReleaseClient
     {
         private readonly API _api;
         private readonly int _projectId;
@@ -20,7 +20,7 @@ namespace NGitLab.Impl
             _releasesPath = projectPath + "/releases";
         }
 
-        public IEnumerable<ReleaseInfo> All  => _api.Get().GetAll<ReleaseInfo>(_releasesPath + "?per_page=50");
+        public IEnumerable<ReleaseInfo> All  => _api.Get().GetAll<ReleaseInfo>(_releasesPath);
 
         public ReleaseInfo this[string tagName] => _api.Get().To<ReleaseInfo>($"{_releasesPath}/{WebUtility.UrlEncode(tagName)}");
 

--- a/NGitLab/Impl/ReleaseLinkClient.cs
+++ b/NGitLab/Impl/ReleaseLinkClient.cs
@@ -8,7 +8,7 @@ namespace NGitLab.Impl
 {
     // Handles interacting with Release links.
     // Documentation: https://docs.gitlab.com/ee/api/releases/links
-    public class ReleaseLinkClient : IReleaseLinkClient
+    internal class ReleaseLinkClient : IReleaseLinkClient
     {
         private readonly API _api;
         private readonly string _linksPath;

--- a/NGitLab/Impl/ReleaseLinkClient.cs
+++ b/NGitLab/Impl/ReleaseLinkClient.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using NGitLab.Models;
+
+namespace NGitLab.Impl
+{
+    // Handles interacting with Release links.
+    // Documentation: https://docs.gitlab.com/ee/api/releases/links
+    public class ReleaseLinkClient : IReleaseLinkClient
+    {
+        private readonly API _api;
+        private readonly string _linksPath;
+
+        public ReleaseLinkClient(API api, string releasesPath, string tagName)
+        {
+            _api = api;
+            _linksPath = $"{releasesPath}/{WebUtility.UrlEncode(tagName)}/assets/links";
+        }
+
+        public IEnumerable<ReleaseLink> All => _api.Get().GetAll<ReleaseLink>(_linksPath);
+
+        public ReleaseLink this[int linkId] => _api.Get().To<ReleaseLink>($"{_linksPath}/{linkId.ToString(CultureInfo.InvariantCulture)}");
+
+        public ReleaseLink Create(ReleaseLinkCreate data) => _api.Post().With(data).To<ReleaseLink>(_linksPath);
+
+        public ReleaseLink Update(int id, ReleaseLinkUpdate data) => _api.Put().With(data).To<ReleaseLink>($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
+
+        public void Delete(int id) => _api.Delete().Execute($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
+    }
+}

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -24,8 +24,6 @@ namespace NGitLab.Impl
 
         public ITagClient Tags => new TagClient(_api, _repoPath);
 
-        public IReleaseClient Releases => new ReleaseClient(_api, _projectPath);
-
         public IContributorClient Contributors => new ContributorClient(_api, _repoPath, _projectId);
 
         public IEnumerable<Tree> Tree => _api.Get().GetAll<Tree>(_repoPath + "/tree");

--- a/NGitLab/Impl/TagClient.cs
+++ b/NGitLab/Impl/TagClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using NGitLab.Models;
 

--- a/NGitLab/Models/ReleaseAssetSource.cs
+++ b/NGitLab/Models/ReleaseAssetSource.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract]
+    public class ReleaseAssetSource
+    {
+        [DataMember(Name = "format")]
+        public string Format;
+
+        [DataMember(Name = "url")]
+        public string Url;
+    }
+}

--- a/NGitLab/Models/ReleaseAssetSource.cs
+++ b/NGitLab/Models/ReleaseAssetSource.cs
@@ -6,9 +6,9 @@ namespace NGitLab.Models
     public class ReleaseAssetSource
     {
         [DataMember(Name = "format")]
-        public string Format;
+        public string Format { get; set; }
 
         [DataMember(Name = "url")]
-        public string Url;
+        public string Url { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseAssetsInfo.cs
+++ b/NGitLab/Models/ReleaseAssetsInfo.cs
@@ -6,12 +6,12 @@ namespace NGitLab.Models
     public class ReleaseAssetsInfo
     {
         [DataMember(Name = "count")]
-        public int? Count;
+        public int? Count { get; set; }
 
         [DataMember(Name = "sources")]
-        public ReleaseAssetSource[] Sources;
+        public ReleaseAssetSource[] Sources { get; set; }
 
         [DataMember(Name = "links")]
-        public ReleaseLink[] Links;
+        public ReleaseLink[] Links { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseAssetsInfo.cs
+++ b/NGitLab/Models/ReleaseAssetsInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract]
+    public class ReleaseAssetsInfo
+    {
+        [DataMember(Name = "count")]
+        public int? Count;
+
+        [DataMember(Name = "sources")]
+        public ReleaseAssetSource[] Sources;
+
+        [DataMember(Name = "links")]
+        public ReleaseLink[] Links;
+    }
+}

--- a/NGitLab/Models/ReleaseCreate.cs
+++ b/NGitLab/Models/ReleaseCreate.cs
@@ -12,42 +12,42 @@ namespace NGitLab.Models
         /// </summary>
         [Required]
         [DataMember(Name = "tag_name")]
-        public string TagName;
+        public string TagName { get; set; }
 
         /// <summary>
         /// (optional) - The description of the release.
         /// </summary>
         [DataMember(Name = "description")]
-        public string Description;
+        public string Description { get; set; }
 
         /// <summary>
         /// (optional) - The release name.
         /// </summary>
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         /// <summary>
         ///  - Required if tag_name doesn't exist. It can be a commit SHA, a tag name, or a branch name.
         /// </summary>
         [DataMember(Name = "ref")]
-        public string Ref;
+        public string Ref { get; set; }
 
         /// <summary>
         ///  - The title of each milestone the release is associated with.
         /// </summary>
         [DataMember(Name = "milestones")]
-        public string[] Milestones;
+        public string[] Milestones { get; set; }
 
         /// <summary>
         ///  - Assets containing an array of links.
         /// </summary>
         [DataMember(Name = "assets")]
-        public ReleaseAssetsInfo Assets;
+        public ReleaseAssetsInfo Assets { get; set; }
 
         /// <summary>
         ///  - The date when the release is/was ready. Defaults to the current time.
         /// </summary>
         [DataMember(Name = "released_at")]
-        public DateTime? ReleasedAt;
+        public DateTime? ReleasedAt { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseCreate.cs
+++ b/NGitLab/Models/ReleaseCreate.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace NGitLab.Models
@@ -7,23 +8,46 @@ namespace NGitLab.Models
     public class ReleaseCreate
     {
         /// <summary>
-        /// (required) - The name of the release from which the release is build on
+        /// (required) - The tag where the release is created from.
         /// </summary>
         [Required]
         [DataMember(Name = "tag_name")]
+        public string TagName;
+
+        /// <summary>
+        /// (optional) - The description of the release.
+        /// </summary>
+        [DataMember(Name = "description")]
+        public string Description;
+
+        /// <summary>
+        /// (optional) - The release name.
+        /// </summary>
+        [DataMember(Name = "name")]
         public string Name;
 
         /// <summary>
-        /// (required) - Create release using commit SHA, a tag name, or branch name.
+        ///  - Required if tag_name doesn't exist. It can be a commit SHA, a tag name, or a branch name.
         /// </summary>
-        [Required]
         [DataMember(Name = "ref")]
         public string Ref;
 
         /// <summary>
-        /// (optional) - Add release notes to the git release and store it in the GitLab database.
+        ///  - The title of each milestone the release is associated with.
         /// </summary>
-        [DataMember(Name = "description")]
-        public string Description;
+        [DataMember(Name = "milestones")]
+        public string[] Milestones;
+
+        /// <summary>
+        ///  - Assets containing an array of links.
+        /// </summary>
+        [DataMember(Name = "assets")]
+        public ReleaseAssetsInfo Assets;
+
+        /// <summary>
+        ///  - The date when the release is/was ready. Defaults to the current time.
+        /// </summary>
+        [DataMember(Name = "released_at")]
+        public DateTime? ReleasedAt;
     }
 }

--- a/NGitLab/Models/ReleaseEvidence.cs
+++ b/NGitLab/Models/ReleaseEvidence.cs
@@ -7,12 +7,12 @@ namespace NGitLab.Models
     public class ReleaseEvidence
     {
         [DataMember(Name = "sha")]
-        public string Sha;
+        public string Sha { get; set; }
 
         [DataMember(Name = "filepath")]
-        public string Filepath;
+        public string Filepath { get; set; }
 
         [DataMember(Name = "collected_at")]
-        public DateTime CollectedAt;
+        public DateTime CollectedAt { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseEvidence.cs
+++ b/NGitLab/Models/ReleaseEvidence.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract]
+    public class ReleaseEvidence
+    {
+        [DataMember(Name = "sha")]
+        public string Sha;
+
+        [DataMember(Name = "filepath")]
+        public string Filepath;
+
+        [DataMember(Name = "collected_at")]
+        public DateTime CollectedAt;
+    }
+}

--- a/NGitLab/Models/ReleaseInfo.cs
+++ b/NGitLab/Models/ReleaseInfo.cs
@@ -7,39 +7,39 @@ namespace NGitLab.Models
     public class ReleaseInfo
     {
         [DataMember(Name = "tag_name")]
-        public string TagName;
+        public string TagName { get; set; }
 
         [DataMember(Name = "description")]
-        public string Description;
+        public string Description { get; set; }
 
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         [DataMember(Name = "created_at")]
-        public DateTime CreatedAt;
+        public DateTime CreatedAt { get; set; }
 
         [DataMember(Name = "released_at")]
-        public DateTime ReleasedAt;
+        public DateTime ReleasedAt { get; set; }
 
         [DataMember(Name = "author")]
-        public Author Author;
+        public Author Author { get; set; }
 
         [DataMember(Name = "commit")]
-        public Commit Commit;
+        public Commit Commit { get; set; }
 
         [DataMember(Name = "milestones")]
-        public Milestone[] Milestones;
+        public Milestone[] Milestones { get; set; }
 
         [DataMember(Name = "commit_path")]
-        public string CommitPath;
+        public string CommitPath { get; set; }
 
         [DataMember(Name = "tag_path")]
-        public string TagPath;
+        public string TagPath { get; set; }
 
         [DataMember(Name = "assets")]
-        public ReleaseAssetsInfo Assets;
+        public ReleaseAssetsInfo Assets { get; set; }
 
         [DataMember(Name = "evidences")]
-        public ReleaseEvidence[] Evidences;
+        public ReleaseEvidence[] Evidences { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseInfo.cs
+++ b/NGitLab/Models/ReleaseInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace NGitLab.Models
 {
@@ -10,5 +11,35 @@ namespace NGitLab.Models
 
         [DataMember(Name = "description")]
         public string Description;
+
+        [DataMember(Name = "name")]
+        public string Name;
+
+        [DataMember(Name = "created_at")]
+        public DateTime CreatedAt;
+
+        [DataMember(Name = "released_at")]
+        public DateTime ReleasedAt;
+
+        [DataMember(Name = "author")]
+        public Author Author;
+
+        [DataMember(Name = "commit")]
+        public Commit Commit;
+
+        [DataMember(Name = "milestones")]
+        public Milestone[] Milestones;
+
+        [DataMember(Name = "commit_path")]
+        public string CommitPath;
+
+        [DataMember(Name = "tag_path")]
+        public string TagPath;
+
+        [DataMember(Name = "assets")]
+        public ReleaseAssetsInfo Assets;
+
+        [DataMember(Name = "evidences")]
+        public ReleaseEvidence[] Evidences;
     }
 }

--- a/NGitLab/Models/ReleaseLink.cs
+++ b/NGitLab/Models/ReleaseLink.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract(Name = "ReleaseLinkType")]
+    public enum ReleaseLinkType
+    {
+        [EnumMember(Value = "other")]
+        Other,
+        [EnumMember(Value = "runbook")]
+        Runbook,
+        [EnumMember(Value = "image")]
+        Image,
+        [EnumMember(Value = "package")]
+        Package,
+    }
+
+    [DataContract]
+    public class ReleaseLink
+    {
+        [DataMember(Name = "id")]
+        public int? Id;
+
+        [DataMember(Name = "name")]
+        public string Name;
+
+        [DataMember(Name = "url")]
+        public string Url;
+
+        [DataMember(Name = "direct_asset_url")]
+        public string DirectAssetUrl;
+
+        [DataMember(Name = "external")]
+        public bool External;
+
+        [DataMember(Name = "link_type")]
+        public ReleaseLinkType LinkType;
+    }
+}

--- a/NGitLab/Models/ReleaseLink.cs
+++ b/NGitLab/Models/ReleaseLink.cs
@@ -20,21 +20,21 @@ namespace NGitLab.Models
     public class ReleaseLink
     {
         [DataMember(Name = "id")]
-        public int? Id;
+        public int? Id { get; set; }
 
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         [DataMember(Name = "url")]
-        public string Url;
+        public string Url { get; set; }
 
         [DataMember(Name = "direct_asset_url")]
-        public string DirectAssetUrl;
+        public string DirectAssetUrl { get; set; }
 
         [DataMember(Name = "external")]
-        public bool External;
+        public bool External { get; set; }
 
         [DataMember(Name = "link_type")]
-        public ReleaseLinkType LinkType;
+        public ReleaseLinkType LinkType { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseLinkCreate.cs
+++ b/NGitLab/Models/ReleaseLinkCreate.cs
@@ -6,15 +6,15 @@ namespace NGitLab.Models
     public class ReleaseLinkCreate
     {
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         [DataMember(Name = "url")]
-        public string Url;
+        public string Url { get; set; }
 
         [DataMember(Name = "filepath")]
-        public string Filepath;
+        public string Filepath { get; set; }
 
         [DataMember(Name = "link_type")]
-        public ReleaseLinkType LinkType;
+        public ReleaseLinkType LinkType { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseLinkCreate.cs
+++ b/NGitLab/Models/ReleaseLinkCreate.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract]
+    public class ReleaseLinkCreate
+    {
+        [DataMember(Name = "name")]
+        public string Name;
+
+        [DataMember(Name = "url")]
+        public string Url;
+
+        [DataMember(Name = "filepath")]
+        public string Filepath;
+
+        [DataMember(Name = "link_type")]
+        public ReleaseLinkType LinkType;
+    }
+}

--- a/NGitLab/Models/ReleaseLinkUpdate.cs
+++ b/NGitLab/Models/ReleaseLinkUpdate.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.Serialization;
+
+namespace NGitLab.Models
+{
+    [DataContract]
+    public class ReleaseLinkUpdate
+    {
+        [DataMember(Name = "name")]
+        public string Name;
+
+        [DataMember(Name = "url")]
+        public string Url;
+
+        [DataMember(Name = "filepath")]
+        public string Filepath;
+
+        [DataMember(Name = "link_type")]
+        public ReleaseLinkType LinkType;
+    }
+}

--- a/NGitLab/Models/ReleaseLinkUpdate.cs
+++ b/NGitLab/Models/ReleaseLinkUpdate.cs
@@ -6,15 +6,15 @@ namespace NGitLab.Models
     public class ReleaseLinkUpdate
     {
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         [DataMember(Name = "url")]
-        public string Url;
+        public string Url { get; set; }
 
         [DataMember(Name = "filepath")]
-        public string Filepath;
+        public string Filepath { get; set; }
 
         [DataMember(Name = "link_type")]
-        public ReleaseLinkType LinkType;
+        public ReleaseLinkType LinkType { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseUpdate.cs
+++ b/NGitLab/Models/ReleaseUpdate.cs
@@ -12,30 +12,30 @@ namespace NGitLab.Models
         /// </summary>
         [Required]
         [DataMember(Name = "tag_name")]
-        public string TagName;
+        public string TagName { get; set; }
 
         /// <summary>
         /// (optional) - The description of the release.
         /// </summary>
         [DataMember(Name = "description")]
-        public string Description;
+        public string Description { get; set; }
 
         /// <summary>
         /// (optional) - The release name.
         /// </summary>
         [DataMember(Name = "name")]
-        public string Name;
+        public string Name { get; set; }
 
         /// <summary>
         ///  - The title of each milestone the release is associated with.
         /// </summary>
         [DataMember(Name = "milestones")]
-        public string[] Milestones;
+        public string[] Milestones { get; set; }
 
         /// <summary>
         ///  - The date when the release is/was ready. Defaults to the current time.
         /// </summary>
         [DataMember(Name = "released_at")]
-        public DateTime? ReleasedAt;
+        public DateTime? ReleasedAt { get; set; }
     }
 }

--- a/NGitLab/Models/ReleaseUpdate.cs
+++ b/NGitLab/Models/ReleaseUpdate.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace NGitLab.Models
@@ -7,16 +8,34 @@ namespace NGitLab.Models
     public class ReleaseUpdate
     {
         /// <summary>
-        /// (required) - The name of the release from which the release is build on
+        /// (required) - The Git tag the release is associated with.
         /// </summary>
         [Required]
         [DataMember(Name = "tag_name")]
-        public string Name;
+        public string TagName;
 
         /// <summary>
-        /// (required) - Release notes to the git release and store it in the GitLab database.
+        /// (optional) - The description of the release.
         /// </summary>
         [DataMember(Name = "description")]
         public string Description;
+
+        /// <summary>
+        /// (optional) - The release name.
+        /// </summary>
+        [DataMember(Name = "name")]
+        public string Name;
+
+        /// <summary>
+        ///  - The title of each milestone the release is associated with.
+        /// </summary>
+        [DataMember(Name = "milestones")]
+        public string[] Milestones;
+
+        /// <summary>
+        ///  - The date when the release is/was ready. Defaults to the current time.
+        /// </summary>
+        [DataMember(Name = "released_at")]
+        public DateTime? ReleasedAt;
     }
 }


### PR DESCRIPTION
Changes to ReleaseClient:
Added all the fields in Release.
The name of the release ca be different than the tag name.
A release can be created with asset links.

Added LinksClient to implement release links API.

Added back CreateRelease and UpdateRelease methods in TagClient. Removing them was a breaking change. (I don't know if there's much sense in adding them back though.)

Added some tests for the new API.


There might be a few changes where there is not much added value (you might wander "What's the point in changing that?") the reason is that I have implemented this before seeing the other commit. I was just about to create a pull request when the other one got merged.

As it is, my code contains some breaking changes. There sure is a way to work around that, but as I mentioned, the previous commit already had some hard breaking changes (the functions that were removed had not been previously deprecated), so first I wanted your input before starting to make changes. Here they are:
- I've chosen to put GetReleases method in GitLabClient, instead of RepositoryClient. For me it made more sense to be there, 
as the api is not related to repository. 
- RelaseClient methods return an object of type "Release", instead of "ReleaseInfo". I wanted to make a distinction between the release info that is returned from the tags api (that is more limited), and the one from the releases. If the functions in tags remain removed, there's no need for the old ReleaseInfo, so I have no problem renaming the new one.
- I created ReleaseCollection class to deal with releases for the mock releaseClient. I didn't want to pollute the repository class, plus it's uniform with how we handle other collections (badges, merge requests, pipelines, etc). But since the logic was already added to Repository class, I guess it's now a breaking change.