### PR TITLE
Add some chars in mocks method that normalize projects and groups path

### DIFF
--- a/NGitLab.Mock/Slug.cs
+++ b/NGitLab.Mock/Slug.cs
@@ -30,7 +30,7 @@ namespace NGitLab.Mock
 
         private static bool IsAllowed(char c)
         {
-            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_';
         }
     }
 }


### PR DESCRIPTION
For now if I create a project in mocks with the name `Project_1`, the project path will be renamed to `Project-1` (same with dot char `.`) but it seems that GitLab support `_` and `.` characters.