### PR TITLE
Adding expires_at to the add member route

### DIFF
--- a/NGitLab.Tests/MembersClientTests.cs
+++ b/NGitLab.Tests/MembersClientTests.cs
@@ -20,7 +20,7 @@ namespace NGitLab.Tests
             context.CreateNewUser(out var user);
             var projectId = project.Id.ToString(CultureInfo.InvariantCulture);
 
-            var expiresAt = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-dd");
+            var expiresAt = DateTimeOffset.UtcNow.AddDays(30).ToString("yyyy-MM-dd");
             context.Client.Members.AddMemberToProject(projectId, new ProjectMemberCreate
             {
                 AccessLevel = AccessLevel.Developer,

--- a/NGitLab.Tests/MembersClientTests.cs
+++ b/NGitLab.Tests/MembersClientTests.cs
@@ -1,14 +1,38 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
 using NUnit.Framework;
+#nullable enable
 
 namespace NGitLab.Tests
 {
     public class MembersClientTests
     {
+        [Test]
+        [NGitLabRetry]
+        public async Task AddMemberToProject()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            context.CreateNewUser(out var user);
+            var projectId = project.Id.ToString(CultureInfo.InvariantCulture);
+
+            var expiresAt = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-dd");
+            context.Client.Members.AddMemberToProject(projectId, new ProjectMemberCreate
+            {
+                AccessLevel = AccessLevel.Developer,
+                UserId = user.Id.ToString(CultureInfo.InvariantCulture),
+                ExpiresAt = expiresAt,
+            });
+
+            var projectUser = context.Client.Members.OfProject(projectId).Single(u => u.Id == user.Id);
+            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)projectUser.AccessLevel);
+            Assert.AreEqual(expiresAt, projectUser.ExpiresAt?.ToString("yyyy-MM-dd"));
+        }
+
         [Test]
         [NGitLabRetry]
         public async Task UpsertAccessLevelMemberOfProject()

--- a/NGitLab/Models/Membership.cs
+++ b/NGitLab/Models/Membership.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#pragma warning disable RS0037 // Activate nullable values in public API
+#nullable enable
+
 namespace NGitLab.Models
 {
     [DataContract]
@@ -33,6 +36,9 @@ namespace NGitLab.Models
         [DataMember(Name = "state")]
         public string State;
 
+        /// <summary>
+        /// Membership creation date
+        /// </summary>
         [DataMember(Name = "created_at")]
         public DateTime CreatedAt;
 
@@ -41,5 +47,11 @@ namespace NGitLab.Models
         /// </summary>
         [DataMember(Name = "access_level")]
         public int AccessLevel;
+
+        /// <summary>
+        /// Membership expiration date
+        /// </summary>
+        [DataMember(Name = "expires_at")]
+        public DateTime? ExpiresAt;
     }
 }

--- a/NGitLab/Models/Membership.cs
+++ b/NGitLab/Models/Membership.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
-#pragma warning disable RS0037 // Activate nullable values in public API
-#nullable enable
-
 namespace NGitLab.Models
 {
     [DataContract]

--- a/NGitLab/Models/ProjectMemberCreate.cs
+++ b/NGitLab/Models/ProjectMemberCreate.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace NGitLab.Models
 {
@@ -14,6 +12,6 @@ namespace NGitLab.Models
         public AccessLevel AccessLevel;
 
         [DataMember(Name = "expires_at")]
-        public string? ExpiresAt;
+        public string ExpiresAt;
     }
 }

--- a/NGitLab/Models/ProjectMemberCreate.cs
+++ b/NGitLab/Models/ProjectMemberCreate.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+﻿#nullable enable
+
+using System.Runtime.Serialization;
 
 namespace NGitLab.Models
 {
@@ -10,5 +12,8 @@ namespace NGitLab.Models
 
         [DataMember(Name = "access_level")]
         public AccessLevel AccessLevel;
+
+        [DataMember(Name = "expires_at")]
+        public string? ExpiresAt;
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1646,6 +1646,7 @@ NGitLab.Models.Membership
 NGitLab.Models.Membership.AccessLevel -> int
 NGitLab.Models.Membership.AvatarURL -> string
 NGitLab.Models.Membership.CreatedAt -> System.DateTime
+NGitLab.Models.Membership.ExpiresAt -> System.DateTime?
 NGitLab.Models.Membership.Id -> int
 NGitLab.Models.Membership.Membership() -> void
 NGitLab.Models.Membership.Name -> string
@@ -2188,6 +2189,7 @@ NGitLab.Models.ProjectLinks.RepoBranches -> string
 NGitLab.Models.ProjectLinks.Self -> string
 NGitLab.Models.ProjectMemberCreate
 NGitLab.Models.ProjectMemberCreate.AccessLevel -> NGitLab.Models.AccessLevel
+NGitLab.Models.ProjectMemberCreate.ExpiresAt -> string
 NGitLab.Models.ProjectMemberCreate.ProjectMemberCreate() -> void
 NGitLab.Models.ProjectMemberCreate.UserId -> string
 NGitLab.Models.ProjectMemberUpdate


### PR DESCRIPTION
Adding the expires_at parameter which is supported by the Gitlab API: https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project  