### PR TITLE
Adding ForkingAccessLevel to GitLabProject mock

### DIFF
--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -871,6 +871,7 @@ namespace NGitLab.Mock.Config
                 Description = project.Description,
                 DefaultBranch = project.DefaultBranch ?? server.DefaultBranchName,
                 Visibility = project.Visibility ?? project.Parent.DefaultVisibility,
+                ForkingAccessLevel = project.ForkingAccessLevel,
             };
 
             var group = GetOrCreateGroup(server, project.Namespace ?? Guid.NewGuid().ToString("D"));

--- a/NGitLab.Mock/Config/GitLabProject.cs
+++ b/NGitLab.Mock/Config/GitLabProject.cs
@@ -28,6 +28,8 @@ namespace NGitLab.Mock.Config
 
         public string Description { get; set; }
 
+        public RepositoryAccessLevel ForkingAccessLevel { get; set; }
+
         /// <summary>
         /// Path where to clone repository after server resolving
         /// </summary>

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -131,6 +131,8 @@ NGitLab.Mock.Config.GitLabMilestone.UpdatedAt.get -> System.DateTime?
 NGitLab.Mock.Config.GitLabMilestone.UpdatedAt.set -> void
 NGitLab.Mock.Config.GitLabMilestonesCollection
 NGitLab.Mock.Config.GitLabObject.Parent.get -> object
+NGitLab.Mock.Config.GitLabProject.ForkingAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
+NGitLab.Mock.Config.GitLabProject.ForkingAccessLevel.set -> void
 NGitLab.Mock.Config.GitLabProject.Milestones.get -> NGitLab.Mock.Config.GitLabMilestonesCollection
 NGitLab.Mock.Config.GitLabProject.Visibility.get -> NGitLab.Models.VisibilityLevel?
 NGitLab.Mock.EffectivePermissions


### PR DESCRIPTION
Adding ForkingAccessLevel to GitLabProject, so it's possible to test a project with or without forkingaccesslevel enabled.  