### PR TITLE
Fix merge requests mocks assignee overriding assignees

### DIFF
--- a/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
+++ b/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
@@ -84,5 +84,25 @@ namespace NGitLab.Mock.Tests
             Assert.AreEqual(1, mergeRequests.Length, "Merge requests count is invalid");
             Assert.AreEqual("Merge request 2", mergeRequests[0].Title, "Merge request found is invalid");
         }
+
+        [Test]
+        public void Test_merge_requests_assignee_should_update_assignees_and_vice_versa()
+        {
+            var user1 = new User("user1");
+            var user2 = new User("user2");
+
+            var mergeRequestSingle = new MergeRequest
+            {
+                Assignee = new UserRef(user1),
+            };
+
+            var mergeRequestTwo = new MergeRequest
+            {
+                Assignees = new[] { new UserRef(user1), new UserRef(user2) },
+            };
+
+            Assert.AreEqual(1, mergeRequestSingle.Assignees.Count, "Merge request assignees count invalid");
+            Assert.AreEqual("user1", mergeRequestTwo.Assignee.UserName, "Merge request assignee is invalid");
+        }
     }
 }

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -589,13 +589,10 @@ namespace NGitLab.Mock.Clients
 
                             mergeRequest.Assignees.Add(new UserRef(user));
                         }
-
-                        mergeRequest.Assignee = mergeRequest.Assignees.First();
                     }
                 }
                 else if (mergeRequestUpdate.AssigneeId != null)
                 {
-                    mergeRequest.Assignees.Clear();
                     if (mergeRequestUpdate.AssigneeId.Value == 0)
                     {
                         mergeRequest.Assignee = null;
@@ -607,7 +604,6 @@ namespace NGitLab.Mock.Clients
                             throw new GitLabBadRequestException("user not found");
 
                         mergeRequest.Assignee = new UserRef(user);
-                        mergeRequest.Assignees.Add(new UserRef(user));
                     }
                 }
 

--- a/NGitLab.Mock/MergeRequest.cs
+++ b/NGitLab.Mock/MergeRequest.cs
@@ -202,7 +202,6 @@ namespace NGitLab.Mock
         {
             return new Models.MergeRequest
             {
-                Assignee = Assignee?.ToUserClient(),
                 Assignees = GetUsers(Assignees),
                 Author = Author.ToUserClient(),
                 CreatedAt = CreatedAt.UtcDateTime,


### PR DESCRIPTION
When assigning a value to `MergeRequest.Assignee`, `Assignees` gets cleared up by the set accessor.

This will remove all code instances where the Assignees gets modified before Assignee, which did unwanted behaviors.  