### PR TITLE
Added Advanced Search using Groups

### DIFF
--- a/NGitLab/Impl/ProjectClient.cs
+++ b/NGitLab/Impl/ProjectClient.cs
@@ -50,6 +50,11 @@ namespace NGitLab.Impl
                 url = $"/users/{query.UserId.Value.ToStringInvariant()}/projects";
             }
 
+            if (query.GroupID != string.Empty)
+            {
+                url = $"/groups/{query.GroupID}/search?scope=projects";
+            }
+
             if (query.LastActivityAfter.HasValue)
             {
                 url = Utils.AddParameter(url, "last_activity_after", query.LastActivityAfter.Value.UtcDateTime.ToString("O"));

--- a/NGitLab/Models/ProjectQuery.cs
+++ b/NGitLab/Models/ProjectQuery.cs
@@ -57,6 +57,11 @@ namespace NGitLab.Models
         public int? UserId;
 
         /// <summary>
+        /// Project visible by group
+        /// </summary>
+        public string GroupID;
+
+        /// <summary>
         /// Limit to projects where current user has at least this access level
         /// (optional)
         /// </summary>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2212,6 +2212,7 @@ NGitLab.Models.ProjectMemberUpdate.UserId -> string
 NGitLab.Models.ProjectQuery
 NGitLab.Models.ProjectQuery.Archived -> bool?
 NGitLab.Models.ProjectQuery.Ascending -> bool?
+NGitLab.Models.ProjectQuery.GroupID -> string
 NGitLab.Models.ProjectQuery.LastActivityAfter -> System.DateTimeOffset?
 NGitLab.Models.ProjectQuery.MinAccessLevel -> NGitLab.Models.AccessLevel?
 NGitLab.Models.ProjectQuery.OrderBy -> string


### PR DESCRIPTION
The  [Group API](https://docs.gitlab.com/ee/api/search.html#scope-projects-1) specifies the following format:

> `curl --header "PRIVATE-TOKEN: <your_access_token>" "https://gitlab.example.com/api/v4/groups/3/search?scope=projects&search=flight"`.

This group selection is supported by introducing the `groupID `parameter to the `ProjectQuery` scope.
