### PR TITLE
Added Advanced Search using Groups

### DIFF
--- a/NGitLab.Mock/Clients/GroupClient.cs
+++ b/NGitLab.Mock/Clients/GroupClient.cs
@@ -127,6 +127,11 @@ namespace NGitLab.Mock.Clients
             throw new NotImplementedException();
         }
 
+        public IEnumerable<Models.Project> SearchProjects(string groupId, string search, GroupQueryScope scope)
+        {
+            throw new NotImplementedException();
+        }
+
         public Models.Group Update(int id, GroupUpdate groupUpdate)
         {
             using (Context.BeginOperationScope())

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -140,6 +140,26 @@ namespace NGitLab.Tests
 
         [Test]
         [NGitLabRetry]
+        public async Task Test_get_by_group_query_SearchProjects_returns_group()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var groupClient = context.Client.Groups;
+            var group = context.CreateGroup();
+            var project = context.Client.Projects.Create(new ProjectCreate { Name = "test", NamespaceId = group.Id.ToString(CultureInfo.InvariantCulture), Path = "testgroup" });
+
+            // Act
+            var result = groupClient.SearchProjects(groupId: group.Name, search: "test", scope: GroupQueryScope.Projects);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotEmpty(result);
+            Assert.AreEqual(project.Name, result.FirstOrDefault().Name);
+            Assert.AreEqual(project.Id, result.FirstOrDefault().Id);
+            Assert.AreEqual(project.Path, result.FirstOrDefault().Path);
+        }
+
+        [Test]
+        [NGitLabRetry]
         public async Task Test_get_by_group_query_groupQuery_AllAvailable_returns_groups()
         {
             using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/IGroupsClient.cs
+++ b/NGitLab/IGroupsClient.cs
@@ -29,6 +29,8 @@ namespace NGitLab
 
         IEnumerable<Project> SearchProjects(int groupId, string search);
 
+        IEnumerable<Project> SearchProjects(string groupId, string search, GroupQueryScope scope);
+
         void Delete(int id);
 
         Group Update(int id, GroupUpdate groupUpdate);

--- a/NGitLab/Impl/GroupsClient.cs
+++ b/NGitLab/Impl/GroupsClient.cs
@@ -91,6 +91,16 @@ namespace NGitLab.Impl
             return _api.Get().GetAll<Project>(url);
         }
 
+        // implementation according to https://docs.gitlab.com/ee/api/search.html#scope-projects-1
+        public IEnumerable<Project> SearchProjects(string groupId, string search, GroupQueryScope scope)
+        {
+            var url = Url + "/" + Uri.EscapeDataString(groupId.ToString(CultureInfo.InvariantCulture)) + "/search";
+            url = Utils.AddParameter(url, "scope", Enum.GetName(typeof(GroupQueryScope), scope).ToLower());
+            url = Utils.AddParameter(url, "search", search);
+            url = Utils.AddOrderBy(url);
+            return _api.Get().GetAll<Project>(url);
+        }
+
         public Group Create(GroupCreate group) => _api.Post().With(group).To<Group>(Url);
 
         public void Delete(int id)

--- a/NGitLab/Models/GroupQuery.cs
+++ b/NGitLab/Models/GroupQuery.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace NGitLab.Models
 {
@@ -62,5 +63,56 @@ namespace NGitLab.Models
         /// (optional)
         /// </summary>
         public AccessLevel? MinAccessLevel;
+
+        public GroupQueryScope Scope = GroupQueryScope.Projects;
+    }
+
+    // implementation according to https://docs.gitlab.com/ee/api/search.html#scope-projects-1
+    public enum GroupQueryScope
+    {
+        /// <summary>
+        /// The response depends on the requested scope project
+        /// </summary>
+        Projects,
+
+        /// <summary>
+        /// The response depends on the requested scope issues
+        /// </summary>
+        Issues,
+
+        /// <summary>
+        /// The response depends on the requested scope merge_requests
+        /// </summary>
+        Merge_requests,
+
+        /// <summary>
+        /// The response depends on the requested scope milestones
+        /// </summary>
+        Milestones,
+
+        /// <summary>
+        /// The response depends on the requested scope wiki_blobs
+        /// </summary>
+        Wiki_blobs,
+
+        /// <summary>
+        /// The response depends on the requested scope commits
+        /// </summary>
+        Commits,
+
+        /// <summary>
+        /// The response depends on the requested scope blobs
+        /// </summary>
+        Blobs,
+
+        /// <summary>
+        /// The response depends on the requested scope notes
+        /// </summary>
+        Notes,
+
+        /// <summary>
+        /// The response depends on the requested scope users
+        /// </summary>
+        Users,
     }
 }

--- a/NGitLab/NGitLab.csproj
+++ b/NGitLab/NGitLab.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -182,6 +182,7 @@ NGitLab.IGroupsClient.Get(NGitLab.Models.GroupQuery query) -> System.Collections
 NGitLab.IGroupsClient.Restore(int id) -> void
 NGitLab.IGroupsClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.IGroupsClient.SearchProjects(int groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.IGroupsClient.SearchProjects(string groupId, string search, NGitLab.Models.GroupQueryScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IGroupsClient.this[int id].get -> NGitLab.Models.Group
 NGitLab.IGroupsClient.this[string fullPath].get -> NGitLab.Models.Group
 NGitLab.IGroupsClient.Update(int id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
@@ -376,6 +377,7 @@ NGitLab.Impl.GroupsClient.GroupsClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.GroupsClient.Restore(int id) -> void
 NGitLab.Impl.GroupsClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.SearchProjects(int groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.Impl.GroupsClient.SearchProjects(string groupId, string search, NGitLab.Models.GroupQueryScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.GroupsClient.this[int id].get -> NGitLab.Models.Group
 NGitLab.Impl.GroupsClient.this[string fullPath].get -> NGitLab.Models.Group
 NGitLab.Impl.GroupsClient.Update(int id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
@@ -1435,11 +1437,22 @@ NGitLab.Models.GroupQuery.GroupQuery() -> void
 NGitLab.Models.GroupQuery.MinAccessLevel -> NGitLab.Models.AccessLevel?
 NGitLab.Models.GroupQuery.OrderBy -> string
 NGitLab.Models.GroupQuery.Owned -> bool?
+NGitLab.Models.GroupQuery.Scope -> NGitLab.Models.GroupQueryScope
 NGitLab.Models.GroupQuery.Search -> string
 NGitLab.Models.GroupQuery.SkipGroups -> int[]
 NGitLab.Models.GroupQuery.Sort -> string
 NGitLab.Models.GroupQuery.Statistics -> bool?
 NGitLab.Models.GroupQuery.WithCustomAttributes -> bool?
+NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Blobs = 6 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Commits = 5 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Issues = 1 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Merge_requests = 2 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Milestones = 3 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Notes = 7 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Projects = 0 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Users = 8 -> NGitLab.Models.GroupQueryScope
+NGitLab.Models.GroupQueryScope.Wiki_blobs = 4 -> NGitLab.Models.GroupQueryScope
 NGitLab.Models.GroupUpdate
 NGitLab.Models.GroupUpdate.Description.get -> string
 NGitLab.Models.GroupUpdate.Description.set -> void


### PR DESCRIPTION
The  [Group API](https://docs.gitlab.com/ee/api/search.html#scope-projects-1) specifies the following format:

> `curl --header "PRIVATE-TOKEN: <your_access_token>" "https://gitlab.example.com/api/v4/groups/3/search?scope=projects&search=flight"`.

This group selection is supported by introducing the `groupID `parameter to the `ProjectQuery` scope.

It addresses the requests in the former pull request: `https://github.com/ubisoft/NGitLab/pull/129`. All tests are passing except for unrelated assert in `Test_merge_request_approvers`.