### PR TITLE
Test on GitLab 14.3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
         # Keep in sync with the version in GitLabDockerContainer.cs
         # Available tags: https://hub.docker.com/r/gitlab/gitlab-ee/tags
         gitlab: [
-          'gitlab/gitlab-ee:14.2.5-ee.0',
-          'gitlab/gitlab-ee:14.0.11-ee.0',
-          'gitlab/gitlab-ee:13.10.3-ee.0'
+          'gitlab/gitlab-ee:14.3.4-ee.0',
+          'gitlab/gitlab-ee:14.0.11-ee.0'
         ]
         configuration: [ Release ]
       fail-fast: false

--- a/NGitLab.Tests/ContributorsTests.cs
+++ b/NGitLab.Tests/ContributorsTests.cs
@@ -48,7 +48,7 @@ namespace NGitLab.Tests
                 Skype = "skype",
                 Twitter = "twitter",
                 Username = $"ngitlabtestcontributor{randomString}",
-                WebsiteURL = "example.com",
+                WebsiteURL = "https://www.example.com",
             };
 
             var user = context.AdminClient.Users.Create(userUpsert);

--- a/NGitLab.Tests/UsersTests.cs
+++ b/NGitLab.Tests/UsersTests.cs
@@ -140,7 +140,7 @@ namespace NGitLab.Tests
                 Skype = "skype",
                 Twitter = "twitter",
                 Username = $"ngitlabtestuser{randomNumber}",
-                WebsiteURL = "wp.pl",
+                WebsiteURL = "https://www.example.com",
             });
         }
 


### PR DESCRIPTION
- Add tests for GitLab 14.3.4
- Remove tests for GitLab 13

In 14.3.4, GitLab validates the website url is valid. I've updated the tests to generate a valid url.