### PR TITLE
Add async implementation

### DIFF
--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Mock.Internals;
 using NGitLab.Models;
 
 namespace NGitLab.Mock.Clients
@@ -206,6 +210,13 @@ namespace NGitLab.Mock.Clients
             }
         }
 
+        [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
+        public async Task<Models.Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            return GetById(id, query);
+        }
+
         public IEnumerable<Models.Project> GetForks(string id, ForkedProjectQuery query)
         {
             using (Context.BeginOperationScope())
@@ -278,6 +289,11 @@ namespace NGitLab.Mock.Clients
         public UploadedProjectFile UploadFile(string id, FormDataContent data)
         {
             throw new NotImplementedException();
+        }
+
+        public GitLabCollectionResponse<Models.Project> GetAsync(ProjectQuery query)
+        {
+            return GitLabCollectionResponse.Create(Get(query));
         }
     }
 }

--- a/NGitLab.Mock/Internals/GitLabCollectionResponse.cs
+++ b/NGitLab.Mock/Internals/GitLabCollectionResponse.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NGitLab.Mock.Internals
+{
+    internal static class GitLabCollectionResponse
+    {
+        public static GitLabCollectionResponse<T> Create<T>(IEnumerable<T> items)
+        {
+            return new GitLabCollectionResponseImpl<T>(items);
+        }
+
+        private sealed class GitLabCollectionResponseImpl<T> : GitLabCollectionResponse<T>
+        {
+            private readonly IEnumerable<T> _items;
+
+            public GitLabCollectionResponseImpl(IEnumerable<T> items)
+            {
+                _items = items;
+            }
+
+            public override async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                await Task.Yield();
+                foreach (var item in _items)
+                {
+                    yield return item;
+                }
+            }
+
+            public override IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+        }
+    }
+}

--- a/NGitLab.Tests/AsyncApiValidation.cs
+++ b/NGitLab.Tests/AsyncApiValidation.cs
@@ -19,6 +19,11 @@ namespace NGitLab.Tests
                 {
                     if (typeof(Task).IsAssignableFrom(method.ReturnType))
                     {
+                        if (!method.Name.EndsWith("Async", System.StringComparison.Ordinal))
+                        {
+                            Assert.Fail($"The method '{method}' must end with 'Async'");
+                        }
+
                         // Ensure method that returns a Task takes a CancellationToken
                         var parameterInfo = method.GetParameters().LastOrDefault();
                         if (parameterInfo is null)
@@ -41,6 +46,14 @@ namespace NGitLab.Tests
                         if (attr is null)
                         {
                             Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' must be optional");
+                        }
+                    }
+
+                    if (method.ReturnType.IsGenericType && typeof(GitLabCollectionResponse<>).IsAssignableFrom(method.ReturnType.GetGenericTypeDefinition()))
+                    {
+                        if (!method.Name.EndsWith("Async", System.StringComparison.Ordinal))
+                        {
+                            Assert.Fail($"The method '{method}' must end with 'Async'");
                         }
                     }
                 }

--- a/NGitLab.Tests/AsyncApiValidation.cs
+++ b/NGitLab.Tests/AsyncApiValidation.cs
@@ -38,7 +38,7 @@ namespace NGitLab.Tests
 
                         if (!string.Equals(parameterInfo.Name, "cancellationToken", System.StringComparison.Ordinal))
                         {
-                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' of must be named 'cancellationToken'");
+                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' must be named 'cancellationToken'");
                         }
 
                         // Ensure the parameter is optional

--- a/NGitLab.Tests/AsyncApiValidation.cs
+++ b/NGitLab.Tests/AsyncApiValidation.cs
@@ -33,7 +33,7 @@ namespace NGitLab.Tests
 
                         if (parameterInfo.ParameterType != typeof(CancellationToken))
                         {
-                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' of must be of type 'CancellationToken'");
+                           Assert.Fail($"The last parameter of method '{method}' must be of type 'CancellationToken' and named 'cancellationToken'");
                         }
 
                         if (!string.Equals(parameterInfo.Name, "cancellationToken", System.StringComparison.Ordinal))

--- a/NGitLab.Tests/AsyncApiValidation.cs
+++ b/NGitLab.Tests/AsyncApiValidation.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NGitLab.Tests
+{
+    public class AsyncApiValidation
+    {
+        [Test]
+        public void ValidateAsyncMethodSignature()
+        {
+            var interfaces = typeof(IGitLabClient).Assembly.GetTypes().Where(t => t.IsInterface && t.IsPublic && t != typeof(IHttpRequestor));
+            foreach (var iface in interfaces)
+            {
+                foreach (var method in iface.GetMethods())
+                {
+                    if (typeof(Task).IsAssignableFrom(method.ReturnType))
+                    {
+                        // Ensure method that returns a Task takes a CancellationToken
+                        var parameterInfo = method.GetParameters().LastOrDefault();
+                        if (parameterInfo is null)
+                        {
+                            Assert.Fail($"The method '{method}' must have a parameter of type 'CancellationToken'");
+                        }
+
+                        if (parameterInfo.ParameterType != typeof(CancellationToken))
+                        {
+                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' of must be of type 'CancellationToken'");
+                        }
+
+                        if (!string.Equals(parameterInfo.Name, "cancellationToken", System.StringComparison.Ordinal))
+                        {
+                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' of must be named 'cancellationToken'");
+                        }
+
+                        // Ensure the parameter is optional
+                        var attr = parameterInfo.GetCustomAttribute<OptionalAttribute>();
+                        if (attr is null)
+                        {
+                            Assert.Fail($"The parameter '{parameterInfo.Name}' of '{method}' must be optional");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
@@ -11,6 +12,35 @@ namespace NGitLab.Tests
 {
     public class ProjectsTests
     {
+        [Test]
+        [NGitLabRetry]
+        public async Task GetProjectByIdAsync()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            var projectClient = context.Client.Projects;
+
+            var projectResult = await projectClient.GetByIdAsync(project.Id, new SingleProjectQuery(), CancellationToken.None);
+            Assert.AreEqual(project.Id, projectResult.Id);
+        }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task GetProjectsAsync()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            var projectClient = context.Client.Projects;
+
+            var projects = new List<Project>();
+            await foreach (var item in projectClient.GetAsync(new ProjectQuery()))
+            {
+                projects.Add(item);
+            }
+
+            CollectionAssert.IsNotEmpty(projects);
+        }
+
         [Test]
         [NGitLabRetry]
         public async Task GetOwnedProjects()

--- a/NGitLab/IHttpRequestor.cs
+++ b/NGitLab/IHttpRequestor.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NGitLab
 {
@@ -8,11 +10,19 @@ namespace NGitLab
     {
         IEnumerable<T> GetAll<T>(string tailUrl);
 
+        GitLabCollectionResponse<T> GetAllAsync<T>(string tailUrl);
+
         void Stream(string tailAPIUrl, Action<Stream> parser);
+
+        Task StreamAsync(string tailAPIUrl, Func<Stream, Task> parser, CancellationToken cancellationToken);
 
         T To<T>(string tailAPIUrl);
 
+        Task<T> ToAsync<T>(string tailAPIUrl, CancellationToken cancellationToken);
+
         void Execute(string tailAPIUrl);
+
+        Task ExecuteAsync(string tailAPIUrl, CancellationToken cancellationToken);
 
         IHttpRequestor With(object data);
     }

--- a/NGitLab/IProjectClient.cs
+++ b/NGitLab/IProjectClient.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Models;
 
 namespace NGitLab
@@ -25,6 +27,8 @@ namespace NGitLab
         /// </summary>
         IEnumerable<Project> Get(ProjectQuery query);
 
+        GitLabCollectionResponse<Project> GetAsync(ProjectQuery query);
+
         Project this[int id] { get; }
 
         /// <summary>
@@ -49,6 +53,8 @@ namespace NGitLab
         UploadedProjectFile UploadFile(string id, FormDataContent data);
 
         Project GetById(int id, SingleProjectQuery query);
+
+        Task<Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default);
 
         Project Fork(string id, ForkProject forkProject);
 

--- a/NGitLab/Impl/GitLabCollectionResponse.cs
+++ b/NGitLab/Impl/GitLabCollectionResponse.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace NGitLab
+{
+    public abstract class GitLabCollectionResponse<T> : IEnumerable<T>, IAsyncEnumerable<T>
+    {
+        public abstract IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
+
+        public abstract IEnumerator<T> GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -66,6 +68,16 @@ namespace NGitLab.Impl
                     options.IsIncremental);
             }
 
+            public Task<WebResponse> GetResponseAsync(RequestOptions options, CancellationToken cancellationToken)
+            {
+                Func<Task<WebResponse>> getResponseImpl = () => GetResponseImplAsync(options, cancellationToken);
+
+                return getResponseImpl.RetryAsync(options.ShouldRetry,
+                    options.RetryInterval,
+                    options.RetryCount,
+                    options.IsIncremental);
+            }
+
             private WebResponse GetResponseImpl(RequestOptions options)
             {
                 try
@@ -76,36 +88,57 @@ namespace NGitLab.Impl
                 catch (WebException wex)
                 {
                     if (wex.Response == null)
-                    {
                         throw;
-                    }
 
-                    using var errorResponse = (HttpWebResponse)wex.Response;
-                    string jsonString;
-                    using (var reader = new StreamReader(errorResponse.GetResponseStream()))
-                    {
-                        jsonString = reader.ReadToEnd();
-                    }
-
-                    var errorMessage = ExtractErrorMessage(jsonString, out var parsedError);
-                    var exceptionMessage =
-                        $"GitLab server returned an error ({errorResponse.StatusCode}): {errorMessage}. " +
-                        $"Original call: {Method} {Url}";
-
-                    if (JsonData != null)
-                    {
-                        exceptionMessage += $". With data {JsonData}";
-                    }
-
-                    throw new GitLabException(exceptionMessage)
-                    {
-                        OriginalCall = Url,
-                        ErrorObject = parsedError,
-                        StatusCode = errorResponse.StatusCode,
-                        ErrorMessage = errorMessage,
-                        MethodType = Method,
-                    };
+                    HandleWebException(wex);
+                    throw;
                 }
+            }
+
+            private async Task<WebResponse> GetResponseImplAsync(RequestOptions options, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    var request = CreateRequest(options);
+                    return await options.GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                catch (WebException wex)
+                {
+                    if (wex.Response == null)
+                        throw;
+
+                    HandleWebException(wex);
+                    throw;
+                }
+            }
+
+            private void HandleWebException(WebException ex)
+            {
+                using var errorResponse = (HttpWebResponse)ex.Response;
+                string jsonString;
+                using (var reader = new StreamReader(errorResponse.GetResponseStream()))
+                {
+                    jsonString = reader.ReadToEnd();
+                }
+
+                var errorMessage = ExtractErrorMessage(jsonString, out var parsedError);
+                var exceptionMessage =
+                    $"GitLab server returned an error ({errorResponse.StatusCode}): {errorMessage}. " +
+                    $"Original call: {Method} {Url}";
+
+                if (JsonData != null)
+                {
+                    exceptionMessage += $". With data {JsonData}";
+                }
+
+                throw new GitLabException(exceptionMessage)
+                {
+                    OriginalCall = Url,
+                    ErrorObject = parsedError,
+                    StatusCode = errorResponse.StatusCode,
+                    ErrorMessage = errorMessage,
+                    MethodType = Method,
+                };
             }
 
             private HttpWebRequest CreateRequest(RequestOptions options)

--- a/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/Impl/HttpRequestor.cs
@@ -55,9 +55,9 @@ namespace NGitLab.Impl
             Stream(tailAPIUrl, parser: null);
         }
 
-        public virtual async Task ExecuteAsync(string tailAPIUrl, CancellationToken cancellationToken)
+        public virtual Task ExecuteAsync(string tailAPIUrl, CancellationToken cancellationToken)
         {
-            await StreamAsync(tailAPIUrl, parser: null, cancellationToken).ConfigureAwait(false);
+            return StreamAsync(tailAPIUrl, parser: null, cancellationToken);
         }
 
         public virtual T To<T>(string tailAPIUrl)

--- a/NGitLab/Impl/ProjectClient.cs
+++ b/NGitLab/Impl/ProjectClient.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -41,7 +42,7 @@ namespace NGitLab.Impl
             return string.IsNullOrEmpty(query.Search);
         }
 
-        public IEnumerable<Project> Get(ProjectQuery query)
+        private static string CreateGetUrl(ProjectQuery query)
         {
             var url = Project.Url;
 
@@ -95,7 +96,19 @@ namespace NGitLab.Impl
                 url = Utils.AddParameter(url, "min_access_level", (int)query.MinAccessLevel.Value);
             }
 
+            return url;
+        }
+
+        public IEnumerable<Project> Get(ProjectQuery query)
+        {
+            var url = CreateGetUrl(query);
             return _api.Get().GetAll<Project>(url);
+        }
+
+        public GitLabCollectionResponse<Project> GetAsync(ProjectQuery query)
+        {
+            var url = CreateGetUrl(query);
+            return _api.Get().GetAllAsync<Project>(url);
         }
 
         public Project GetById(int id, SingleProjectQuery query)
@@ -104,6 +117,14 @@ namespace NGitLab.Impl
             url = Utils.AddParameter(url, "statistics", query.Statistics);
 
             return _api.Get().To<Project>(url);
+        }
+
+        public async Task<Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default)
+        {
+            var url = Project.Url + "/" + id.ToStringInvariant();
+            url = Utils.AddParameter(url, "statistics", query.Statistics);
+
+            return await _api.Get().ToAsync<Project>(url, cancellationToken).ConfigureAwait(false);
         }
 
         public Project Fork(string id, ForkProject forkProject)

--- a/NGitLab/NGitLab.csproj
+++ b/NGitLab/NGitLab.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Net.Http" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
@@ -13,7 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
-﻿const NGitLab.Impl.GroupsClient.Url = "/groups" -> string
+﻿abstract NGitLab.GitLabCollectionResponse<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<T>
+abstract NGitLab.GitLabCollectionResponse<T>.GetEnumerator() -> System.Collections.Generic.IEnumerator<T>
+const NGitLab.Impl.GroupsClient.Url = "/groups" -> string
 const NGitLab.Impl.LabelClient.GroupLabelUrl = "/groups/{0}/labels" -> string
 const NGitLab.Impl.LabelClient.ProjectLabelUrl = "/projects/{0}/labels" -> string
 const NGitLab.Impl.NamespacesClient.Url = "/namespaces" -> string
@@ -75,6 +77,8 @@ NGitLab.GitLabClient.Snippets.get -> NGitLab.ISnippetClient
 NGitLab.GitLabClient.SystemHooks.get -> NGitLab.ISystemHookClient
 NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
+NGitLab.GitLabCollectionResponse<T>
+NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string
 NGitLab.GitLabException.ErrorMessage.set -> void
@@ -193,9 +197,13 @@ NGitLab.IGroupVariableClient.this[string key].get -> NGitLab.Models.Variable
 NGitLab.IGroupVariableClient.Update(string key, NGitLab.Models.VariableUpdate model) -> NGitLab.Models.Variable
 NGitLab.IHttpRequestor
 NGitLab.IHttpRequestor.Execute(string tailAPIUrl) -> void
+NGitLab.IHttpRequestor.ExecuteAsync(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NGitLab.IHttpRequestor.GetAll<T>(string tailUrl) -> System.Collections.Generic.IEnumerable<T>
+NGitLab.IHttpRequestor.GetAllAsync<T>(string tailUrl) -> NGitLab.GitLabCollectionResponse<T>
 NGitLab.IHttpRequestor.Stream(string tailAPIUrl, System.Action<System.IO.Stream> parser) -> void
+NGitLab.IHttpRequestor.StreamAsync(string tailAPIUrl, System.Func<System.IO.Stream, System.Threading.Tasks.Task> parser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NGitLab.IHttpRequestor.To<T>(string tailAPIUrl) -> T
+NGitLab.IHttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>
 NGitLab.IHttpRequestor.With(object data) -> NGitLab.IHttpRequestor
 NGitLab.IIssueClient
 NGitLab.IIssueClient.ClosedBy(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
@@ -547,7 +555,9 @@ NGitLab.Impl.ProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitL
 NGitLab.Impl.ProjectClient.Delete(int id) -> void
 NGitLab.Impl.ProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.Impl.ProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
+NGitLab.Impl.ProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetForks(string id, NGitLab.Models.ForkedProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetLanguages(string id) -> System.Collections.Generic.Dictionary<string, double>
 NGitLab.Impl.ProjectClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
@@ -703,7 +713,9 @@ NGitLab.IProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitLab.M
 NGitLab.IProjectClient.Delete(int id) -> void
 NGitLab.IProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.IProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.IProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
+NGitLab.IProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetForks(string id, NGitLab.Models.ForkedProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetLanguages(string id) -> System.Collections.Generic.Dictionary<string, double>
 NGitLab.IProjectClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
@@ -2905,8 +2917,13 @@ static NGitLab.Models.QueryAssigneeId.None.get -> NGitLab.Models.QueryAssigneeId
 static NGitLab.RequestOptions.Default.get -> NGitLab.RequestOptions
 virtual NGitLab.Impl.API.CreateRequestor(NGitLab.Impl.MethodType methodType) -> NGitLab.IHttpRequestor
 virtual NGitLab.Impl.HttpRequestor.Execute(string tailAPIUrl) -> void
+virtual NGitLab.Impl.HttpRequestor.ExecuteAsync(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 virtual NGitLab.Impl.HttpRequestor.GetAll<T>(string tailUrl) -> System.Collections.Generic.IEnumerable<T>
+virtual NGitLab.Impl.HttpRequestor.GetAllAsync<T>(string tailUrl) -> NGitLab.GitLabCollectionResponse<T>
 virtual NGitLab.Impl.HttpRequestor.Stream(string tailAPIUrl, System.Action<System.IO.Stream> parser) -> void
+virtual NGitLab.Impl.HttpRequestor.StreamAsync(string tailAPIUrl, System.Func<System.IO.Stream, System.Threading.Tasks.Task> parser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 virtual NGitLab.Impl.HttpRequestor.To<T>(string tailAPIUrl) -> T
+virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
+virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NGitLab
 {
@@ -72,6 +74,19 @@ namespace NGitLab
         public virtual WebResponse GetResponse(HttpWebRequest request)
         {
             return request.GetResponse();
+        }
+
+        public virtual async Task<WebResponse> GetResponseAsync(HttpWebRequest request, CancellationToken cancellationToken)
+        {
+            CancellationTokenRegistration cancellationTokenRegistration = default;
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationTokenRegistration = cancellationToken.Register(() => request.Abort());
+            }
+
+            var result = await request.GetResponseAsync().ConfigureAwait(false);
+            cancellationTokenRegistration.Dispose();
+            return result;
         }
 
         internal virtual Stream GetRequestStream(HttpWebRequest request)


### PR DESCRIPTION
- Add a new dependency: `Microsoft.Bcl.AsyncInterfaces`
- Change the target framework from net45 to net461 as this is the minimum version supported by `Microsoft.Bcl.AsyncInterfaces`
- Add `GitLabCollectionResponse<T>`
- Add a unit test to ensure the new async methods follow best practices

fix #45 