### PR TITLE
Add ability to set IsEmpty property for the Project mock

### DIFF
--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -91,6 +91,8 @@ namespace NGitLab.Mock
 
         public RepositoryAccessLevel RepositoryAccessLevel { get; set; } = RepositoryAccessLevel.Enabled;
 
+        public bool IsEmpty { get; set; }
+
         public PermissionCollection Permissions { get; }
 
         public Repository Repository { get; }
@@ -349,6 +351,7 @@ namespace NGitLab.Mock
                 Id = Id,
                 Name = Name,
                 Description = Description,
+                EmptyRepo = IsEmpty,
                 Path = Path,
                 PathWithNamespace = PathWithNamespace,
                 ForkedFromProject = ForkedFrom?.ToClientProject(),

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -750,6 +750,8 @@ NGitLab.Mock.Project.Id.get -> int
 NGitLab.Mock.Project.Id.set -> void
 NGitLab.Mock.Project.ImportStatus.get -> string
 NGitLab.Mock.Project.ImportStatus.set -> void
+NGitLab.Mock.Project.IsEmpty.get -> bool
+NGitLab.Mock.Project.IsEmpty.set -> void
 NGitLab.Mock.Project.Issues.get -> NGitLab.Mock.IssueCollection
 NGitLab.Mock.Project.IsUserMember(NGitLab.Mock.User user) -> bool
 NGitLab.Mock.Project.IsUserOwner(NGitLab.Mock.User user) -> bool


### PR DESCRIPTION
It adds the ability to set the `EmptyRepo` property of Project through the new property `IsEmpty` of the Mocked Project 