### PR TITLE
Modify misleading parameter description

### DIFF
--- a/NGitLab/IPipelineClient.cs
+++ b/NGitLab/IPipelineClient.cs
@@ -54,7 +54,7 @@ namespace NGitLab
         /// <summary>
         /// Create a new pipeline.
         /// </summary>
-        /// <param name="ref">Reference to commit</param>
+        /// <param name="ref">Branch or tag</param>
         Pipeline Create(string @ref);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NGitLab
         /// Trigger a pipeline and send some info with a custom variable
         /// </summary>
         /// <param name="token">Token of the trigger</param>
-        /// <param name="ref">Reference to commit for the pipeline to start on</param>
+        /// <param name="ref">Branch or tag for the pipeline to start on</param>
         /// <param name="variables">Names and values of the custom variables</param>
         /// <returns></returns>
         Pipeline CreatePipelineWithTrigger(string token, string @ref, Dictionary<string, string> variables);

--- a/NGitLab/IPipelineClient.cs
+++ b/NGitLab/IPipelineClient.cs
@@ -54,7 +54,7 @@ namespace NGitLab
         /// <summary>
         /// Create a new pipeline.
         /// </summary>
-        /// <param name="ref">Branch or tag</param>
+        /// <param name="ref">The branch or tag to run the pipeline on</param>
         Pipeline Create(string @ref);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NGitLab
         /// Trigger a pipeline and send some info with a custom variable
         /// </summary>
         /// <param name="token">Token of the trigger</param>
-        /// <param name="ref">Branch or tag for the pipeline to start on</param>
+        /// <param name="ref">The branch or tag to run the pipeline on</param>
         /// <param name="variables">Names and values of the custom variables</param>
         /// <returns></returns>
         Pipeline CreatePipelineWithTrigger(string token, string @ref, Dictionary<string, string> variables);


### PR DESCRIPTION
Hi 👋

The description of this parameter made me thought it would be a commit ID, but it's not. It expects a branch name, I realised by reading these GitLab doc: https://docs.gitlab.com/ee/ci/triggers/#pass-cicd-variables-in-the-api-call

This is more of a suggestion but, would not it be better making this more explicit in the parameter description?