### PR TITLE
Improve mocks for pipelines

### DIFF
--- a/NGitLab.Mock.Tests/PipelineTests.cs
+++ b/NGitLab.Mock.Tests/PipelineTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using NGitLab.Mock.Config;
+using NUnit.Framework;
+
+namespace NGitLab.Mock.Tests
+{
+    public class PipelineTests
+    {
+        [Test]
+        public async Task Test_pipelines()
+        {
+            using var server = new GitLabServer();
+            var user = server.Users.AddNew();
+            var project = user.Namespace.Projects.AddNew(project => project.Visibility = Models.VisibilityLevel.Internal);
+            var commit = project.Repository.Commit(user, "test");
+
+            var pipeline = project.Pipelines.Add(commit.Sha, JobStatus.Success, user);
+            var job = pipeline.AddNewJob("Test_job", JobStatus.Success);
+            job.Trace = "This is a trace\nWith Multiple line";
+
+            var client = server.CreateClient();
+            Assert.AreEqual(job.Trace, await client.GetJobs(project.Id).GetTraceAsync(job.Id));
+        }
+    }
+}

--- a/NGitLab.Mock/Job.cs
+++ b/NGitLab.Mock/Job.cs
@@ -32,9 +32,9 @@ namespace NGitLab.Mock
 
         public Models.Job.JobRunner Runner { get; set; }
 
-        public Models.Job.JobPipeline Pipeline { get; set; }
+        public Pipeline Pipeline { get; set; }
 
-        public Models.Job.JobProject Project { get; set; }
+        public Project Project => Pipeline.Parent;
 
         public JobStatus Status { get; set; }
 
@@ -49,6 +49,8 @@ namespace NGitLab.Mock
         public float? Duration { get; set; }
 
         public float? QueuedDuration { get; set; }
+
+        public string Trace { get; set; }
 
         internal Models.Job ToJobClient()
         {
@@ -65,12 +67,23 @@ namespace NGitLab.Mock
                 Coverage = Coverage,
                 Artifacts = Artifacts,
                 Runner = Runner,
-                Pipeline = Pipeline,
-                Project = Project,
+                Pipeline = new Models.Job.JobPipeline
+                {
+                    Id = Pipeline.Id,
+                    Ref = Pipeline.Ref,
+                    Sha = Pipeline.Sha,
+                    Status = Pipeline.Status,
+                },
+                Project = new Models.Job.JobProject
+                {
+                    Id = Project.Id,
+                    Name = Project.Name,
+                    PathWithNamespace = Project.PathWithNamespace,
+                },
                 Status = Status,
                 AllowFailure = AllowFailure,
                 Tag = Tag,
-                User = User.ToClientUser(),
+                User = User?.ToClientUser(),
                 WebUrl = WebUrl,
                 Duration = Duration,
                 QueuedDuration = QueuedDuration,
@@ -93,7 +106,6 @@ namespace NGitLab.Mock
                 Artifacts = Artifacts,
                 Runner = Runner,
                 Pipeline = Pipeline,
-                Project = Project,
                 Status = Status,
                 Tag = Tag,
                 User = User,

--- a/NGitLab.Mock/JobCollection.cs
+++ b/NGitLab.Mock/JobCollection.cs
@@ -31,7 +31,7 @@ namespace NGitLab.Mock
         public Job Add(Job job, Pipeline pipeline)
         {
             Add(job);
-            job.Pipeline = pipeline.ToJobPipeline();
+            job.Pipeline = pipeline;
             return job;
         }
 
@@ -46,8 +46,9 @@ namespace NGitLab.Mock
         {
             var job = new Job
             {
-                Pipeline = pipeline.ToJobPipeline(),
+                Pipeline = pipeline,
             };
+
             Add(job);
             return job;
         }

--- a/NGitLab.Mock/Pipeline.cs
+++ b/NGitLab.Mock/Pipeline.cs
@@ -47,14 +47,32 @@ namespace NGitLab.Mock
 
         public TestReport TestReports { get; set; }
 
+        [Obsolete("Use other overloads")]
         public Job AddNewJob(Project project)
         {
             return AddJob(project, new Job());
         }
 
+        public Job AddNewJob(string name, JobStatus status, User user = null)
+        {
+            return AddJob(new Job
+            {
+                Name = name,
+                Pipeline = this,
+                Status = status,
+                User = user ?? User,
+            });
+        }
+
+        [Obsolete("Use other overloads")]
         public Job AddJob(Project project, Job job)
         {
             return project.Jobs.Add(job, this);
+        }
+
+        public Job AddJob(Job job)
+        {
+            return Parent.Jobs.Add(job, this);
         }
 
         internal Models.Job.JobPipeline ToJobPipeline()

--- a/NGitLab.Mock/PipelineCollection.cs
+++ b/NGitLab.Mock/PipelineCollection.cs
@@ -34,6 +34,8 @@ namespace NGitLab.Mock
             {
                 Status = status,
                 User = user,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
             };
 
             Add(pipeline);

--- a/NGitLab.Mock/ProjectCollection.cs
+++ b/NGitLab.Mock/ProjectCollection.cs
@@ -11,7 +11,13 @@ namespace NGitLab.Mock
 
         public Project AddNew()
         {
+            return AddNew(null);
+        }
+
+        public Project AddNew(Action<Project> configure)
+        {
             var project = new Project();
+            configure?.Invoke(project);
             Add(project);
             return project;
         }

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -496,10 +496,9 @@ NGitLab.Mock.Job.Id.set -> void
 NGitLab.Mock.Job.Job() -> void
 NGitLab.Mock.Job.Name.get -> string
 NGitLab.Mock.Job.Name.set -> void
-NGitLab.Mock.Job.Pipeline.get -> NGitLab.Models.Job.JobPipeline
+NGitLab.Mock.Job.Pipeline.get -> NGitLab.Mock.Pipeline
 NGitLab.Mock.Job.Pipeline.set -> void
-NGitLab.Mock.Job.Project.get -> NGitLab.Models.Job.JobProject
-NGitLab.Mock.Job.Project.set -> void
+NGitLab.Mock.Job.Project.get -> NGitLab.Mock.Project
 NGitLab.Mock.Job.QueuedDuration.get -> float?
 NGitLab.Mock.Job.QueuedDuration.set -> void
 NGitLab.Mock.Job.Ref.get -> string
@@ -514,6 +513,8 @@ NGitLab.Mock.Job.Status.get -> NGitLab.JobStatus
 NGitLab.Mock.Job.Status.set -> void
 NGitLab.Mock.Job.Tag.get -> bool
 NGitLab.Mock.Job.Tag.set -> void
+NGitLab.Mock.Job.Trace.get -> string
+NGitLab.Mock.Job.Trace.set -> void
 NGitLab.Mock.Job.User.get -> NGitLab.Mock.User
 NGitLab.Mock.Job.User.set -> void
 NGitLab.Mock.Job.WebUrl.get -> string
@@ -676,8 +677,10 @@ NGitLab.Mock.Permission.User.get -> NGitLab.Mock.User
 NGitLab.Mock.PermissionCollection
 NGitLab.Mock.PermissionCollection.PermissionCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.Pipeline
+NGitLab.Mock.Pipeline.AddJob(NGitLab.Mock.Job job) -> NGitLab.Mock.Job
 NGitLab.Mock.Pipeline.AddJob(NGitLab.Mock.Project project, NGitLab.Mock.Job job) -> NGitLab.Mock.Job
 NGitLab.Mock.Pipeline.AddNewJob(NGitLab.Mock.Project project) -> NGitLab.Mock.Job
+NGitLab.Mock.Pipeline.AddNewJob(string name, NGitLab.JobStatus status, NGitLab.Mock.User user = null) -> NGitLab.Mock.Job
 NGitLab.Mock.Pipeline.BeforeSha.get -> NGitLab.Sha1
 NGitLab.Mock.Pipeline.BeforeSha.set -> void
 NGitLab.Mock.Pipeline.CommittedAt.get -> System.DateTimeOffset
@@ -803,6 +806,7 @@ NGitLab.Mock.Project.Visibility.set -> void
 NGitLab.Mock.Project.WebUrl.get -> string
 NGitLab.Mock.ProjectCollection
 NGitLab.Mock.ProjectCollection.AddNew() -> NGitLab.Mock.Project
+NGitLab.Mock.ProjectCollection.AddNew(System.Action<NGitLab.Mock.Project> configure) -> NGitLab.Mock.Project
 NGitLab.Mock.ProjectCollection.ProjectCollection(NGitLab.Mock.Group group) -> void
 NGitLab.Mock.ProjectExtensions
 NGitLab.Mock.ProjectHook


### PR DESCRIPTION
There is a breaking change!

- NGitLab.Mock.Job.Project => irrelevant as it is a duplicate of the Parent property
- NGitLab.Mock.Job.Pipeline => We should use the right type instead of using a _client_ type