### PR TITLE
Add support to retrieve last activity date for all users

### DIFF
--- a/NGitLab.Mock/Clients/UserClient.cs
+++ b/NGitLab.Mock/Clients/UserClient.cs
@@ -162,5 +162,10 @@ namespace NGitLab.Mock.Clients
             await Task.Yield();
             return Current;
         }
+
+        public IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/NGitLab.Mock/Clients/UserClient.cs
+++ b/NGitLab.Mock/Clients/UserClient.cs
@@ -163,7 +163,7 @@ namespace NGitLab.Mock.Clients
             return Current;
         }
 
-        public IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null)
+        public GitLabCollectionResponse<LastActivityDate> GetLastActivityDatesAsync(DateTimeOffset? from = null)
         {
             throw new NotImplementedException();
         }

--- a/NGitLab.Tests/UsersTests.cs
+++ b/NGitLab.Tests/UsersTests.cs
@@ -128,7 +128,7 @@ namespace NGitLab.Tests
         public async Task GetLastActivityDates()
         {
             using var context = await GitLabTestContext.CreateAsync();
-            var activities = context.AdminClient.Users.GetLastActivityDates().ToArray();
+            var activities = context.AdminClient.Users.GetLastActivityDatesAsync().ToArray();
             CollectionAssert.IsNotEmpty(activities.Where(a => string.Equals(a.Username, context.AdminClient.Users.Current.Username, StringComparison.Ordinal)));
         }
 
@@ -138,7 +138,7 @@ namespace NGitLab.Tests
         {
             using var context = await GitLabTestContext.CreateAsync();
             var yesterday = DateTimeOffset.UtcNow.AddDays(-1);
-            var activities = context.AdminClient.Users.GetLastActivityDates(from: yesterday).ToArray();
+            var activities = context.AdminClient.Users.GetLastActivityDatesAsync(from: yesterday).ToArray();
             CollectionAssert.IsNotEmpty(activities);
         }
 
@@ -148,7 +148,7 @@ namespace NGitLab.Tests
         {
             using var context = await GitLabTestContext.CreateAsync();
             var tomorrow = DateTimeOffset.UtcNow.AddDays(1);
-            var activities = context.AdminClient.Users.GetLastActivityDates(from: tomorrow).ToArray();
+            var activities = context.AdminClient.Users.GetLastActivityDatesAsync(from: tomorrow).ToArray();
             CollectionAssert.IsEmpty(activities);
         }
 
@@ -156,7 +156,7 @@ namespace NGitLab.Tests
         public async Task GetLastActivityDates_UsingNonAdminCredentials_ThrowsForbidden()
         {
             using var context = await GitLabTestContext.CreateAsync();
-            var exception = Assert.Throws<GitLabException>(() => context.Client.Users.GetLastActivityDates().ToArray());
+            var exception = Assert.Throws<GitLabException>(() => context.Client.Users.GetLastActivityDatesAsync().ToArray());
             Assert.AreEqual(HttpStatusCode.Forbidden, exception.StatusCode);
         }
 

--- a/NGitLab.Tests/UsersTests.cs
+++ b/NGitLab.Tests/UsersTests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -120,6 +121,43 @@ namespace NGitLab.Tests
 
             Assert.IsNotEmpty(tokenResult.Token);
             Assert.AreEqual(tokenRequest.Name, tokenResult.Name);
+        }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task GetLastActivityDates()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var activities = context.AdminClient.Users.GetLastActivityDates().ToArray();
+            CollectionAssert.IsNotEmpty(activities.Where(a => string.Equals(a.Username, context.AdminClient.Users.Current.Username, StringComparison.Ordinal)));
+        }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task GetLastActivityDatesSinceYesterday()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var yesterday = DateTimeOffset.UtcNow.AddDays(-1);
+            var activities = context.AdminClient.Users.GetLastActivityDates(from: yesterday).ToArray();
+            CollectionAssert.IsNotEmpty(activities);
+        }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task GetLastActivityDatesFromTheFuture()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var tomorrow = DateTimeOffset.UtcNow.AddDays(1);
+            var activities = context.AdminClient.Users.GetLastActivityDates(from: tomorrow).ToArray();
+            CollectionAssert.IsEmpty(activities);
+        }
+
+        [Test]
+        public async Task GetLastActivityDates_UsingNonAdminCredentials_ThrowsForbidden()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var exception = Assert.Throws<GitLabException>(() => context.Client.Users.GetLastActivityDates().ToArray());
+            Assert.AreEqual(HttpStatusCode.Forbidden, exception.StatusCode);
         }
 
         private static User CreateNewUser(GitLabTestContext context)

--- a/NGitLab/IUserClient.cs
+++ b/NGitLab/IUserClient.cs
@@ -61,6 +61,7 @@ namespace NGitLab
 
         /// <summary>
         /// Gets the last activity date for all users, sorted from oldest to newest
+        /// (<seealso href="https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only">GitLab documentation</seealso>).
         /// </summary>
         /// <param name="from">Date from which activities will be considered. If unspecified, will look back over the last 6 months.</param>
         /// <remarks>
@@ -73,6 +74,6 @@ namespace NGitLab
         /// <item><description>User using the GraphQL API</description></item>
         /// </list>
         /// </remarks>
-        IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null);
+        GitLabCollectionResponse<LastActivityDate> GetLastActivityDatesAsync(DateTimeOffset? from = null);
     }
 }

--- a/NGitLab/IUserClient.cs
+++ b/NGitLab/IUserClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -57,5 +58,21 @@ namespace NGitLab
         /// Get a list of users that match the query.
         /// </summary>
         IEnumerable<User> Get(UserQuery query);
+
+        /// <summary>
+        /// Gets the last activity date for all users, sorted from oldest to newest
+        /// </summary>
+        /// <param name="from">Date from which activities will be considered. If unspecified, will look back over the last 6 months.</param>
+        /// <remarks>
+        /// The activities that update the timestamp are:
+        /// <list type="bullet">
+        /// <item><description>Git HTTP/SSH activities (such as clone, push)</description></item>
+        /// <item><description>User logging in to GitLab</description></item>
+        /// <item><description>User visiting pages related to dashboards, projects, issues, and merge requests (introduced in GitLab 11.8)</description></item>
+        /// <item><description>User using the API</description></item>
+        /// <item><description>User using the GraphQL API</description></item>
+        /// </list>
+        /// </remarks>
+        IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null);
     }
 }

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -86,12 +86,12 @@ namespace NGitLab.Impl
             _api.Post().Execute($"{User.Url}/{userId.ToStringInvariant()}/deactivate");
         }
 
-        public IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null)
+        public GitLabCollectionResponse<LastActivityDate> GetLastActivityDatesAsync(DateTimeOffset? from = null)
         {
             var url = "/user/activities";
             if (from is not null)
                 url = Utils.AddParameter(url, "from", from.Value.ToString("yyyy-MM-dd"));
-            return _api.Get().GetAll<LastActivityDate>(url);
+            return _api.Get().GetAllAsync<LastActivityDate>(url);
         }
     }
 }

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Extensions;
@@ -83,6 +84,14 @@ namespace NGitLab.Impl
         public void Deactivate(int userId)
         {
             _api.Post().Execute($"{User.Url}/{userId.ToStringInvariant()}/deactivate");
+        }
+
+        public IEnumerable<LastActivityDate> GetLastActivityDates(DateTimeOffset? from = null)
+        {
+            var url = "/user/activities";
+            if (from is not null)
+                url = Utils.AddParameter(url, "from", from.Value.ToString("yyyy-MM-dd"));
+            return _api.Get().GetAll<LastActivityDate>(url);
         }
     }
 }

--- a/NGitLab/Models/LastActivityDate.cs
+++ b/NGitLab/Models/LastActivityDate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace NGitLab.Models
+{
+    public class LastActivityDate
+    {
+        [JsonPropertyName("username")]
+        public string Username { get; set; }
+
+        [JsonPropertyName("last_activity_on")]
+        public DateTimeOffset LastActivityOn { get; set; }
+    }
+}

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -712,6 +712,7 @@ NGitLab.Impl.UserClient.Get(NGitLab.UserQuery query) -> System.Collections.Gener
 NGitLab.Impl.UserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
+NGitLab.Impl.UserClient.GetLastActivityDates(System.DateTimeOffset? from = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.LastActivityDate>
 NGitLab.Impl.UserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
 NGitLab.Impl.UserClient.this[int id].get -> NGitLab.Models.User
@@ -899,6 +900,7 @@ NGitLab.IUserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.I
 NGitLab.IUserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
+NGitLab.IUserClient.GetLastActivityDates(System.DateTimeOffset? from = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.LastActivityDate>
 NGitLab.IUserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
 NGitLab.IUserClient.this[int id].get -> NGitLab.Models.User
@@ -1742,6 +1744,12 @@ NGitLab.Models.LabelEdit.LabelEdit() -> void
 NGitLab.Models.LabelEdit.LabelEdit(int projectId, NGitLab.Models.Label label) -> void
 NGitLab.Models.LabelEdit.Name -> string
 NGitLab.Models.LabelEdit.NewName -> string
+NGitLab.Models.LastActivityDate
+NGitLab.Models.LastActivityDate.LastActivityDate() -> void
+NGitLab.Models.LastActivityDate.LastActivityOn.get -> System.DateTimeOffset
+NGitLab.Models.LastActivityDate.LastActivityOn.set -> void
+NGitLab.Models.LastActivityDate.Username.get -> string
+NGitLab.Models.LastActivityDate.Username.set -> void
 NGitLab.Models.Membership
 NGitLab.Models.Membership.AccessLevel -> int
 NGitLab.Models.Membership.AvatarURL -> string

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -712,7 +712,7 @@ NGitLab.Impl.UserClient.Get(NGitLab.UserQuery query) -> System.Collections.Gener
 NGitLab.Impl.UserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
-NGitLab.Impl.UserClient.GetLastActivityDates(System.DateTimeOffset? from = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.LastActivityDate>
+NGitLab.Impl.UserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.Impl.UserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
 NGitLab.Impl.UserClient.this[int id].get -> NGitLab.Models.User
@@ -900,7 +900,7 @@ NGitLab.IUserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.I
 NGitLab.IUserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
-NGitLab.IUserClient.GetLastActivityDates(System.DateTimeOffset? from = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.LastActivityDate>
+NGitLab.IUserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.IUserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
 NGitLab.IUserClient.this[int id].get -> NGitLab.Models.User


### PR DESCRIPTION
Add support for [`/user/activities`](https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only)