### PR TITLE
Add implementation of get single issue

### DIFF
--- a/NGitLab.Mock.Tests/IssuesMockTests.cs
+++ b/NGitLab.Mock.Tests/IssuesMockTests.cs
@@ -55,5 +55,21 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             Assert.DoesNotThrow(() => client.Issues.Get(new IssueQuery { Scope = "assigned_to_me" }).ToArray());
         }
+
+        [Test]
+        public void Test_issue_by_id_can_be_found()
+        {
+            using var server = new GitLabConfig()
+                .WithUser("user", isDefault: true, isAdmin: true)
+                .WithProject("Test", configure: project => project
+                    .WithIssue("Issue title", author: "user", id: 5))
+                .BuildServer();
+
+            var client = server.CreateClient();
+
+            var issue = client.Issues.GetById(10001);
+            Assert.AreEqual(5, issue.IssueId);
+            Assert.AreEqual("Issue title", issue.Title);
+        }
     }
 }

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -206,6 +206,16 @@ namespace NGitLab.Mock.Clients
             return GitLabCollectionResponse.Create(Get(projectId, query));
         }
 
+        public Task<Models.Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Models.Issue GetById(int issueId)
+        {
+            throw new NotImplementedException();
+        }
+
         private IEnumerable<Issue> FilterByQuery(IEnumerable<Issue> issues, IssueQuery query)
         {
             if (query.State != null)

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -206,14 +206,22 @@ namespace NGitLab.Mock.Clients
             return GitLabCollectionResponse.Create(Get(projectId, query));
         }
 
-        public Task<Models.Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
+        public async Task<Models.Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            await Task.Yield();
+            return GetById(issueId);
         }
 
         public Models.Issue GetById(int issueId)
         {
-            throw new NotImplementedException();
+            using (Context.BeginOperationScope())
+            {
+                var viewableProjects = Server.AllProjects.Where(p => p.CanUserViewProject(Context.User));
+                return viewableProjects
+                    .SelectMany(p => p.Issues.Where(i => i.CanUserViewIssue(Context.User) && i.Id == issueId))
+                    .FirstOrDefault()?
+                    .ToClientIssue() ?? throw new GitLabNotFoundException();
+            }
         }
 
         private IEnumerable<Issue> FilterByQuery(IEnumerable<Issue> issues, IssueQuery query)

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -28,6 +28,23 @@ namespace NGitLab.Tests
 
         [Test]
         [NGitLabRetry]
+        public async Task Test_get_issue_by_id()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            var issuesClient = context.Client.Issues;
+            var adminIssuesClient = context.AdminClient.Issues;
+
+            var issue1 = issuesClient.Create(new IssueCreate { Id = project.Id, Title = "title1" });
+
+            var issue = adminIssuesClient.GetById(issue1.Id);
+
+            Assert.AreEqual(issue1.Id, issue.Id);
+            Assert.AreEqual(issue1.IssueId, issue.IssueId);
+        }
+
+        [Test]
+        [NGitLabRetry]
         public async Task Test_get_unassigned_issues_with_IssueQuery()
         {
             using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -56,6 +56,16 @@ namespace NGitLab
         GitLabCollectionResponse<Issue> GetAsync(int projectId, IssueQuery query);
 
         /// <summary>
+        ///     <para>Return a single issue, only for administrators.</para>
+        ///     <para>url like GET /issues/:id</para>
+        /// </summary>
+        /// <param name="issueId"></param>
+        /// <returns>The issue that corresponds to the issue id</returns>
+        Issue GetById(int issueId);
+
+        Task<Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Add an issue witht he proposed title to the GitLab list for the selected proejct id.
         /// </summary>
         /// <param name="issueCreate"></param>

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -24,11 +24,11 @@ namespace NGitLab
         ///     <para>url like GET /projects/:id/issues/:issue_id</para>
         /// </summary>
         /// <param name="projectId"></param>
-        /// <param name="issueId"></param>
+        /// <param name="issueIid"></param>
         /// <returns>The issue that corresponds to the project id and issue id</returns>
-        Issue Get(int projectId, int issueId);
+        Issue Get(int projectId, int issueIid);
 
-        Task<Issue> GetAsync(int projectId, int issueId, CancellationToken cancellationToken = default);
+        Task<Issue> GetAsync(int projectId, int issueIid, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return issues for a given query.

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -36,14 +36,14 @@ namespace NGitLab.Impl
             return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId));
         }
 
-        public Issue Get(int projectId, int issueId)
+        public Issue Get(int projectId, int issueIid)
         {
-            return _api.Get().To<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueId));
+            return _api.Get().To<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueIid));
         }
 
-        public Task<Issue> GetAsync(int projectId, int issueId, CancellationToken cancellationToken = default)
+        public Task<Issue> GetAsync(int projectId, int issueIid, CancellationToken cancellationToken = default)
         {
-            return _api.Get().ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueId), cancellationToken);
+            return _api.Get().ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueIid), cancellationToken);
         }
 
         public IEnumerable<Issue> Get(int projectId, IssueQuery query)

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -9,6 +9,7 @@ namespace NGitLab.Impl
     public class IssueClient : IIssueClient
     {
         private const string IssuesUrl = "/issues";
+        private const string IssueByIdUrl = "/issues/{0}";
         private const string ProjectIssuesUrl = "/projects/{0}/issues";
         private const string SingleIssueUrl = "/projects/{0}/issues/{1}";
         private const string ResourceLabelEventUrl = "/projects/{0}/issues/{1}/resource_label_events";
@@ -63,6 +64,16 @@ namespace NGitLab.Impl
         public GitLabCollectionResponse<Issue> GetAsync(IssueQuery query)
         {
             return Get(IssuesUrl, query);
+        }
+
+        public Issue GetById(int issueId)
+        {
+            return _api.Get().To<Issue>(string.Format(CultureInfo.InvariantCulture, IssueByIdUrl, issueId));
+        }
+
+        public Task<Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
+        {
+            return _api.Get().ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, IssueByIdUrl, issueId), cancellationToken);
         }
 
         public Issue Create(IssueCreate issueCreate)

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -228,10 +228,10 @@ NGitLab.IIssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Models.
 NGitLab.IIssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.IIssueClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.ForProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.IIssueClient.Get(int projectId, int issueId) -> NGitLab.Models.Issue
+NGitLab.IIssueClient.Get(int projectId, int issueIid) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.Get(int projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.IIssueClient.GetAsync(int projectId, int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetById(int issueId) -> NGitLab.Models.Issue
@@ -447,10 +447,10 @@ NGitLab.Impl.IssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Mod
 NGitLab.Impl.IssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.ForProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.Get(int projectId, int issueId) -> NGitLab.Models.Issue
+NGitLab.Impl.IssueClient.Get(int projectId, int issueIid) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.Get(int projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.GetAsync(int projectId, int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.GetAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetById(int issueId) -> NGitLab.Models.Issue

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -234,6 +234,8 @@ NGitLab.IIssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.
 NGitLab.IIssueClient.GetAsync(int projectId, int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetById(int issueId) -> NGitLab.Models.Issue
+NGitLab.IIssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IIssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
@@ -451,6 +453,8 @@ NGitLab.Impl.IssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collecti
 NGitLab.Impl.IssueClient.GetAsync(int projectId, int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.GetById(int issueId) -> NGitLab.Models.Issue
+NGitLab.Impl.IssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.IssueClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.IssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>


### PR DESCRIPTION
This is an implementation of [Get Single Issue](https://docs.gitlab.com/ee/api/issues.html#single-issue) allowing admin access tokens to retrieve any issue by its unique ID. Happy to update anything as required, I was also unsure on the best approach to add tests for the new methods so have omitted them pending guidance if you'd like them adding.