### PR TITLE
Add AccessibleMergeRequests to Project

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -234,6 +234,15 @@ namespace NGitLab.Mock.Clients
                 }
 
                 var project = GetProject(_projectId.GetValueOrDefault(), ProjectPermission.View);
+
+                if (!project.AccessibleMergeRequests)
+                {
+                    throw new GitLabException("403 Forbidden")
+                    {
+                        StatusCode = HttpStatusCode.Forbidden,
+                    };
+                }
+
                 return project.MergeRequests.Where(mr => mr.State == state).Select(mr => mr.ToMergeRequestClient()).ToList();
             }
         }

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -87,6 +87,8 @@ namespace NGitLab.Mock
 
         public bool OnlyMirrorProtectedBranch { get; set; }
 
+        public bool AccessibleMergeRequests { get; set; } = true;
+
         public bool MirrorOverwritesDivergedBranches { get; set; }
 
         public RepositoryAccessLevel RepositoryAccessLevel { get; set; } = RepositoryAccessLevel.Enabled;

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -727,6 +727,8 @@ NGitLab.Mock.PipelineCollection.Add(string ref, NGitLab.JobStatus status, NGitLa
 NGitLab.Mock.PipelineCollection.GetById(int id) -> NGitLab.Mock.Pipeline
 NGitLab.Mock.PipelineCollection.PipelineCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.Project
+NGitLab.Mock.Project.AccessibleMergeRequests.get -> bool
+NGitLab.Mock.Project.AccessibleMergeRequests.set -> void
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, int id) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.ApprovalsBeforeMerge.get -> int


### PR DESCRIPTION
Add AccessibleMergeRequests to Project to be able to simulate a project that is accessible but not their MRs