### PR TITLE
Add issue due date to create and edit models

### DIFF
--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -235,15 +235,13 @@ namespace NGitLab.Tests
             using var context = await GitLabTestContext.CreateAsync();
             var project = context.CreateProject();
             var issuesClient = context.Client.Issues;
-            const string formatString = "yyyy-MM-dd";
 
-            var initialDueDate = DateTime.Now.AddDays(3).ToString(formatString);
+            var initialDueDate = new DateTime(2022, 1, 1);
             var issue1 = issuesClient.Create(new IssueCreate { Id = project.Id, Title = "title1", DueDate = initialDueDate });
             var issue = issuesClient.Get(project.Id, issue1.IssueId);
-            Assert.IsNotNull(issue.DueDate);
-            Assert.AreEqual(initialDueDate, issue.DueDate?.ToString(formatString));
+            Assert.AreEqual(initialDueDate, issue1.DueDate);
 
-            var updatedDueDate = DateTime.Now.AddDays(5).ToString(formatString);
+            var updatedDueDate = new DateTime(2022, 2, 1);
             var updatedIssue = issuesClient.Edit(new IssueEdit()
             {
                 Id = project.Id,
@@ -251,8 +249,7 @@ namespace NGitLab.Tests
                 DueDate = updatedDueDate,
             });
 
-            Assert.IsNotNull(updatedIssue.DueDate);
-            Assert.AreEqual(updatedDueDate, updatedIssue.DueDate?.ToString(formatString));
+            Assert.AreEqual(updatedDueDate, updatedIssue.DueDate);
         }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
@@ -225,6 +226,33 @@ namespace NGitLab.Tests
             var removeLabelEvent = resourceLabelEvents.First(e => e.Action == ResourceLabelEventAction.Remove);
             Assert.AreEqual(testLabel, removeLabelEvent.Label.Name);
             Assert.AreEqual(ResourceLabelEventAction.Remove, removeLabelEvent.Action);
+        }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task Test_get_new_and_updated_issue_with_duedate()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            var issuesClient = context.Client.Issues;
+            const string formatString = "yyyy-MM-dd";
+
+            var initialDueDate = DateTime.Now.AddDays(3).ToString(formatString);
+            var issue1 = issuesClient.Create(new IssueCreate { Id = project.Id, Title = "title1", DueDate = initialDueDate });
+            var issue = issuesClient.Get(project.Id, issue1.IssueId);
+            Assert.IsNotNull(issue.DueDate);
+            Assert.AreEqual(initialDueDate, issue.DueDate?.ToString(formatString));
+
+            var updatedDueDate = DateTime.Now.AddDays(5).ToString(formatString);
+            var updatedIssue = issuesClient.Edit(new IssueEdit()
+            {
+                Id = project.Id,
+                IssueId = issue.IssueId,
+                DueDate = updatedDueDate,
+            });
+
+            Assert.IsNotNull(updatedIssue.DueDate);
+            Assert.AreEqual(updatedDueDate, updatedIssue.DueDate?.ToString(formatString));
         }
     }
 }

--- a/NGitLab/Impl/Json/DateTimeConverter.cs
+++ b/NGitLab/Impl/Json/DateTimeConverter.cs
@@ -39,6 +39,23 @@ namespace NGitLab.Impl.Json
         }
     }
 
+    internal sealed class DateOnlyConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                return DateTime.MinValue;
+
+            var str = reader.GetString();
+            return str.TryParseAsDateOnly(out DateTime dateOnly) ? dateOnly : str.ParseIso8601DateTime();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToDateOnlyString());
+        }
+    }
+
     internal static class DateTimeFormatter
     {
         private const string DateOnlyFormat = "yyyy-MM-dd";
@@ -96,6 +113,11 @@ namespace NGitLab.Impl.Json
                 Iso8601Format,
                 CultureInfo.InvariantCulture);
             return str;
+        }
+
+        public static string ToDateOnlyString(this DateTime value)
+        {
+            return value.ToString(DateOnlyFormat, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/NGitLab/Models/IssueCreate.cs
+++ b/NGitLab/Models/IssueCreate.cs
@@ -27,5 +27,8 @@ namespace NGitLab.Models
 
         [JsonPropertyName("confidential")]
         public bool Confidential;
+
+        [JsonPropertyName("due_date")]
+        public string DueDate;
     }
 }

--- a/NGitLab/Models/IssueCreate.cs
+++ b/NGitLab/Models/IssueCreate.cs
@@ -1,5 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using NGitLab.Impl.Json;
 
 namespace NGitLab.Models
 {
@@ -29,6 +31,7 @@ namespace NGitLab.Models
         public bool Confidential;
 
         [JsonPropertyName("due_date")]
-        public string DueDate;
+        [JsonConverter(typeof(DateOnlyConverter))]
+        public DateTime? DueDate;
     }
 }

--- a/NGitLab/Models/IssueEdit.cs
+++ b/NGitLab/Models/IssueEdit.cs
@@ -1,5 +1,7 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using NGitLab.Impl.Json;
 
 namespace NGitLab.Models
 {
@@ -32,6 +34,7 @@ namespace NGitLab.Models
         public string State;
 
         [JsonPropertyName("due_date")]
-        public string DueDate;
+        [JsonConverter(typeof(DateOnlyConverter))]
+        public DateTime? DueDate;
     }
 }

--- a/NGitLab/Models/IssueEdit.cs
+++ b/NGitLab/Models/IssueEdit.cs
@@ -30,5 +30,8 @@ namespace NGitLab.Models
 
         [JsonPropertyName("state_event")]
         public string State;
+
+        [JsonPropertyName("due_date")]
+        public string DueDate;
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1609,7 +1609,7 @@ NGitLab.Models.IssueCreate
 NGitLab.Models.IssueCreate.AssigneeId -> int?
 NGitLab.Models.IssueCreate.Confidential -> bool
 NGitLab.Models.IssueCreate.Description -> string
-NGitLab.Models.IssueCreate.DueDate -> string
+NGitLab.Models.IssueCreate.DueDate -> System.DateTime?
 NGitLab.Models.IssueCreate.Id -> int
 NGitLab.Models.IssueCreate.IssueCreate() -> void
 NGitLab.Models.IssueCreate.Labels -> string
@@ -1618,7 +1618,7 @@ NGitLab.Models.IssueCreate.Title -> string
 NGitLab.Models.IssueEdit
 NGitLab.Models.IssueEdit.AssigneeId -> int?
 NGitLab.Models.IssueEdit.Description -> string
-NGitLab.Models.IssueEdit.DueDate -> string
+NGitLab.Models.IssueEdit.DueDate -> System.DateTime?
 NGitLab.Models.IssueEdit.Id -> int
 NGitLab.Models.IssueEdit.IssueEdit() -> void
 NGitLab.Models.IssueEdit.IssueId -> int

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1609,6 +1609,7 @@ NGitLab.Models.IssueCreate
 NGitLab.Models.IssueCreate.AssigneeId -> int?
 NGitLab.Models.IssueCreate.Confidential -> bool
 NGitLab.Models.IssueCreate.Description -> string
+NGitLab.Models.IssueCreate.DueDate -> string
 NGitLab.Models.IssueCreate.Id -> int
 NGitLab.Models.IssueCreate.IssueCreate() -> void
 NGitLab.Models.IssueCreate.Labels -> string
@@ -1617,6 +1618,7 @@ NGitLab.Models.IssueCreate.Title -> string
 NGitLab.Models.IssueEdit
 NGitLab.Models.IssueEdit.AssigneeId -> int?
 NGitLab.Models.IssueEdit.Description -> string
+NGitLab.Models.IssueEdit.DueDate -> string
 NGitLab.Models.IssueEdit.Id -> int
 NGitLab.Models.IssueEdit.IssueEdit() -> void
 NGitLab.Models.IssueEdit.IssueId -> int


### PR DESCRIPTION
This allows `due_date` to be specified at issue creation time or when updating, as well as adding a test for this functionality. Let me know if anything needs tweaking.