### PR TITLE
Add property for moved_to_id

### DIFF
--- a/NGitLab/Models/Issue.cs
+++ b/NGitLab/Models/Issue.cs
@@ -70,5 +70,8 @@ namespace NGitLab.Models
 
         [JsonPropertyName("issue_type")]
         public string IssueType;
+
+        [JsonPropertyName("moved_to_id")]
+        public int? MovedToId;
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1598,6 +1598,7 @@ NGitLab.Models.Issue.Labels -> string[]
 NGitLab.Models.Issue.MergeRequestsCount.get -> int
 NGitLab.Models.Issue.MergeRequestsCount.set -> void
 NGitLab.Models.Issue.Milestone -> NGitLab.Models.Milestone
+NGitLab.Models.Issue.MovedToId -> int?
 NGitLab.Models.Issue.ProjectId -> int
 NGitLab.Models.Issue.State -> string
 NGitLab.Models.Issue.Title -> string


### PR DESCRIPTION
The Issues API returns a `moved_to_id` for Issue GET requests (e.g. [list issues](https://docs.gitlab.com/ee/api/issues.html#list-issues)) which isn't present on the Issue model. This PR will add in a `MovedToId` property which should prove useful for detecting if an issue has been "moved" between projects.

Although there's not much to it, happy to tweak if necessary.