### PR TITLE
fix MergeRequestCommentClient path

### DIFF
--- a/NGitLab/Impl/MergeRequestCommentClient.cs
+++ b/NGitLab/Impl/MergeRequestCommentClient.cs
@@ -14,9 +14,9 @@ namespace NGitLab.Impl
         {
             _api = api;
             _notesPath = "/projects/" + projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/notes";
-            _discussionsPath = projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/discussions";
+            _discussionsPath = "/projects/" + projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/discussions";
         }
-         
+
         public IEnumerable<MergeRequestComment> All => _api.Get().GetAll<MergeRequestComment>(_notesPath);
 
         public IEnumerable<MergeRequestDiscussion> Discussions => _api.Get().GetAll<MergeRequestDiscussion>(_discussionsPath);

--- a/NGitLab/Impl/MergeRequestCommentClient.cs
+++ b/NGitLab/Impl/MergeRequestCommentClient.cs
@@ -13,10 +13,10 @@ namespace NGitLab.Impl
         public MergeRequestCommentClient(API api, string projectPath, int mergeRequestIid)
         {
             _api = api;
-            _notesPath = projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/notes";
+            _notesPath = "/projects/" + projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/notes";
             _discussionsPath = projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/discussions";
         }
-
+         
         public IEnumerable<MergeRequestComment> All => _api.Get().GetAll<MergeRequestComment>(_notesPath);
 
         public IEnumerable<MergeRequestDiscussion> Discussions => _api.Get().GetAll<MergeRequestDiscussion>(_discussionsPath);


### PR DESCRIPTION
Regarding the doc (https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note), the notes path and discussions path are preceded by "/projects/".