### PR TITLE
Add status field in Runner object and mock

### DIFF
--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -944,6 +944,8 @@ NGitLab.Mock.Runner.Parent.get -> NGitLab.Mock.Project
 NGitLab.Mock.Runner.Runner() -> void
 NGitLab.Mock.Runner.RunUntagged.get -> bool
 NGitLab.Mock.Runner.RunUntagged.set -> void
+NGitLab.Mock.Runner.Status.get -> string
+NGitLab.Mock.Runner.Status.set -> void
 NGitLab.Mock.Runner.TagList.get -> string[]
 NGitLab.Mock.Runner.TagList.set -> void
 NGitLab.Mock.Runner.Token.get -> string

--- a/NGitLab.Mock/Runner.cs
+++ b/NGitLab.Mock/Runner.cs
@@ -15,6 +15,8 @@ namespace NGitLab.Mock
 
         public bool Online { get; set; }
 
+        public string Status { get; set; }
+
         public string Description { get; set; }
 
         public bool IsShared { get; set; }
@@ -41,6 +43,7 @@ namespace NGitLab.Mock
                 Name = Name,
                 Active = Active,
                 Online = Online,
+                Status = Status,
                 Description = Description,
                 IsShared = IsShared,
                 Projects = Parent.Server.AllProjects.Where(p => p.EnabledRunners.Any(r => r.Id == Id)).Select(p => p.ToClientProject()).ToArray(),

--- a/NGitLab/Models/Runner.cs
+++ b/NGitLab/Models/Runner.cs
@@ -21,6 +21,9 @@ namespace NGitLab.Models
         [JsonPropertyName("online")]
         public bool Online;
 
+        [JsonPropertyName("status")]
+        public string Status;
+
         [JsonPropertyName("description")]
         public string Description;
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2703,6 +2703,7 @@ NGitLab.Models.Runner.Online -> bool
 NGitLab.Models.Runner.Projects -> NGitLab.Models.Project[]
 NGitLab.Models.Runner.Runner() -> void
 NGitLab.Models.Runner.RunUntagged -> bool
+NGitLab.Models.Runner.Status -> string
 NGitLab.Models.Runner.TagList -> string[]
 NGitLab.Models.Runner.Token -> string
 NGitLab.Models.Runner.Version -> string


### PR DESCRIPTION
I need to use the _status_ field of the runner in order to filter "just created" runners (without a first connection). There is a possibility to use the _contacted_at_ and play with the date, but it's not very clean for what I want to do.

From the gitlab doc : 
_The status of runners to show, one of: online, offline, stale, and never_contacted. active and paused are also possible values which were deprecated in GitLab 14.8 and will be removed in GitLab 16.0_