### PR TITLE
Adjust code so ProjectCreate.Tags and ProjectUpdate.TagList work again

### DIFF
--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -293,13 +293,6 @@ namespace NGitLab.Mock.Clients
                     project.LfsEnabled = projectUpdate.LfsEnabled.Value;
                 }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (projectUpdate.TagList != null)
-                {
-                    project.Topics = projectUpdate.TagList.Where(t => !string.IsNullOrEmpty(t)).Distinct(StringComparer.Ordinal).ToArray();
-                }
-#pragma warning restore CS0618 // Type or member is obsolete
-
                 if (projectUpdate.Topics.Count > 0)
                 {
                     project.Topics = projectUpdate.Topics.Where(t => !string.IsNullOrEmpty(t)).Distinct(StringComparer.Ordinal).ToArray();

--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -293,6 +293,13 @@ namespace NGitLab.Mock.Clients
                     project.LfsEnabled = projectUpdate.LfsEnabled.Value;
                 }
 
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (projectUpdate.TagList != null)
+                {
+                    project.Topics = projectUpdate.TagList.Where(t => !string.IsNullOrEmpty(t)).Distinct(StringComparer.Ordinal).ToArray();
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+
                 if (projectUpdate.Topics.Count > 0)
                 {
                     project.Topics = projectUpdate.Topics.Where(t => !string.IsNullOrEmpty(t)).Distinct(StringComparer.Ordinal).ToArray();

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -63,7 +63,7 @@ namespace NGitLab.Models
         public VisibilityLevel VisibilityLevel;
 
         [JsonPropertyName("tag_list")]
-        [Obsolete("Deprecated by GitLab. Use Topics instead")]
+        [Obsolete("Deprecated by GitLab. Use Topics instead", error: true)]
         public List<string> Tags;
 
         [JsonPropertyName("topics")]

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -63,11 +63,11 @@ namespace NGitLab.Models
         public VisibilityLevel VisibilityLevel;
 
         [JsonPropertyName("tag_list")]
-        [Obsolete("Deprecated by GitLab. Use Topics instead", error: true)]
+        [Obsolete("Deprecated by GitLab. Use Topics instead")]
         public List<string> Tags;
 
         [JsonPropertyName("topics")]
-        public List<string> Topics { get; } = new List<string>();
+        public List<string> Topics { get; set; }
 
         [JsonPropertyName("build_timeout")]
         public int? BuildTimeout;

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -90,7 +90,7 @@ namespace NGitLab.Models
         public int? BuildTimeout;
 
         [JsonPropertyName("tag_list")]
-        [Obsolete("Deprecated by GitLab. Use Topics instead")]
+        [Obsolete("Deprecated by GitLab. Use Topics instead", error: true)]
         public string[] TagList;
 
         [JsonPropertyName("topics")]

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -90,10 +90,10 @@ namespace NGitLab.Models
         public int? BuildTimeout;
 
         [JsonPropertyName("tag_list")]
-        [Obsolete("Deprecated by GitLab. Use Topics instead", error: true)]
+        [Obsolete("Deprecated by GitLab. Use Topics instead")]
         public string[] TagList;
 
         [JsonPropertyName("topics")]
-        public List<string> Topics { get; } = new List<string>();
+        public List<string> Topics { get; set; }
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2401,6 +2401,7 @@ NGitLab.Models.ProjectCreate.SquashOption.get -> NGitLab.Models.SquashOption?
 NGitLab.Models.ProjectCreate.SquashOption.set -> void
 NGitLab.Models.ProjectCreate.Tags -> System.Collections.Generic.List<string>
 NGitLab.Models.ProjectCreate.Topics.get -> System.Collections.Generic.List<string>
+NGitLab.Models.ProjectCreate.Topics.set -> void
 NGitLab.Models.ProjectCreate.VisibilityLevel -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.ProjectCreate.WallEnabled -> bool
 NGitLab.Models.ProjectCreate.WikiAccessLevel -> string
@@ -2551,6 +2552,7 @@ NGitLab.Models.ProjectUpdate.SnippetsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.set -> void
 NGitLab.Models.ProjectUpdate.TagList -> string[]
 NGitLab.Models.ProjectUpdate.Topics.get -> System.Collections.Generic.List<string>
+NGitLab.Models.ProjectUpdate.Topics.set -> void
 NGitLab.Models.ProjectUpdate.Visibility.get -> NGitLab.Models.VisibilityLevel?
 NGitLab.Models.ProjectUpdate.Visibility.set -> void
 NGitLab.Models.ProjectUpdate.WikiAccessLevel.get -> string


### PR DESCRIPTION
Since https://github.com/ubisoft/NGitLab/pull/268 was merged, setting `ProjectCreate.Tags` or `ProjectUpdate.TagList` no longer had any effect, as the `Topics` property *(whose default value was an empty collection)* seemed to override data on the GitLab server side.

Make `Topics` null by default, in which case `Tags` or `TagList` can prevail. 