### PR TITLE
Add AvatarUrl to Assignee

### DIFF
--- a/NGitLab.Mock/UserRef.cs
+++ b/NGitLab.Mock/UserRef.cs
@@ -61,6 +61,7 @@ namespace NGitLab.Mock
                 Email = Email,
                 Name = Name,
                 State = _user.State.ToString(),
+                AvatarURL = _user.AvatarUrl,
             };
         }
     }

--- a/NGitLab/Models/Assignee.cs
+++ b/NGitLab/Models/Assignee.cs
@@ -22,8 +22,8 @@ namespace NGitLab.Models
 
         [JsonPropertyName("created_at")]
         public DateTime CreatedAt;
-        
+
         [JsonPropertyName("avatar_url")]
-        public string? AvatarURL;
+        public string AvatarURL;
     }
 }

--- a/NGitLab/Models/Assignee.cs
+++ b/NGitLab/Models/Assignee.cs
@@ -22,5 +22,8 @@ namespace NGitLab.Models
 
         [JsonPropertyName("created_at")]
         public DateTime CreatedAt;
+        
+        [JsonPropertyName("avatar_url")]
+        public string? AvatarUrl;
     }
 }

--- a/NGitLab/Models/Assignee.cs
+++ b/NGitLab/Models/Assignee.cs
@@ -24,6 +24,6 @@ namespace NGitLab.Models
         public DateTime CreatedAt;
         
         [JsonPropertyName("avatar_url")]
-        public string? AvatarUrl;
+        public string? AvatarURL;
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1044,6 +1044,7 @@ NGitLab.Models.ApprovalRuleUpdate.UserIds.get -> int[]
 NGitLab.Models.ApprovalRuleUpdate.UserIds.set -> void
 NGitLab.Models.Assignee
 NGitLab.Models.Assignee.Assignee() -> void
+NGitLab.Models.Assignee.AvatarURL -> string
 NGitLab.Models.Assignee.CreatedAt -> System.DateTime
 NGitLab.Models.Assignee.Email -> string
 NGitLab.Models.Assignee.Id -> int


### PR DESCRIPTION
This PR adds the missing optional AvatarUrl property to the Assignee class.

<sub>([API reference](https://docs.gitlab.com/ee/api/issues.html#single-issue))</sub>