### PR TITLE
Expose set for Project Topics

### DIFF
--- a/NGitLab/Models/Project.cs
+++ b/NGitLab/Models/Project.cs
@@ -130,8 +130,7 @@ namespace NGitLab.Models
         public string[] TagList;
 
         [JsonPropertyName("topics")]
-        [JsonInclude]
-        public string[] Topics { get; internal init; }
+        public string[] Topics { get; set; }
 
         [JsonPropertyName("star_count")]
         public int StarCount;

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2413,6 +2413,7 @@ NGitLab.Models.Project.StarCount -> int
 NGitLab.Models.Project.Statistics -> NGitLab.Models.ProjectStatistics
 NGitLab.Models.Project.TagList -> string[]
 NGitLab.Models.Project.Topics.get -> string[]
+NGitLab.Models.Project.Topics.set -> void
 NGitLab.Models.Project.VisibilityLevel -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.Project.WallEnabled -> bool
 NGitLab.Models.Project.WebUrl -> string


### PR DESCRIPTION
- Aligned with other object properties we have exposed in the library
- Avoid trouble when serializing/deserializing objects outside NGItlab
- Simplify initialization on some scenario (tests)