### PR TITLE
Include 'diverged_commits_count' when retrieving info about a single MR

### DIFF
--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -234,6 +234,7 @@ namespace NGitLab.Tests
         private static void ListMergeRequest(IMergeRequestClient mergeRequestClient, Models.MergeRequest mergeRequest)
         {
             Assert.IsTrue(mergeRequestClient.All.Any(x => x.Id == mergeRequest.Id), "Test 'All' accessor returns the merge request");
+            Assert.IsFalse(mergeRequestClient.All.Any(x => x.DivergedCommitsCount.HasValue), "Listing multiple MRs will not set their DivergedCommitsCount property");
             Assert.IsTrue(mergeRequestClient.AllInState(MergeRequestState.opened).Any(x => x.Id == mergeRequest.Id), "Can return all open requests");
             Assert.IsFalse(mergeRequestClient.AllInState(MergeRequestState.merged).Any(x => x.Id == mergeRequest.Id), "Can return all closed requests");
         }

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -62,6 +62,7 @@ namespace NGitLab.Impl
             {
                 var url = $"{_projectPath}{MergeRequest.Url}/{iid.ToStringInvariant()}";
                 url = Utils.AddParameter(url, "include_rebase_in_progress", value: true);
+                url = Utils.AddParameter(url, "include_diverged_commits_count", value: true);
 
                 return _api.Get().To<MergeRequest>(url);
             }

--- a/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/Models/MergeRequest.cs
@@ -125,6 +125,9 @@ namespace NGitLab.Models
         [JsonPropertyName("rebase_in_progress")]
         public bool RebaseInProgress;
 
+        [JsonPropertyName("diverged_commits_count")]
+        public int? DivergedCommitsCount { get; set; }
+
         [JsonPropertyName("has_conflicts")]
         public bool HasConflicts { get; set; }
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1935,6 +1935,8 @@ NGitLab.Models.MergeRequest.ClosedBy -> NGitLab.Models.User
 NGitLab.Models.MergeRequest.CreatedAt -> System.DateTime
 NGitLab.Models.MergeRequest.Description -> string
 NGitLab.Models.MergeRequest.DiffRefs -> NGitLab.Models.DiffRefs
+NGitLab.Models.MergeRequest.DivergedCommitsCount.get -> int?
+NGitLab.Models.MergeRequest.DivergedCommitsCount.set -> void
 NGitLab.Models.MergeRequest.Downvotes -> int
 NGitLab.Models.MergeRequest.ForceRemoveSourceBranch -> bool
 NGitLab.Models.MergeRequest.HasConflicts.get -> bool


### PR DESCRIPTION
Plus, adapted exiting tests to validate this.