### PR TITLE
Fix yet again some of the MR mock classes' shortcomings

### DIFF
--- a/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
+++ b/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
@@ -144,10 +144,12 @@ namespace NGitLab.Mock.Tests
             {
                 MergeWhenPipelineSucceeds = mr.HeadPipeline != null,
                 ShouldRemoveSourceBranch = true,
+                Sha = mr.HeadSha,
             });
 
             // Assert
             Assert.IsFalse(modelMr.HasConflicts);
+            Assert.AreEqual(0, modelMr.DivergedCommitsCount);
             Assert.IsNotNull(modelMr.DiffRefs?.BaseSha);
             Assert.AreEqual(modelMr.DiffRefs.BaseSha, modelMr.DiffRefs.StartSha);
             Assert.AreEqual("merged", modelMr.State);
@@ -204,6 +206,7 @@ namespace NGitLab.Mock.Tests
             Assert.IsTrue(exception.Message.Equals("The MR cannot be merged with method 'ff': the source branch must first be rebased", StringComparison.Ordinal));
 
             Assert.IsFalse(mr.HasConflicts);
+            Assert.AreEqual(1, mr.DivergedCommitsCount);
             Assert.AreNotEqual(mr.BaseSha, mr.StartSha);
 
             Assert.IsTrue(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
@@ -259,6 +262,7 @@ namespace NGitLab.Mock.Tests
             Assert.IsTrue(exception.Message.Equals("The merge request has some conflicts and cannot be merged", StringComparison.Ordinal));
 
             Assert.IsTrue(mr.HasConflicts);
+            Assert.AreEqual(1, mr.DivergedCommitsCount);
             Assert.AreNotEqual(mr.BaseSha, mr.StartSha);
 
             Assert.IsTrue(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -97,7 +97,7 @@ namespace NGitLab.Mock.Clients
 
                 if (message.Sha != null)
                 {
-                    var commit = project.Repository.GetBranchTipCommit(mergeRequest.SourceBranch);
+                    var commit = mergeRequest.SourceBranchHeadCommit;
                     if (!string.Equals(commit.Sha, message.Sha, StringComparison.OrdinalIgnoreCase))
                     {
                         throw new GitLabException("SHA does not match HEAD of source branch")

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -573,6 +573,7 @@ NGitLab.Mock.MergeRequest.CreatedAt.get -> System.DateTimeOffset
 NGitLab.Mock.MergeRequest.CreatedAt.set -> void
 NGitLab.Mock.MergeRequest.Description.get -> string
 NGitLab.Mock.MergeRequest.Description.set -> void
+NGitLab.Mock.MergeRequest.DivergedCommitsCount.get -> int?
 NGitLab.Mock.MergeRequest.ForceRemoveSourceBranch.get -> bool
 NGitLab.Mock.MergeRequest.ForceRemoveSourceBranch.set -> void
 NGitLab.Mock.MergeRequest.GetDiscussions() -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequestDiscussion>

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -652,5 +652,19 @@ namespace NGitLab.Mock
                 _ => throw new NotSupportedException(),
             };
         }
+
+        internal int ComputeDivergence(Commit first, Commit second)
+        {
+            var repository = GetGitRepository();
+            var historyDivergence = repository.ObjectDatabase.CalculateHistoryDivergence(first, second);
+
+            var divergence = 0;
+            if (historyDivergence.AheadBy.HasValue)
+                divergence += historyDivergence.AheadBy.Value;
+            if (historyDivergence.BehindBy.HasValue)
+                divergence += historyDivergence.BehindBy.Value;
+
+            return divergence;
+        }
     }
 }


### PR DESCRIPTION
- Fix the `NGitLab.Mock.Clients.MergeRequestClient.Accept` method, as it could fail if
  - a `message.Sha` was specified, and
  - source and target projects were different
- Implement the `NGitLab.Mock.MergeRequest.DivergedCommitsCount` property logic
- Adjust some of the `MergeRequestsMockTests` to validate aforementioned changes