### PR TITLE
Allow to create multiple branches from same ref in mocks

### DIFF
--- a/NGitLab.Mock/Config/GitLabCommit.cs
+++ b/NGitLab.Mock/Config/GitLabCommit.cs
@@ -37,6 +37,11 @@ namespace NGitLab.Mock.Config
         public string TargetBranch { get; set; }
 
         /// <summary>
+        /// Branch to checkout before make more operation
+        /// </summary>
+        public string FromBranch { get; set; }
+
+        /// <summary>
         /// Indicates if source branch must be deleted after merge
         /// </summary>
         public bool DeleteSourceBranch { get; set; }

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -364,15 +364,17 @@ namespace NGitLab.Mock.Config
         /// <param name="user">Author username (required if default user not defined)</param>
         /// <param name="sourceBranch">Source branch (required if checkout or merge)</param>
         /// <param name="targetBranch">Target branch (required if merge)</param>
+        /// <param name="fromBranch">From branch</param>
         /// <param name="tags">Tags.</param>
         /// <param name="alias">Alias to reference it in pipeline.</param>
         /// <param name="configure">Configuration method</param>
-        public static GitLabProject WithCommit(this GitLabProject project, string? message = null, string? user = null, string? sourceBranch = null, string? targetBranch = null, IEnumerable<string>? tags = null, string? alias = null, Action<GitLabCommit>? configure = null)
+        public static GitLabProject WithCommit(this GitLabProject project, string? message = null, string? user = null, string? sourceBranch = null, string? targetBranch = null, string? fromBranch = null, IEnumerable<string>? tags = null, string? alias = null, Action<GitLabCommit>? configure = null)
         {
             return WithCommit(project, message, user, commit =>
             {
                 commit.SourceBranch = sourceBranch;
                 commit.TargetBranch = targetBranch;
+                commit.FromBranch = fromBranch;
                 commit.Alias = alias;
                 if (tags != null)
                 {
@@ -1203,6 +1205,11 @@ namespace NGitLab.Mock.Config
             var user = GetOrCreateUser(server, username);
             var targetBranch = commit.TargetBranch;
             Commit cmt;
+            if (!string.IsNullOrEmpty(commit.FromBranch))
+            {
+                prj.Repository.Checkout(commit.FromBranch);
+            }
+
             if (string.IsNullOrEmpty(targetBranch))
             {
                 var branchExists = string.IsNullOrEmpty(commit.SourceBranch) || prj.Repository.GetAllBranches().Any(x => string.Equals(x.FriendlyName, commit.SourceBranch, StringComparison.Ordinal));

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -122,6 +122,8 @@ NGitLab.Mock.Config.GitLabComment.UpdatedAt.set -> void
 NGitLab.Mock.Config.GitLabCommentsCollection
 NGitLab.Mock.Config.GitLabCommit.DeleteSourceBranch.get -> bool
 NGitLab.Mock.Config.GitLabCommit.DeleteSourceBranch.set -> void
+NGitLab.Mock.Config.GitLabCommit.FromBranch.get -> string
+NGitLab.Mock.Config.GitLabCommit.FromBranch.set -> void
 NGitLab.Mock.Config.GitLabConfig.DefaultBranch.get -> string
 NGitLab.Mock.Config.GitLabConfig.DefaultBranch.set -> void
 NGitLab.Mock.Config.GitLabConfig.DefaultUser.get -> string
@@ -1150,7 +1152,7 @@ static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.Gi
 static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabIssue issue, string message, System.Action<NGitLab.Mock.Config.GitLabComment> configure) -> NGitLab.Mock.Config.GitLabIssue
 static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, int id = 0, string author = null, bool system = false, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, string thread = null, bool resolvable = false, bool resolved = false, System.Action<NGitLab.Mock.Config.GitLabComment> configure = null) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message, System.Action<NGitLab.Mock.Config.GitLabComment> configure) -> NGitLab.Mock.Config.GitLabMergeRequest
-static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message = null, string user = null, string sourceBranch = null, string targetBranch = null, System.Collections.Generic.IEnumerable<string> tags = null, string alias = null, System.Action<NGitLab.Mock.Config.GitLabCommit> configure = null) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message = null, string user = null, string sourceBranch = null, string targetBranch = null, string fromBranch = null, System.Collections.Generic.IEnumerable<string> tags = null, string alias = null, System.Action<NGitLab.Mock.Config.GitLabCommit> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message, string user, System.Action<NGitLab.Mock.Config.GitLabCommit> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithGroup(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithGroupPermission(this NGitLab.Mock.Config.GitLabGroup grp, string groupName, NGitLab.Models.AccessLevel level) -> NGitLab.Mock.Config.GitLabGroup


### PR DESCRIPTION
For the fluent API by using `fromBranch` parameter.

Example:

```csharp
using var server = new GitLabConfig()
                .WithUser("user1", isDefault: true)
                .WithProject("test-project", id: 1, addDefaultUserAsMaintainer: true, defaultBranch: "main", configure: project => project
                    .WithCommit("Initial commit")
                    .WithCommit("Commit for branch_1", sourceBranch: "branch_1")
                    .WithCommit("Commit for branch_2", sourceBranch: "branch_2", fromBranch: "main"))
                .BuildServer();
```