### PR TITLE
Fix a few bugs in mock handling of forks

### DIFF
--- a/NGitLab.Mock/MergeRequest.cs
+++ b/NGitLab.Mock/MergeRequest.cs
@@ -139,7 +139,7 @@ namespace NGitLab.Mock
                 if (string.IsNullOrEmpty(HeadSha))
                     return null;
                 var headSha = new Sha1(_headSha);
-                var pipeline = Project.Pipelines
+                var pipeline = SourceProject.Pipelines
                   .Where(p => p.Sha.Equals(headSha))
                   .OrderByDescending(p => p.CreatedAt)
                   .FirstOrDefault();
@@ -215,6 +215,7 @@ namespace NGitLab.Mock
 
             if (ForceRemoveSourceBranch || ShouldRemoveSourceBranch)
             {
+                SourceProject.Repository.Checkout(SourceProject.DefaultBranch);
                 SourceProject.Repository.RemoveBranch(SourceBranch);
             }
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -380,7 +380,11 @@ namespace NGitLab.Mock
 
             var existingProject = group.Projects.FirstOrDefault(p => string.Equals(p.Name, projectName, StringComparison.Ordinal));
             if (existingProject != null)
-                return existingProject;
+            {
+                return existingProject == this ?
+                    throw new InvalidOperationException($"Cannot fork '{PathWithNamespace}' onto itself") :
+                    existingProject;
+            }
 
             var newProject = new Project(projectName)
             {


### PR DESCRIPTION
Make changes in mocks to address the following:

- A merge request's head pipeline should not be looked up among the target project's pipelines, but the source project's.
- When a merge request is accepted and we try to delete the source branch, make sure the repository's HEAD does not point to that branch.
- Add a check to prevent forking a project onto itself.