### PR TITLE
Rename Test

### DIFF
--- a/NGitLab.Mock.Tests/IssuesMockTests.cs
+++ b/NGitLab.Mock.Tests/IssuesMockTests.cs
@@ -73,7 +73,7 @@ namespace NGitLab.Mock.Tests
         }
 
         [Test]
-        public void Test_issue_bla()
+        public void Test_issue_resource_milestone_events_can_be_found()
         {
             using var server = new GitLabConfig()
                 .WithUser("user1", isDefault: true)


### PR DESCRIPTION
The test name for the resource milestone events was left with its WIP name. This name should be more descriptive of the goal of the actual test.