### PR TITLE
Add page query option for releases

### DIFF
--- a/NGitLab.Mock.Tests/CommitsMockTests.cs
+++ b/NGitLab.Mock.Tests/CommitsMockTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using NGitLab.Mock.Config;
 using NUnit.Framework;
 

--- a/NGitLab.Mock.Tests/ReleasesMockTests.cs
+++ b/NGitLab.Mock.Tests/ReleasesMockTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using NGitLab.Mock.Config;
 using NUnit.Framework;
 
@@ -24,6 +25,76 @@ namespace NGitLab.Mock.Tests
             Assert.IsNotNull(singleRelease);
             Assert.AreEqual("1.2.3", singleRelease.TagName);
             Assert.AreEqual($"{project.WebUrl}/-/releases/1.2.3", singleRelease.Links.Self);
+        }
+
+        [Test]
+        public void Test_release_page()
+        {
+            using var server = new GitLabConfig()
+                .WithUser("user1", isDefault: true)
+                .WithProject("Test", configure: project => project
+                    .WithCommit("Changes with tag", tags: new[] { "1.2.3", "1.2.4" })
+                    .WithRelease("user1", "1.2.3", createdAt: DateTime.UtcNow.AddHours(-2), releasedAt: DateTime.UtcNow.AddHours(-2))
+                    .WithRelease("user1", "1.2.4", createdAt: DateTime.UtcNow.AddHours(-1), releasedAt: DateTime.UtcNow.AddHours(-1)))
+                .BuildServer();
+
+            var client = server.CreateClient("user1");
+            var project = client.Projects.Visible.First();
+            var releaseClient = client.GetReleases(project.Id);
+            var firstRelease = releaseClient.GetAsync(new Models.ReleaseQuery
+            {
+                PerPage = 1,
+                Page = 2,
+            }).SingleOrDefault();
+
+            Assert.IsNotNull(firstRelease);
+            Assert.AreEqual("1.2.3", firstRelease.TagName);
+        }
+
+        [Test]
+        public void Test_release_sort()
+        {
+            using var server = new GitLabConfig()
+                .WithUser("user1", isDefault: true)
+                .WithProject("Test", configure: project => project
+                    .WithCommit("Changes with tag", tags: new[] { "1.2.3", "1.2.4" })
+                    .WithRelease("user1", "1.2.3", createdAt: DateTime.UtcNow.AddHours(-2), releasedAt: DateTime.UtcNow.AddHours(-2))
+                    .WithRelease("user1", "1.2.4", createdAt: DateTime.UtcNow.AddHours(-1), releasedAt: DateTime.UtcNow.AddHours(-1)))
+                .BuildServer();
+
+            var client = server.CreateClient("user1");
+            var project = client.Projects.Visible.First();
+            var releaseClient = client.GetReleases(project.Id);
+            var firstRelease = releaseClient.GetAsync(new Models.ReleaseQuery
+            {
+                Sort = "asc",
+            }).First();
+
+            Assert.IsNotNull(firstRelease);
+            Assert.AreEqual("1.2.3", firstRelease.TagName);
+        }
+
+        [Test]
+        public void Test_release_orderBy()
+        {
+            using var server = new GitLabConfig()
+                .WithUser("user1", isDefault: true)
+                .WithProject("Test", configure: project => project
+                    .WithCommit("Changes with tag", tags: new[] { "1.2.3", "1.2.4" })
+                    .WithRelease("user1", "1.2.3", createdAt: DateTime.UtcNow.AddHours(-1), releasedAt: DateTime.UtcNow.AddHours(-1))
+                    .WithRelease("user1", "1.2.4", createdAt: DateTime.UtcNow.AddHours(-2), releasedAt: DateTime.UtcNow.AddHours(-2)))
+                .BuildServer();
+
+            var client = server.CreateClient("user1");
+            var project = client.Projects.Visible.First();
+            var releaseClient = client.GetReleases(project.Id);
+            var firstRelease = releaseClient.GetAsync(new Models.ReleaseQuery
+            {
+                OrderBy = "created_at",
+            }).First();
+
+            Assert.IsNotNull(firstRelease);
+            Assert.AreEqual("1.2.3", firstRelease.TagName);
         }
     }
 }

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -510,14 +510,17 @@ namespace NGitLab.Mock.Config
             });
         }
 
-        public static GitLabProject WithRelease(this GitLabProject project, string author, string tagName)
+        public static GitLabProject WithRelease(this GitLabProject project, string author, string tagName, DateTime? createdAt = null, DateTime? releasedAt = null)
         {
             return Configure(project, _ =>
             {
+                var date = DateTime.UtcNow;
                 var release = new GitLabReleaseInfo
                 {
                     Author = author,
                     TagName = tagName,
+                    CreatedAt = createdAt ?? date,
+                    ReleasedAt = releasedAt ?? date,
                 };
 
                 project.Releases.Add(release);
@@ -1194,6 +1197,8 @@ namespace NGitLab.Mock.Config
             {
                 Author = new UserRef(user),
                 TagName = gitLabRelease.TagName,
+                CreatedAt = gitLabRelease.CreatedAt,
+                ReleasedAt = gitLabRelease.ReleasedAt,
             };
 
             project.Releases.Add(release);

--- a/NGitLab.Mock/Config/GitLabReleaseInfo.cs
+++ b/NGitLab.Mock/Config/GitLabReleaseInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace NGitLab.Mock.Config
+﻿using System;
+
+namespace NGitLab.Mock.Config
 {
     /// <summary>
     /// Describes a release in a GitLab project
@@ -12,6 +14,10 @@
         public string Author { get; set; }
 
         public string TagName { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime ReleasedAt { get; set; }
     }
 
     public class GitLabReleaseInfoCollection : GitLabCollection<GitLabReleaseInfo, GitLabProject>

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -199,7 +199,11 @@ NGitLab.Mock.Config.GitLabProject.Visibility.get -> NGitLab.Models.VisibilityLev
 NGitLab.Mock.Config.GitLabReleaseInfo
 NGitLab.Mock.Config.GitLabReleaseInfo.Author.get -> string
 NGitLab.Mock.Config.GitLabReleaseInfo.Author.set -> void
+NGitLab.Mock.Config.GitLabReleaseInfo.CreatedAt.get -> System.DateTime
+NGitLab.Mock.Config.GitLabReleaseInfo.CreatedAt.set -> void
 NGitLab.Mock.Config.GitLabReleaseInfo.GitLabReleaseInfo() -> void
+NGitLab.Mock.Config.GitLabReleaseInfo.ReleasedAt.get -> System.DateTime
+NGitLab.Mock.Config.GitLabReleaseInfo.ReleasedAt.set -> void
 NGitLab.Mock.Config.GitLabReleaseInfo.TagName.get -> string
 NGitLab.Mock.Config.GitLabReleaseInfo.TagName.set -> void
 NGitLab.Mock.Config.GitLabReleaseInfoCollection
@@ -1209,7 +1213,7 @@ static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.
 static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabProject project, string title, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithPipeline(this NGitLab.Mock.Config.GitLabProject project, string ref, System.Action<NGitLab.Mock.Config.GitLabPipeline> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
-static NGitLab.Mock.Config.GitLabHelpers.WithRelease(this NGitLab.Mock.Config.GitLabProject project, string author, string tagName) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithRelease(this NGitLab.Mock.Config.GitLabProject project, string author, string tagName, System.DateTime? createdAt = null, System.DateTime? releasedAt = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabIssue
 static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithUser(this NGitLab.Mock.Config.GitLabConfig config, string username, string name = null, string email = null, string avatarUrl = null, bool isAdmin = false, bool isDefault = false, System.Action<NGitLab.Mock.Config.GitLabUser> configure = null) -> NGitLab.Mock.Config.GitLabConfig

--- a/NGitLab/Impl/ReleaseClient.cs
+++ b/NGitLab/Impl/ReleaseClient.cs
@@ -44,6 +44,7 @@ namespace NGitLab.Impl
                 url = Utils.AddParameter(url, "sort", query.Sort);
                 url = Utils.AddParameter(url, "include_html_description", query.IncludeHtmlDescription);
                 url = Utils.AddParameter(url, "per_page", query.PerPage);
+                url = Utils.AddParameter(url, "page", query.Page);
             }
 
             return _api.Get().GetAllAsync<ReleaseInfo>(url);

--- a/NGitLab/Models/ReleaseQuery.cs
+++ b/NGitLab/Models/ReleaseQuery.cs
@@ -2,12 +2,29 @@
 {
     public class ReleaseQuery
     {
+        /// <summary>
+        /// The field to use as order. Either released_at (default) or created_at.
+        /// </summary>
         public string OrderBy { get; set; }
 
+        /// <summary>
+        /// The direction of the order. Either desc (default) for descending order or asc for ascending order.
+        /// </summary>
         public string Sort { get; set; }
 
+        /// <summary>
+        /// If true, a response includes HTML rendered Markdown of the release description.
+        /// </summary>
         public bool? IncludeHtmlDescription { get; set; }
 
+        /// <summary>
+        /// Specifies how many records per page (GitLab supports a maximum of 100 items per page and defaults to 20).
+        /// </summary>
         public int? PerPage { get; set; }
+
+        /// <summary>
+        /// Specifies the start page.
+        /// </summary>
+        public int? Page { get; set; }
     }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2881,6 +2881,8 @@ NGitLab.Models.ReleaseQuery.IncludeHtmlDescription.get -> bool?
 NGitLab.Models.ReleaseQuery.IncludeHtmlDescription.set -> void
 NGitLab.Models.ReleaseQuery.OrderBy.get -> string
 NGitLab.Models.ReleaseQuery.OrderBy.set -> void
+NGitLab.Models.ReleaseQuery.Page.get -> int?
+NGitLab.Models.ReleaseQuery.Page.set -> void
 NGitLab.Models.ReleaseQuery.PerPage.get -> int?
 NGitLab.Models.ReleaseQuery.PerPage.set -> void
 NGitLab.Models.ReleaseQuery.ReleaseQuery() -> void


### PR DESCRIPTION
- To be able to skip pages if desired (load first results, then next pages if triggered/required)
- Implement some parts of the query usage in mock