### PR TITLE
Add GitLabTestContext.ReportTestAsInconclusiveIfVersionOutOfRange

### DIFF
--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -132,6 +132,5 @@ namespace NGitLab.Mock.Tests
             project.Permissions.ProjectAccess.Should().BeNull();
             project.Permissions.GroupAccess.AccessLevel.Should().Be(AccessLevel.Maintainer);
         }
-
     }
 }

--- a/NGitLab.Tests/Docker/GitLabDockerContainer.cs
+++ b/NGitLab.Tests/Docker/GitLabDockerContainer.cs
@@ -349,7 +349,7 @@ namespace NGitLab.Tests.Docker
 
             static void EnsureChromiumIsInstalled()
             {
-                TestContext.Progress.WriteLine("Make sure Chromium is installed");
+                TestContext.Progress.WriteLine("Making sure Chromium is installed");
 
                 var exitCode = Microsoft.Playwright.Program.Main(new[] { "install", "--force", "chromium", "--with-deps" });
                 if (exitCode != 0)

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Meziantou.Framework.Versioning;
 using NGitLab.Models;
 using NUnit.Framework;
 using Polly;
@@ -252,6 +253,19 @@ namespace NGitLab.Tests.Docker
         public int GetRandomNumber()
         {
             return RandomNumberGenerator.GetInt32(0, int.MaxValue);
+        }
+
+        public void ReportTestAsInconclusiveIfVersionOutOfRange(SemanticVersion minVersion = null, SemanticVersion maxVersion = null)
+        {
+            var gitLabVersion = AdminClient.Version.Get();
+            if (!SemanticVersion.TryParse(gitLabVersion.Version, out var currentVersion))
+                return;
+
+            if (minVersion is not null && currentVersion < minVersion)
+                Assert.Inconclusive($"Test supported starting at version {minVersion}, but currently running against {currentVersion}");
+
+            if (maxVersion is not null && currentVersion > maxVersion)
+                Assert.Inconclusive($"Test supported up to version {maxVersion}, but currently running against {currentVersion}");
         }
 
         private IGitLabClient CreateClient(string token)

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Meziantou.Framework.Versioning;
 using NGitLab.Models;
+using NuGet.Versioning;
 using NUnit.Framework;
 using Polly;
 
@@ -255,17 +255,13 @@ namespace NGitLab.Tests.Docker
             return RandomNumberGenerator.GetInt32(0, int.MaxValue);
         }
 
-        public void ReportTestAsInconclusiveIfVersionOutOfRange(SemanticVersion minVersion = null, SemanticVersion maxVersion = null)
+        public void ReportTestAsInconclusiveIfVersionOutOfRange(VersionRange versionRange)
         {
-            var gitLabVersion = AdminClient.Version.Get();
-            if (!SemanticVersion.TryParse(gitLabVersion.Version, out var currentVersion))
+            var gitLabVersion = Client.Version.Get();
+            if (!NuGetVersion.TryParse(gitLabVersion.Version, out var currentVersion))
                 return;
-
-            if (minVersion is not null && currentVersion < minVersion)
-                Assert.Inconclusive($"Test supported starting at version {minVersion}, but currently running against {currentVersion}");
-
-            if (maxVersion is not null && currentVersion > maxVersion)
-                Assert.Inconclusive($"Test supported up to version {maxVersion}, but currently running against {currentVersion}");
+            if (!versionRange.Satisfies(currentVersion))
+                Assert.Inconclusive($"Test supported in version range '{versionRange}', but currently running against '{currentVersion}'");
         }
 
         private IGitLabClient CreateClient(string token)

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -175,11 +175,9 @@ namespace NGitLab.Tests
         public async Task Test_merge_request_approvers()
         {
             using var context = await GitLabTestContext.CreateAsync();
-            var version = SemanticVersion.Parse(context.AdminClient.Version.Get().Version);
-            if (version >= SemanticVersion.Parse("13.11.0"))
-            {
-                Assert.Inconclusive("Setting approvers is not supported in GitLab 14, you must use approval rules");
-            }
+
+            // https://about.gitlab.com/releases/2021/04/22/gitlab-13-11-released/#removal-of-merge-request-approvers-endpoint-in-favor-of-approval-rules-api
+            context.ReportTestAsInconclusiveIfVersionOutOfRange(maxVersion: SemanticVersion.Parse("13.10.99"));
 
             var (project, mergeRequest) = context.CreateMergeRequest();
             var mergeRequestClient = context.Client.GetMergeRequest(project.Id);

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Meziantou.Framework.Versioning;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
+using NuGet.Versioning;
 using NUnit.Framework;
 using Polly;
 
@@ -177,7 +178,7 @@ namespace NGitLab.Tests
             using var context = await GitLabTestContext.CreateAsync();
 
             // https://about.gitlab.com/releases/2021/04/22/gitlab-13-11-released/#removal-of-merge-request-approvers-endpoint-in-favor-of-approval-rules-api
-            context.ReportTestAsInconclusiveIfVersionOutOfRange(maxVersion: SemanticVersion.Parse("13.10.99"));
+            context.ReportTestAsInconclusiveIfVersionOutOfRange(VersionRange.Parse("[,13.11)"));
 
             var (project, mergeRequest) = context.CreateMergeRequest();
             var mergeRequestClient = context.Client.GetMergeRequest(project.Id);

--- a/NGitLab.Tests/NGitLab.Tests.csproj
+++ b/NGitLab.Tests/NGitLab.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.34.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.6.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />

--- a/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
+++ b/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
-using Meziantou.Framework.Versioning;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
+using NuGet.Versioning;
 using NUnit.Framework;
 
 namespace NGitLab.Tests
@@ -9,14 +9,14 @@ namespace NGitLab.Tests
     public class ProjectLevelApprovalRulesClientTests
     {
         // Starting at version 15.2.0, project-level approval rules require a Premium subscription
-        private readonly SemanticVersion MaxVersion = new(15, 1, 99);
+        private readonly VersionRange SupportedVersionRange = VersionRange.Parse("[,15.2)");
         private GitLabTestContext context;
 
         [SetUp]
         public async Task SetUp()
         {
             context = await GitLabTestContext.CreateAsync();
-            context.ReportTestAsInconclusiveIfVersionOutOfRange(maxVersion: MaxVersion);
+            context.ReportTestAsInconclusiveIfVersionOutOfRange(SupportedVersionRange);
         }
 
         [TearDown]

--- a/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
+++ b/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
@@ -9,20 +9,14 @@ namespace NGitLab.Tests
     public class ProjectLevelApprovalRulesClientTests
     {
         // Starting at version 15.2.0, project-level approval rules require a Premium subscription
-        private readonly SemanticVersion MaxVersion = new(15, 1, 0);
+        private readonly SemanticVersion MaxVersion = new(15, 1, 99);
         private GitLabTestContext context;
 
         [SetUp]
         public async Task SetUp()
         {
             context = await GitLabTestContext.CreateAsync();
-            var gitLabVersion = context.Client.Version.Get();
-
-            if (SemanticVersion.TryParse(gitLabVersion.Version, out var version) &&
-                version > MaxVersion)
-            {
-                Assert.Inconclusive($"Test supported up to version {MaxVersion}, but currently running against {version}");
-            }
+            context.ReportTestAsInconclusiveIfVersionOutOfRange(maxVersion: MaxVersion);
         }
 
         [TearDown]


### PR DESCRIPTION
Centralize the GitLab version checking logic that reports tests as inconclusive. It was being previously repeated across tests.