### PR TITLE
Remove redundant `projectId` from ContributorClient

### DIFF
--- a/NGitLab/Impl/ContributorClient.cs
+++ b/NGitLab/Impl/ContributorClient.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using NGitLab.Extensions;
+using System;
+using System.Collections.Generic;
 using NGitLab.Models;
 
 namespace NGitLab.Impl
@@ -8,18 +8,22 @@ namespace NGitLab.Impl
     {
         private readonly API _api;
         private readonly string _contributorPath;
-        private readonly int _projectId;
 
-        public ContributorClient(API api, string repoPath, int projectId)
+        public ContributorClient(API api, string repoPath)
         {
             _api = api;
             _contributorPath = repoPath + Contributor.Url;
-            _projectId = projectId;
+        }
+
+        [Obsolete("Argument projectId is redundant, please use ContributorClient(API api, string repoPath) instead.")]
+        public ContributorClient(API api, string repoPath, int projectId)
+            : this(api, repoPath)
+        {
         }
 
         /// <remarks>
         /// HACK: We force the order_by and sort due to a pagination bug from GitLab
         /// </remarks>
-        public IEnumerable<Contributor> All => _api.Get().GetAll<Contributor>(_contributorPath + $"?id={_projectId.ToStringInvariant()}&order_by=commits&sort=desc");
+        public IEnumerable<Contributor> All => _api.Get().GetAll<Contributor>(_contributorPath + $"?order_by=commits&sort=desc");
     }
 }

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -24,7 +24,7 @@ namespace NGitLab.Impl
 
         public ITagClient Tags => new TagClient(_api, _repoPath);
 
-        public IContributorClient Contributors => new ContributorClient(_api, _repoPath, _projectId);
+        public IContributorClient Contributors => new ContributorClient(_api, _repoPath);
 
         public IEnumerable<Tree> Tree => _api.Get().GetAll<Tree>(_repoPath + "/tree");
 


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/repositories.html#contributors

The `id` argument has already been included in the `repoPath`.

No need to pass it through query parameters.