### PR TITLE
Add project_id and group_id properties for the Milestone model

### DIFF
--- a/NGitLab.Tests/Milestone/MilestoneClientTests.cs
+++ b/NGitLab.Tests/Milestone/MilestoneClientTests.cs
@@ -79,6 +79,8 @@ namespace NGitLab.Tests.Milestone
             Assert.That(milestone.Description, Is.EqualTo($"{title} description"));
             Assert.That(milestone.StartDate, Is.EqualTo("2017-08-20"));
             Assert.That(milestone.DueDate, Is.EqualTo("2017-09-20"));
+            Assert.That(milestone.ProjectId, scope == MilestoneScope.Projects ? Is.EqualTo(id) : Is.Null);
+            Assert.That(milestone.GroupId, scope == MilestoneScope.Groups ? Is.EqualTo(id) : Is.Null);
 
             return milestone;
         }
@@ -100,6 +102,8 @@ namespace NGitLab.Tests.Milestone
             Assert.That(updatedMilestone.StartDate, Is.EqualTo("2018-08-20"));
             Assert.That(updatedMilestone.DueDate, Is.EqualTo("2018-09-20"));
             Assert.That(updatedMilestone.State, Is.EqualTo(milestone.State));
+            Assert.That(milestone.ProjectId, scope == MilestoneScope.Projects ? Is.EqualTo(id) : Is.Null);
+            Assert.That(milestone.GroupId, scope == MilestoneScope.Groups ? Is.EqualTo(id) : Is.Null);
 
             return updatedMilestone;
         }
@@ -118,6 +122,8 @@ namespace NGitLab.Tests.Milestone
             Assert.That(updatedMilestone.StartDate, Is.EqualTo(milestone.StartDate));
             Assert.That(updatedMilestone.DueDate, Is.EqualTo(milestone.DueDate));
             Assert.That(updatedMilestone.State, Is.EqualTo(milestone.State));
+            Assert.That(updatedMilestone.ProjectId, scope == MilestoneScope.Projects ? Is.EqualTo(id) : Is.Null);
+            Assert.That(updatedMilestone.GroupId, scope == MilestoneScope.Groups ? Is.EqualTo(id) : Is.Null);
 
             return updatedMilestone;
         }
@@ -125,15 +131,17 @@ namespace NGitLab.Tests.Milestone
         private static Models.Milestone ActivateMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
         {
             var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
-            var closedMilestone = milestoneClient.Activate(milestone.Id);
+            var activeMilestone = milestoneClient.Activate(milestone.Id);
 
-            Assert.That(closedMilestone.State, Is.EqualTo(nameof(MilestoneState.active)));
-            Assert.That(closedMilestone.Title, Is.EqualTo(milestone.Title));
-            Assert.That(closedMilestone.Description, Is.EqualTo(milestone.Description));
-            Assert.That(closedMilestone.StartDate, Is.EqualTo(milestone.StartDate));
-            Assert.That(closedMilestone.DueDate, Is.EqualTo(milestone.DueDate));
+            Assert.That(activeMilestone.State, Is.EqualTo(nameof(MilestoneState.active)));
+            Assert.That(activeMilestone.Title, Is.EqualTo(milestone.Title));
+            Assert.That(activeMilestone.Description, Is.EqualTo(milestone.Description));
+            Assert.That(activeMilestone.StartDate, Is.EqualTo(milestone.StartDate));
+            Assert.That(activeMilestone.DueDate, Is.EqualTo(milestone.DueDate));
+            Assert.That(activeMilestone.ProjectId, scope == MilestoneScope.Projects ? Is.EqualTo(id) : Is.Null);
+            Assert.That(activeMilestone.GroupId, scope == MilestoneScope.Groups ? Is.EqualTo(id) : Is.Null);
 
-            return closedMilestone;
+            return activeMilestone;
         }
 
         private static Models.Milestone CloseMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
@@ -146,6 +154,8 @@ namespace NGitLab.Tests.Milestone
             Assert.That(closedMilestone.Description, Is.EqualTo(milestone.Description));
             Assert.That(closedMilestone.StartDate, Is.EqualTo(milestone.StartDate));
             Assert.That(closedMilestone.DueDate, Is.EqualTo(milestone.DueDate));
+            Assert.That(closedMilestone.ProjectId, scope == MilestoneScope.Projects ? Is.EqualTo(id) : Is.Null);
+            Assert.That(closedMilestone.GroupId, scope == MilestoneScope.Groups ? Is.EqualTo(id) : Is.Null);
 
             return closedMilestone;
         }

--- a/NGitLab/Models/Milestone.cs
+++ b/NGitLab/Models/Milestone.cs
@@ -20,6 +20,12 @@ namespace NGitLab.Models
         [JsonPropertyName("due_date")]
         public string DueDate;
 
+        [JsonPropertyName("group_id")]
+        public int? GroupId;
+
+        [JsonPropertyName("project_id")]
+        public int? ProjectId;
+
         [JsonPropertyName("start_date")]
         public string StartDate;
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2305,9 +2305,11 @@ NGitLab.Models.Milestone
 NGitLab.Models.Milestone.CreatedAt -> System.DateTime
 NGitLab.Models.Milestone.Description -> string
 NGitLab.Models.Milestone.DueDate -> string
+NGitLab.Models.Milestone.GroupId -> int?
 NGitLab.Models.Milestone.Id -> int
 NGitLab.Models.Milestone.Iid -> int
 NGitLab.Models.Milestone.Milestone() -> void
+NGitLab.Models.Milestone.ProjectId -> int?
 NGitLab.Models.Milestone.StartDate -> string
 NGitLab.Models.Milestone.State -> string
 NGitLab.Models.Milestone.Title -> string


### PR DESCRIPTION
Milestone has either of `project_id` or `group_id` property:
https://docs.gitlab.com/ee/api/milestones.html
https://docs.gitlab.com/ee/api/group_milestones.html

Although they are not listed in the attribute list, they are included in all the examples.

In the practical use case, we may get a milestone from the issues or merge requests:
https://docs.gitlab.com/ee/api/issues.html#single-issue
https://docs.gitlab.com/ee/api/merge_requests.html#list-project-merge-requests