### PR TITLE
Add Merge Trains Properties in projects

### DIFF
--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -239,9 +239,7 @@ namespace NGitLab.Tests
             {
                 Description = "desc",
                 IssuesEnabled = true,
-                MergePipelinesEnabled = true,
                 MergeRequestsEnabled = true,
-                MergeTrainsEnabled = true,
                 Name = "CreateDelete_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture),
                 NamespaceId = null,
                 SnippetsEnabled = true,
@@ -259,9 +257,7 @@ namespace NGitLab.Tests
 
             Assert.AreEqual(project.Description, createdProject.Description);
             Assert.AreEqual(project.IssuesEnabled, createdProject.IssuesEnabled);
-            Assert.AreEqual(project.MergePipelinesEnabled, createdProject.MergePipelinesEnabled);
             Assert.AreEqual(project.MergeRequestsEnabled, createdProject.MergeRequestsEnabled);
-            Assert.AreEqual(project.MergeTrainsEnabled, createdProject.MergeTrainsEnabled);
             Assert.AreEqual(project.Name, createdProject.Name);
             Assert.AreEqual(project.VisibilityLevel, createdProject.VisibilityLevel);
             CollectionAssert.AreEquivalent(expectedTopics, createdProject.Topics);

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -239,7 +239,9 @@ namespace NGitLab.Tests
             {
                 Description = "desc",
                 IssuesEnabled = true,
+                MergePipelinesEnabled = true,
                 MergeRequestsEnabled = true,
+                MergeTrainsEnabled = true,
                 Name = "CreateDelete_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture),
                 NamespaceId = null,
                 SnippetsEnabled = true,
@@ -257,7 +259,9 @@ namespace NGitLab.Tests
 
             Assert.AreEqual(project.Description, createdProject.Description);
             Assert.AreEqual(project.IssuesEnabled, createdProject.IssuesEnabled);
+            Assert.AreEqual(project.MergePipelinesEnabled, createdProject.MergePipelinesEnabled);
             Assert.AreEqual(project.MergeRequestsEnabled, createdProject.MergeRequestsEnabled);
+            Assert.AreEqual(project.MergeTrainsEnabled, createdProject.MergeTrainsEnabled);
             Assert.AreEqual(project.Name, createdProject.Name);
             Assert.AreEqual(project.VisibilityLevel, createdProject.VisibilityLevel);
             CollectionAssert.AreEquivalent(expectedTopics, createdProject.Topics);

--- a/NGitLab/Models/Project.cs
+++ b/NGitLab/Models/Project.cs
@@ -69,12 +69,18 @@ namespace NGitLab.Models
         [JsonPropertyName("issues_access_level")]
         public string IssuesAccessLevel;
 
+        [JsonPropertyName("merge_pipelines_enabled")]
+        public bool MergePipelinesEnabled;
+
         [JsonPropertyName("merge_requests_enabled")]
         [Obsolete("Deprecated by GitLab. Use MergeRequestsAccessLevel instead")]
         public bool MergeRequestsEnabled;
 
         [JsonPropertyName("merge_requests_access_level")]
         public string MergeRequestsAccessLevel;
+
+        [JsonPropertyName("merge_trains_enabled")]
+        public bool MergeTrainsEnabled;
 
         [JsonPropertyName("repository_access_level")]
         public RepositoryAccessLevel RepositoryAccessLevel;

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -35,12 +35,18 @@ namespace NGitLab.Models
         [JsonIgnore]
         public bool WallEnabled;
 
+        [JsonPropertyName("merge_pipelines_enabled")]
+        public bool MergePipelinesEnabled;
+
         [JsonPropertyName("merge_requests_enabled")]
         [Obsolete("Deprecated by GitLab. Use MergeRequestsAccessLevel instead")]
         public bool MergeRequestsEnabled;
 
         [JsonPropertyName("merge_requests_access_level")]
         public string MergeRequestsAccessLevel;
+
+        [JsonPropertyName("merge_trains_enabled")]
+        public bool MergeTrainsEnabled;
 
         [JsonPropertyName("snippets_enabled")]
         [Obsolete("Deprecated by GitLab. Use SnippetsAccessLevel instead")]

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -26,7 +26,7 @@ namespace NGitLab.Models
         public string IssuesAccessLeve { get; set; }
 
         [JsonPropertyName("merge_pipelines_enabled")]
-        public bool MergePipelinesEnabled;
+        public bool MergePipelinesEnabled { get; set; }
 
         [JsonPropertyName("merge_requests_enabled")]
         [Obsolete("Deprecated by GitLab. Use MergeRequestsAccessLevel instead")]
@@ -36,7 +36,7 @@ namespace NGitLab.Models
         public string MergeRequestsAccessLevel { get; set; }
 
         [JsonPropertyName("merge_trains_enabled")]
-        public bool MergeTrainsEnabled;
+        public bool MergeTrainsEnabled { get; set; }
 
         [JsonPropertyName("jobs_enabled")]
         [Obsolete("Deprecated by GitLab. Use BuildsAccessLevel instead")]

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -25,12 +25,18 @@ namespace NGitLab.Models
         [JsonPropertyName("issues_access_level")]
         public string IssuesAccessLeve { get; set; }
 
+        [JsonPropertyName("merge_pipelines_enabled")]
+        public bool MergePipelinesEnabled;
+
         [JsonPropertyName("merge_requests_enabled")]
         [Obsolete("Deprecated by GitLab. Use MergeRequestsAccessLevel instead")]
         public bool? MergeRequestsEnabled { get; set; }
 
         [JsonPropertyName("merge_requests_access_level")]
         public string MergeRequestsAccessLevel { get; set; }
+
+        [JsonPropertyName("merge_trains_enabled")]
+        public bool MergeTrainsEnabled;
 
         [JsonPropertyName("jobs_enabled")]
         [Obsolete("Deprecated by GitLab. Use BuildsAccessLevel instead")]

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2752,12 +2752,14 @@ NGitLab.Models.ProjectUpdate.JobsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.JobsEnabled.set -> void
 NGitLab.Models.ProjectUpdate.LfsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.LfsEnabled.set -> void
-NGitLab.Models.ProjectUpdate.MergePipelinesEnabled -> bool
+NGitLab.Models.ProjectUpdate.MergePipelinesEnabled.get -> bool
+NGitLab.Models.ProjectUpdate.MergePipelinesEnabled.set -> void
 NGitLab.Models.ProjectUpdate.MergeRequestsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.MergeRequestsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.MergeRequestsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.MergeRequestsEnabled.set -> void
-NGitLab.Models.ProjectUpdate.MergeTrainsEnabled -> bool
+NGitLab.Models.ProjectUpdate.MergeTrainsEnabled.get -> bool
+NGitLab.Models.ProjectUpdate.MergeTrainsEnabled.set -> void
 NGitLab.Models.ProjectUpdate.Name.get -> string
 NGitLab.Models.ProjectUpdate.Name.set -> void
 NGitLab.Models.ProjectUpdate.OnlyAllowMergeIfAllDiscussionsAreResolved.get -> bool?

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2532,8 +2532,10 @@ NGitLab.Models.Project.LastActivityAt -> System.DateTime
 NGitLab.Models.Project.LfsEnabled -> bool
 NGitLab.Models.Project.Links -> NGitLab.Models.ProjectLinks
 NGitLab.Models.Project.MergeMethod -> string
+NGitLab.Models.Project.MergePipelinesEnabled -> bool
 NGitLab.Models.Project.MergeRequestsAccessLevel -> string
 NGitLab.Models.Project.MergeRequestsEnabled -> bool
+NGitLab.Models.Project.MergeTrainsEnabled -> bool
 NGitLab.Models.Project.Mirror -> bool
 NGitLab.Models.Project.MirrorOverwritesDivergedBranches -> bool
 NGitLab.Models.Project.MirrorTriggerBuilds -> bool
@@ -2580,8 +2582,10 @@ NGitLab.Models.ProjectCreate.Description -> string
 NGitLab.Models.ProjectCreate.ImportUrl -> string
 NGitLab.Models.ProjectCreate.IssuesAccessLevel -> string
 NGitLab.Models.ProjectCreate.IssuesEnabled -> bool
+NGitLab.Models.ProjectCreate.MergePipelinesEnabled -> bool
 NGitLab.Models.ProjectCreate.MergeRequestsAccessLevel -> string
 NGitLab.Models.ProjectCreate.MergeRequestsEnabled -> bool
+NGitLab.Models.ProjectCreate.MergeTrainsEnabled -> bool
 NGitLab.Models.ProjectCreate.Name -> string
 NGitLab.Models.ProjectCreate.NamespaceId -> string
 NGitLab.Models.ProjectCreate.Path -> string
@@ -2748,10 +2752,12 @@ NGitLab.Models.ProjectUpdate.JobsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.JobsEnabled.set -> void
 NGitLab.Models.ProjectUpdate.LfsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.LfsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.MergePipelinesEnabled -> bool
 NGitLab.Models.ProjectUpdate.MergeRequestsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.MergeRequestsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.MergeRequestsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.MergeRequestsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.MergeTrainsEnabled -> bool
 NGitLab.Models.ProjectUpdate.Name.get -> string
 NGitLab.Models.ProjectUpdate.Name.set -> void
 NGitLab.Models.ProjectUpdate.OnlyAllowMergeIfAllDiscussionsAreResolved.get -> bool?


### PR DESCRIPTION
This merge requests add the fields `merge_pipelines_enabled` and `merge_trains_enabled` to the project model. They corresponds to the "Enable merged results pipelines" and "Enable merge trains" checkboxes in the project's Merge Requests options, respectively.