### PR TITLE
Add LinkedTo method to IIssueClient Interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,10 +73,10 @@ csharp_style_var_for_built_in_types = true : suggestion
 csharp_style_var_when_type_is_apparent = true : warning
 
 # Expression-Bodied members
-csharp_style_expression_bodied_accessors = true : suggestion
-csharp_style_expression_bodied_indexers = true : suggestion
-csharp_style_expression_bodied_operators = true : suggestion
-csharp_style_expression_bodied_properties = true : suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
 # Explicitly disabled due to difference in coding style between source and tests
 #csharp_style_expression_bodied_constructors = true : warning
 #csharp_style_expression_bodied_methods = true : warning
@@ -101,7 +101,7 @@ csharp_style_conditional_delegate_call = true : warning
 csharp_style_throw_expression = true : warning
 
 # Code block preferences
-csharp_prefer_braces = when_multiline : suggestion
+csharp_prefer_braces = when_multiline:suggestion
 
 ## Formatting conventions
 # Dotnet formatting settings:
@@ -141,6 +141,16 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping options
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+dotnet_diagnostic.SA1507.severity = error
 
 ## Naming conventions
 [*.{cs,vb}]
@@ -159,7 +169,7 @@ dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
 # Constants are PascalCase
 dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
-dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+dotnet_naming_rule.constants_should_be_pascal_case.style = non_private_static_field_style
 
 dotnet_naming_symbols.constants.applicable_kinds = field, local
 dotnet_naming_symbols.constants.required_modifiers = const
@@ -198,7 +208,7 @@ dotnet_naming_style.camel_case_style.capitalization = camel_case
 # Local functions are PascalCase
 dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
-dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = non_private_static_field_style
 
 dotnet_naming_symbols.local_functions.applicable_kinds = local_function
 dotnet_naming_style.local_function_style.capitalization = pascal_case
@@ -216,7 +226,7 @@ dotnet_naming_symbols.type_parameter_symbol.applicable_accessibilities = *
 # By default, name items with PascalCase
 dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
-dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.members_should_be_pascal_case.style = non_private_static_field_style
 
 dotnet_naming_symbols.all_members.applicable_kinds = *
 
@@ -373,3 +383,6 @@ dotnet_diagnostic.SA1636.severity = none
 
 # SA1649: File name should match first type name
 dotnet_diagnostic.SA1649.severity = none
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -302,6 +302,14 @@ namespace NGitLab.Mock.Clients
             return GetById(issueId);
         }
 
+        public IEnumerable<Models.Issue> LinkedTo(int projectId, int issueId)
+        {
+            using (Context.BeginOperationScope())
+            {
+                return Enumerable.Empty<Models.Issue>();
+            }
+        }
+
         public Models.Issue GetById(int issueId)
         {
             using (Context.BeginOperationScope())

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -193,9 +193,7 @@ namespace NGitLab.Mock.Clients
         {
             throw new NotImplementedException();
         }
-
-
-
+        
         public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(int projectId, int issueIid)
         {
             throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -302,12 +302,9 @@ namespace NGitLab.Mock.Clients
             return GetById(issueId);
         }
 
-        public IEnumerable<Models.Issue> LinkedTo(int projectId, int issueId)
+        public GitLabCollectionResponse<Models.Issue> LinkedTo(int projectId, int issueId)
         {
-            using (Context.BeginOperationScope())
-            {
-                return Enumerable.Empty<Models.Issue>();
-            }
+            throw new NotImplementedException();
         }
 
         public Models.Issue GetById(int issueId)

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -193,7 +193,6 @@ namespace NGitLab.Mock.Clients
         {
             throw new NotImplementedException();
         }
-        
         public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(int projectId, int issueIid)
         {
             throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -302,7 +302,7 @@ namespace NGitLab.Mock.Clients
             return GetById(issueId);
         }
 
-        public GitLabCollectionResponse<Models.Issue> LinkedTo(int projectId, int issueId)
+        public GitLabCollectionResponse<Models.Issue> LinkedToAsync(int projectId, int issueId)
         {
             throw new NotImplementedException();
         }

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -194,6 +194,8 @@ namespace NGitLab.Mock.Clients
             throw new NotImplementedException();
         }
 
+
+
         public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(int projectId, int issueIid)
         {
             throw new NotImplementedException();
@@ -303,6 +305,11 @@ namespace NGitLab.Mock.Clients
         }
 
         public GitLabCollectionResponse<Models.Issue> LinkedTo(int projectId, int issueId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId)
         {
             throw new NotImplementedException();
         }

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -193,6 +193,7 @@ namespace NGitLab.Mock.Clients
         {
             throw new NotImplementedException();
         }
+
         public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(int projectId, int issueIid)
         {
             throw new NotImplementedException();

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -306,7 +306,9 @@ namespace NGitLab.Tests
             var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "related to #1" });
 
             var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
-            Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
+
+            // for now, no API to link issues so not links exist but API should not throw
+            Assert.AreEqual(0, issues.Count, "Expected 0. Got {0}", issues.Count);
         }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -303,11 +303,10 @@ namespace NGitLab.Tests
             var issuesClient = context.Client.Issues;
 
             var issue1 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title1" });
-            var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "blocks #1" });
+            var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "related to #1" });
 
             var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
-            Assert.AreEqual(1, issues.Count);
-            Assert.IsTrue(issue2.IssueId.Equals(issues.FirstOrDefault()?.IssueId));
+            Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
         }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -307,7 +307,7 @@ namespace NGitLab.Tests
 
             var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
             Assert.AreEqual(1, issues.Count);
-            Assert.IsTrue(issue2.Id.Equals(issues.FirstOrDefault()?.IssueId));
+            Assert.IsTrue(issue2.Id.Equals(issues.FirstOrDefault()?.Id));
         }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -307,6 +307,7 @@ namespace NGitLab.Tests
             var linked = issuesClient.CreateLinkBetweenIssues(project.Id, issue1.IssueId, project.Id, issue2.IssueId);
             Assert.IsTrue(linked, "Expected true for create Link between issues");
             var issues = issuesClient.LinkedToAsync(project.Id, issue1.IssueId).ToList();
+
             // for now, no API to link issues so not links exist but API should not throw
             Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
         }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -307,7 +307,7 @@ namespace NGitLab.Tests
 
             var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
             Assert.AreEqual(1, issues.Count);
-            Assert.IsTrue(issue2.Id.Equals(issues.FirstOrDefault()?.Id));
+            Assert.IsTrue(issue2.IssueId.Equals(issues.FirstOrDefault()?.IssueId));
         }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -306,7 +306,7 @@ namespace NGitLab.Tests
             var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "related to #1" });
             var linked = issuesClient.CreateLinkBetweenIssues(project.Id, issue1.IssueId, project.Id, issue2.IssueId);
             Assert.IsTrue(linked, "Expected true for create Link between issues");
-            var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
+            var issues = issuesClient.LinkedToAsync(project.Id, issue1.IssueId).ToList();
             // for now, no API to link issues so not links exist but API should not throw
             Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
         }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -293,5 +293,21 @@ namespace NGitLab.Tests
 
             Assert.AreEqual(updatedDueDate, updatedIssue.DueDate);
         }
+
+        [Test]
+        [NGitLabRetry]
+        public async Task Test_get_linked_issue()
+        {
+            using var context = await GitLabTestContext.CreateAsync();
+            var project = context.CreateProject();
+            var issuesClient = context.Client.Issues;
+
+            var issue1 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title1" });
+            var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "blocks #1" });
+
+            var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.IsTrue(issue2.Id.Equals(issues.FirstOrDefault()?.IssueId));
+        }
     }
 }

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -304,11 +304,11 @@ namespace NGitLab.Tests
 
             var issue1 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title1" });
             var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "related to #1" });
-
+            var linked = issuesClient.CreateLinkBetweenIssues(project.Id, issue1.IssueId, project.Id, issue2.IssueId);
+            Assert.IsTrue(linked, "Expected true for create Link between issues");
             var issues = issuesClient.LinkedTo(project.Id, issue1.IssueId).ToList();
-
             // for now, no API to link issues so not links exist but API should not throw
-            Assert.AreEqual(0, issues.Count, "Expected 0. Got {0}", issues.Count);
+            Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
         }
     }
 }

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -140,7 +140,7 @@ namespace NGitLab
         /// <param name="projectId">The project id.</param>
         /// <param name="issueId">The id of the issue in the project's scope.</param>
         /// <returns>The list of Issues linked to this issue.</returns>
-        GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId);
+        GitLabCollectionResponse<Issue> LinkedToAsync(int projectId, int issueId);
 
         /// <summary>
         /// Create links between Issues.

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -134,6 +134,14 @@ namespace NGitLab
         /// <returns>The list of MR that are related this issue.</returns>
         IEnumerable<MergeRequest> RelatedTo(int projectId, int issueIid);
 
+        /// <summary>
+        /// Get all merge requests that are related to a particular issue.
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="issueId">The id of the issue in the project's scope.</param>
+        /// <returns>The list of Issues linked to this issue.</returns>
+        IEnumerable<Issue> LinkedTo(int projectId,int issueId);
+
         GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid);
 
         /// <summary>

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -140,7 +140,7 @@ namespace NGitLab
         /// <param name="projectId">The project id.</param>
         /// <param name="issueId">The id of the issue in the project's scope.</param>
         /// <returns>The list of Issues linked to this issue.</returns>
-        IEnumerable<Issue> LinkedTo(int projectId,int issueId);
+        GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId);
 
         GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid);
 

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -135,7 +135,7 @@ namespace NGitLab
         IEnumerable<MergeRequest> RelatedTo(int projectId, int issueIid);
 
         /// <summary>
-        /// Get all merge requests that are related to a particular issue.
+        /// Get all Issues that are linked to a particular issue of particular project.
         /// </summary>
         /// <param name="projectId">The project id.</param>
         /// <param name="issueId">The id of the issue in the project's scope.</param>

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -142,6 +142,15 @@ namespace NGitLab
         /// <returns>The list of Issues linked to this issue.</returns>
         GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId);
 
+        /// <summary>
+        /// Create links between Issues.
+        /// </summary>
+        /// <param name="sourceProjectId">The project id.</param>
+        /// <param name="sourceIssueId">The id of the issue in the project's scope.</param>
+        /// <param name="targetProjectId">The target project id.</param>
+        /// <param name="targetIssueId">The target id of the issue to link to.</param>
+        bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId);
+
         GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid);
 
         /// <summary>

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -10,6 +10,7 @@ namespace NGitLab.Impl
     {
         private const string IssuesUrl = "/issues";
         private const string IssueByIdUrl = "/issues/{0}";
+        private const string LinkedIssuesByIdUrl = "/projects/{0}/issues/{1}/links";
         private const string GroupIssuesUrl = "/groups/{0}/issues";
         private const string ProjectIssuesUrl = "/projects/{0}/issues";
         private const string SingleIssueUrl = "/projects/{0}/issues/{1}";
@@ -143,6 +144,11 @@ namespace NGitLab.Impl
         public IEnumerable<MergeRequest> RelatedTo(int projectId, int issueIid)
         {
             return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, RelatedToUrl, projectId, issueIid));
+        }
+
+        public IEnumerable<Issue> LinkedTo(int projectId, int issueId)
+        {
+            return _api.Get().To<IEnumerable<Issue>>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
         }
 
         public GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid)

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -146,9 +146,9 @@ namespace NGitLab.Impl
             return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, RelatedToUrl, projectId, issueIid));
         }
 
-        public IEnumerable<Issue> LinkedTo(int projectId, int issueId)
+        public GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId)
         {
-            return _api.Get().To<IEnumerable<Issue>>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
+            return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
         }
 
         public GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid)

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -148,7 +148,7 @@ namespace NGitLab.Impl
             return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, RelatedToUrl, projectId, issueIid));
         }
 
-        public GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId)
+        public GitLabCollectionResponse<Issue> LinkedToAsync(int projectId, int issueId)
         {
             return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
         }

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -155,8 +156,15 @@ namespace NGitLab.Impl
         public bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId,
             int targetIssueId)
         {
-            _api.Post().Execute(string.Format(CultureInfo.InvariantCulture, CreateLinkBetweenIssuesUrl, sourceProjectId, sourceIssueId, targetProjectId, targetIssueId));
-            return true;
+            try
+            {
+                _api.Post().Execute(string.Format(CultureInfo.InvariantCulture, CreateLinkBetweenIssuesUrl, sourceProjectId, sourceIssueId, targetProjectId, targetIssueId));
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid)

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -11,6 +11,7 @@ namespace NGitLab.Impl
         private const string IssuesUrl = "/issues";
         private const string IssueByIdUrl = "/issues/{0}";
         private const string LinkedIssuesByIdUrl = "/projects/{0}/issues/{1}/links";
+        private const string CreateLinkBetweenIssuesUrl = "/projects/{0}/issues/{1}/links?target_project_id={2}&target_issue_iid={3}";
         private const string GroupIssuesUrl = "/groups/{0}/issues";
         private const string ProjectIssuesUrl = "/projects/{0}/issues";
         private const string SingleIssueUrl = "/projects/{0}/issues/{1}";
@@ -149,6 +150,13 @@ namespace NGitLab.Impl
         public GitLabCollectionResponse<Issue> LinkedTo(int projectId, int issueId)
         {
             return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
+        }
+
+        public bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId,
+            int targetIssueId)
+        {
+            _api.Post().Execute(string.Format(CultureInfo.InvariantCulture, CreateLinkBetweenIssuesUrl, sourceProjectId, sourceIssueId, targetProjectId, targetIssueId));
+            return true;
         }
 
         public GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid)

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -264,7 +264,7 @@ NGitLab.IIssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) ->
 NGitLab.IIssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetById(int issueId) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.LinkedTo(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.LinkedToAsync(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IIssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
@@ -516,7 +516,7 @@ NGitLab.Impl.IssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.Gi
 NGitLab.Impl.IssueClient.GetById(int issueId) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.IssueClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.IssueClient.LinkedTo(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.LinkedToAsync(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.IssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -249,6 +249,7 @@ NGitLab.IIssueClient.ClosedBy(int projectId, int issueIid) -> System.Collections
 NGitLab.IIssueClient.ClosedByAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.IIssueClient.Create(NGitLab.Models.IssueCreate issueCreate) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.CreateAsync(NGitLab.Models.IssueCreate issueCreate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId) -> bool
 NGitLab.IIssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.IIssueClient.ForGroupsAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
@@ -499,6 +500,7 @@ NGitLab.Impl.IssueClient.ClosedBy(int projectId, int issueIid) -> System.Collect
 NGitLab.Impl.IssueClient.ClosedByAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.IssueClient.Create(NGitLab.Models.IssueCreate issueCreate) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.CreateAsync(NGitLab.Models.IssueCreate issueCreate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId) -> bool
 NGitLab.Impl.IssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.ForGroupsAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -514,6 +514,7 @@ NGitLab.Impl.IssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.Gi
 NGitLab.Impl.IssueClient.GetById(int issueId) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.IssueClient(NGitLab.Impl.API api) -> void
+NGitLab.Impl.IssueClient.LinkedTo(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.IssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -263,6 +263,7 @@ NGitLab.IIssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) ->
 NGitLab.IIssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetById(int issueId) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.LinkedTo(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IIssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>


### PR DESCRIPTION
## API Changes:

Adding the following method:
```cs
        /// <summary>
        /// Get all Issues that are linked to a particular issue of particular project.
        /// </summary>
        /// <param name="projectId">The project id.</param>
        /// <param name="issueId">The id of the issue in the project's scope.</param>
        /// <returns>The list of Issues linked to this issue.</returns>
        IEnumerable<Issue> LinkedTo(int projectId,int issueId);
```

## Open Issues:
- [x] Public API analyzer: needs action to resolve finding.
- [x] Mock class returns empty collection:
  ```cs
     public IEnumerable<Models.Issue> LinkedTo(int projectId, int issueId)
     {
         using (Context.BeginOperationScope())
         {
             return Enumerable.Empty<Models.Issue>();
         }
     }
  ```

## Tests:

- Tested locally on personal repository. Linked issues are fetched correctly 
- recursive test (linked issues of fetched linked issues) probably should be blocked due to ciruclar reference?

## Related Issues:

Fix #482 