### PR TITLE
Implements support for OAuth tokens

### DIFF
--- a/NGitLab.Tests/HttpRequestorTests.cs
+++ b/NGitLab.Tests/HttpRequestorTests.cs
@@ -125,6 +125,22 @@ namespace NGitLab.Tests
             Assert.AreEqual(commonUserSession.Id, issue.Author.Id);
         }
 
+        [Test]
+        public async Task Test_authorization_header_uses_bearer()
+        {
+            // Arrange
+            using var context = await GitLabTestContext.CreateAsync();
+            var commonUserClient = context.Client;
+            string expectedHeaderValue = string.Concat("Bearer ", context.DockerContainer.Credentials.UserToken);
+
+            // Act
+            var project = commonUserClient.Projects.Accessible.First();
+
+            // Assert
+            var actualHeaderValue = context.LastRequest.Headers[HttpRequestHeader.Authorization];
+            Assert.AreEqual(expectedHeaderValue, actualHeaderValue);
+        }
+
         private sealed class MockRequestOptions : RequestOptions
         {
             public string HttpRequestSudoHeader { get; set; }

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -48,7 +48,11 @@ namespace NGitLab.Impl
 
                 if (apiToken != null)
                 {
-                    Headers.Add("Private-Token", apiToken);
+                    // Use the 'Authorization: Bearer token' header as this provides flexibility to use
+                    // personal, project, group and OAuth tokens. The 'PRIVATE-TOKEN' header does not
+                    // provide OAuth token support.
+                    // Reference: https://docs.gitlab.com/ee/api/rest/#personalprojectgroup-access-tokens
+                    Headers.Add(HttpRequestHeader.Authorization, string.Concat("Bearer ", apiToken));
                 }
 
                 if (!string.IsNullOrEmpty(options?.UserAgent))


### PR DESCRIPTION
Proposing this change to allow support of OAuth token authentication. 

As per the GitLab API documentation (https://docs.gitlab.com/ee/api/rest/#personalprojectgroup-access-tokens) the 'PRIVATE-TOKEN' header supports personal, project, or group access token.

Switching this to use an Authorization Bearer header allows the use of OAuth tokens as well.