### PR TITLE
fix: NamespaceId is not required when create project

### DIFF
--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -11,7 +11,6 @@ namespace NGitLab.Models
         [JsonPropertyName("name")]
         public string Name;
 
-        [Required]
         [JsonPropertyName("namespace_id")]
         public string NamespaceId;
 


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/projects.html#create-project

`NamespacceId` is not required. It defaults to the current user’s namespace.

The `[Required]` attribute confuses us. Let's correct it.