### PR TITLE
Implements since and until parameters when retrieving commit list

### DIFF
--- a/NGitLab/GetCommitsRequest.cs
+++ b/NGitLab/GetCommitsRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace NGitLab
+﻿using System;
+
+namespace NGitLab
 {
     public class GetCommitsRequest
     {
@@ -13,5 +15,9 @@
         public int MaxResults { get; set; }
 
         public uint PerPage { get; set; } = DefaultPerPage;
+
+        public DateTime? Since { get; set; }
+
+        public DateTime? Until { get; set; }
     }
 }

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -83,6 +85,16 @@ namespace NGitLab.Impl
             if (request.FirstParent != null)
             {
                 lst.Add($"first_parent={Uri.EscapeDataString(request.FirstParent.ToString())}");
+            }
+
+            if (request.Since.HasValue)
+            {
+                lst.Add($"since={WebUtility.UrlEncode(request.Since.Value.ToString("s", CultureInfo.InvariantCulture))}");
+            }
+
+            if (request.Until.HasValue)
+            {
+                lst.Add($"until={WebUtility.UrlEncode(request.Until.Value.ToString("s", CultureInfo.InvariantCulture))}");
             }
 
             var perPage = request.MaxResults > 0 ? Math.Min(request.MaxResults, request.PerPage) : request.PerPage;

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -35,6 +35,10 @@ NGitLab.GetCommitsRequest.PerPage.get -> uint
 NGitLab.GetCommitsRequest.PerPage.set -> void
 NGitLab.GetCommitsRequest.RefName.get -> string
 NGitLab.GetCommitsRequest.RefName.set -> void
+NGitLab.GetCommitsRequest.Since.get -> System.DateTime?
+NGitLab.GetCommitsRequest.Since.set -> void
+NGitLab.GetCommitsRequest.Until.get -> System.DateTime?
+NGitLab.GetCommitsRequest.Until.set -> void
 NGitLab.GitLabClient
 NGitLab.GitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.GitLabClient.Deployments.get -> NGitLab.IDeploymentClient


### PR DESCRIPTION
Implements the ability to use the _since_ and _until_ parameters when retrieving a list of commits.