### PR TITLE
Implements since and until parameters when retrieving commit list

### DIFF
--- a/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
@@ -140,7 +139,7 @@ namespace NGitLab.Tests.RepositoryClient
 
             var defaultBranch = context.Project.DefaultBranch;
             var since = DateTime.UtcNow;
-            var expectedSinceValue = WebUtility.UrlEncode(since.ToString("s", CultureInfo.InvariantCulture));
+            var expectedSinceValue = Uri.EscapeDataString(since.ToString("s", CultureInfo.InvariantCulture));
             var commitRequest = new GetCommitsRequest
             {
                 RefName = defaultBranch,
@@ -188,7 +187,7 @@ namespace NGitLab.Tests.RepositoryClient
 
             var defaultBranch = context.Project.DefaultBranch;
             var until = DateTime.UtcNow;
-            var expectedUntilValue = WebUtility.UrlEncode(until.ToString("s", CultureInfo.InvariantCulture));
+            var expectedUntilValue = Uri.EscapeDataString(until.ToString("s", CultureInfo.InvariantCulture));
             var commitRequest = new GetCommitsRequest
             {
                 RefName = defaultBranch,

--- a/NGitLab/GetCommitsRequest.cs
+++ b/NGitLab/GetCommitsRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace NGitLab
+﻿using System;
+
+namespace NGitLab
 {
     public class GetCommitsRequest
     {
@@ -13,5 +15,9 @@
         public int MaxResults { get; set; }
 
         public uint PerPage { get; set; } = DefaultPerPage;
+
+        public DateTime? Since { get; set; }
+
+        public DateTime? Until { get; set; }
     }
 }

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -83,6 +85,16 @@ namespace NGitLab.Impl
             if (request.FirstParent != null)
             {
                 lst.Add($"first_parent={Uri.EscapeDataString(request.FirstParent.ToString())}");
+            }
+
+            if (request.Since.HasValue)
+            {
+                lst.Add($"since={WebUtility.UrlEncode(request.Since.Value.ToString("s", CultureInfo.InvariantCulture))}");
+            }
+
+            if (request.Until.HasValue)
+            {
+                lst.Add($"until={WebUtility.UrlEncode(request.Until.Value.ToString("s", CultureInfo.InvariantCulture))}");
             }
 
             var perPage = request.MaxResults > 0 ? Math.Min(request.MaxResults, request.PerPage) : request.PerPage;

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -89,12 +88,12 @@ namespace NGitLab.Impl
 
             if (request.Since.HasValue)
             {
-                lst.Add($"since={WebUtility.UrlEncode(request.Since.Value.ToString("s", CultureInfo.InvariantCulture))}");
+                lst.Add($"since={Uri.EscapeDataString(request.Since.Value.ToString("s", CultureInfo.InvariantCulture))}");
             }
 
             if (request.Until.HasValue)
             {
-                lst.Add($"until={WebUtility.UrlEncode(request.Until.Value.ToString("s", CultureInfo.InvariantCulture))}");
+                lst.Add($"until={Uri.EscapeDataString(request.Until.Value.ToString("s", CultureInfo.InvariantCulture))}");
             }
 
             var perPage = request.MaxResults > 0 ? Math.Min(request.MaxResults, request.PerPage) : request.PerPage;

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -35,6 +35,10 @@ NGitLab.GetCommitsRequest.PerPage.get -> uint
 NGitLab.GetCommitsRequest.PerPage.set -> void
 NGitLab.GetCommitsRequest.RefName.get -> string
 NGitLab.GetCommitsRequest.RefName.set -> void
+NGitLab.GetCommitsRequest.Since.get -> System.DateTime?
+NGitLab.GetCommitsRequest.Since.set -> void
+NGitLab.GetCommitsRequest.Until.get -> System.DateTime?
+NGitLab.GetCommitsRequest.Until.set -> void
 NGitLab.GitLabClient
 NGitLab.GitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.GitLabClient.Deployments.get -> NGitLab.IDeploymentClient


### PR DESCRIPTION
This PR adds two new properties to the [GitCommitsRequest](https://github.com/ubisoft/NGitLab/pull/516/files#diff-40287b0782fbac6570425266f20834bfb7732ec77a218b1721d92024455e565a) class, _Since_ and _Until_. The purpose of this is to allow callers to retrieve a list of commits within a specified date range.

GitLab API reference for listing commits: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
