### PR TITLE
Support sub modules in mocks

### DIFF
--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -59,6 +59,28 @@ namespace NGitLab.Mock.Tests
         }
 
         [Test]
+        public void Test_project_with_nested_submodules()
+        {
+            using var tempDir = TemporaryDirectory.Create();
+            using var server = new GitLabConfig()
+                .WithUser("Test", isDefault: true)
+                .WithProject("ModuleA", configure: x => x.WithCommit(configure: c => c.WithFile("A.txt")))
+                .WithProject("ModuleB", configure: x => x.WithCommit(configure: c
+                                                                         => c.WithFile("B.txt")
+                                                                             .WithSubModule("ModuleA")))
+                .WithProject("Test", clonePath: tempDir.FullPath, configure: x =>
+                    x.WithCommit(configure: c
+                        => c.WithSubModule("ModuleB")))
+                .BuildServer();
+
+            Assert.IsTrue(Directory.Exists(tempDir.GetFullPath(".git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/.git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/A.txt")));
+        }
+
+        [Test]
         public void Test_projects_created_url_ends_with_namespace_and_name()
         {
             using var server = new GitLabConfig()

--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -38,6 +38,27 @@ namespace NGitLab.Mock.Tests
         }
 
         [Test]
+        public void Test_project_with_submodules()
+        {
+            using var tempDir = TemporaryDirectory.Create();
+            using var server = new GitLabConfig()
+                .WithUser("Test", isDefault: true)
+                .WithProject("ModuleA", configure: x => x.WithCommit(configure: c => c.WithFile("A.txt")))
+                .WithProject("ModuleB", configure: x => x.WithCommit(configure: c => c.WithFile("B.txt")))
+                .WithProject("Test", clonePath: tempDir.FullPath, configure: x =>
+                    x.WithCommit("Init", configure: c
+                        => c.WithSubModule("ModuleA")
+                            .WithSubModule("ModuleB")))
+                .BuildServer();
+
+            Assert.IsTrue(Directory.Exists(tempDir.GetFullPath(".git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/.git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/A.txt")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")));
+            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")));
+        }
+
+        [Test]
         public void Test_projects_created_url_ends_with_namespace_and_name()
         {
             using var server = new GitLabConfig()

--- a/NGitLab.Mock/Config/GitLabCommit.cs
+++ b/NGitLab.Mock/Config/GitLabCommit.cs
@@ -24,6 +24,11 @@ namespace NGitLab.Mock.Config
         /// </summary>
         public IList<GitLabFileDescriptor> Files { get; } = new List<GitLabFileDescriptor>();
 
+        /// <summary>
+        /// Submodules added at this commit
+        /// </summary>
+        public IList<GitLabSubModuleDescriptor> SubModules { get; } = new List<GitLabSubModuleDescriptor>();
+
         public IList<string> Tags { get; } = new List<string>();
 
         /// <summary>

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -1337,7 +1337,7 @@ namespace NGitLab.Mock.Config
                 }
 
                 using var process = Process.Start(
-                    new ProcessStartInfo("git", $"-c protocol.file.allow=always submodule add {subModuleProject.SshUrl} {subModuleProject.Name}")
+                    new ProcessStartInfo("git", $"-c protocol.file.allow=always submodule add \"{subModuleProject.SshUrl}\" \"{subModuleProject.Name}\"")
                     {
                         RedirectStandardError = true,
                         UseShellExecute = false,

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -1278,12 +1278,17 @@ namespace NGitLab.Mock.Config
                 using var process = Process.Start(
                     new ProcessStartInfo("git", $"-c protocol.file.allow=always submodule add {subModuleProject.SshUrl} {subModuleProject.Name}")
                     {
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
                         WorkingDirectory = prj.Repository.FullPath,
                     });
 
                 process.WaitForExit();
                 if (process.ExitCode != 0)
-                    throw new GitLabException("Cannot add submodule");
+                {
+                    var error = process.StandardError.ReadToEnd();
+                    throw new GitLabException($"Cannot add submodule: {error}");
+                }
 
                 submodules.Add(subModuleProject.Name);
             }

--- a/NGitLab.Mock/Config/GitLabSubModuleDescriptor.cs
+++ b/NGitLab.Mock/Config/GitLabSubModuleDescriptor.cs
@@ -1,0 +1,13 @@
+namespace NGitLab.Mock.Config
+{
+    /// <summary>
+    /// Describe a sub module in project repository
+    /// </summary>
+    public class GitLabSubModuleDescriptor
+    {
+        /// <summary>
+        /// Project's ID added as a submodule
+        /// </summary>
+        public string ProjectName { get; init; }
+    }
+}

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -124,6 +124,7 @@ NGitLab.Mock.Config.GitLabCommit.DeleteSourceBranch.get -> bool
 NGitLab.Mock.Config.GitLabCommit.DeleteSourceBranch.set -> void
 NGitLab.Mock.Config.GitLabCommit.FromBranch.get -> string
 NGitLab.Mock.Config.GitLabCommit.FromBranch.set -> void
+NGitLab.Mock.Config.GitLabCommit.SubModules.get -> System.Collections.Generic.IList<NGitLab.Mock.Config.GitLabSubModuleDescriptor>
 NGitLab.Mock.Config.GitLabConfig.DefaultBranch.get -> string
 NGitLab.Mock.Config.GitLabConfig.DefaultBranch.set -> void
 NGitLab.Mock.Config.GitLabConfig.DefaultUser.get -> string
@@ -207,6 +208,10 @@ NGitLab.Mock.Config.GitLabReleaseInfo.ReleasedAt.set -> void
 NGitLab.Mock.Config.GitLabReleaseInfo.TagName.get -> string
 NGitLab.Mock.Config.GitLabReleaseInfo.TagName.set -> void
 NGitLab.Mock.Config.GitLabReleaseInfoCollection
+NGitLab.Mock.Config.GitLabSubModuleDescriptor
+NGitLab.Mock.Config.GitLabSubModuleDescriptor.GitLabSubModuleDescriptor() -> void
+NGitLab.Mock.Config.GitLabSubModuleDescriptor.ProjectName.get -> string
+NGitLab.Mock.Config.GitLabSubModuleDescriptor.ProjectName.init -> void
 NGitLab.Mock.EffectivePermissions
 NGitLab.Mock.EffectivePermissions.GetAccessLevel(NGitLab.Mock.User user) -> NGitLab.Models.AccessLevel?
 NGitLab.Mock.EffectivePermissions.GetEffectivePermission(NGitLab.Mock.User user) -> NGitLab.Mock.EffectiveUserPermission
@@ -945,6 +950,7 @@ NGitLab.Mock.Repository.Checkout(string committishOrBranchNameSpec) -> void
 NGitLab.Mock.Repository.CherryPick(NGitLab.Models.CommitCherryPick commitCherryPick) -> LibGit2Sharp.Commit
 NGitLab.Mock.Repository.Commit(NGitLab.Mock.User user, string message) -> LibGit2Sharp.Commit
 NGitLab.Mock.Repository.Commit(NGitLab.Mock.User user, string message, string targetBranch, System.Collections.Generic.IEnumerable<NGitLab.Mock.File> files) -> LibGit2Sharp.Commit
+NGitLab.Mock.Repository.Commit(NGitLab.Mock.User user, string message, string targetBranch, System.Collections.Generic.IEnumerable<NGitLab.Mock.File> files, System.Collections.Generic.IEnumerable<string> submodules) -> LibGit2Sharp.Commit
 NGitLab.Mock.Repository.Commit(NGitLab.Mock.User user, string message, System.Collections.Generic.IEnumerable<NGitLab.Mock.File> files) -> LibGit2Sharp.Commit
 NGitLab.Mock.Repository.Commit(NGitLab.Models.CommitCreate commitCreate) -> LibGit2Sharp.Commit
 NGitLab.Mock.Repository.CreateAndCheckoutBranch(string branchName) -> LibGit2Sharp.Branch
@@ -1216,6 +1222,7 @@ static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.
 static NGitLab.Mock.Config.GitLabHelpers.WithPipeline(this NGitLab.Mock.Config.GitLabProject project, string ref, System.Action<NGitLab.Mock.Config.GitLabPipeline> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithRelease(this NGitLab.Mock.Config.GitLabProject project, string author, string tagName, System.DateTime? createdAt = null, System.DateTime? releasedAt = null) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithSubModule(this NGitLab.Mock.Config.GitLabCommit commit, string projectName) -> NGitLab.Mock.Config.GitLabCommit
 static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabIssue
 static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithUser(this NGitLab.Mock.Config.GitLabConfig config, string username, string name = null, string email = null, string avatarUrl = null, bool isAdmin = false, bool isDefault = false, System.Action<NGitLab.Mock.Config.GitLabUser> configure = null) -> NGitLab.Mock.Config.GitLabConfig

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -157,7 +157,7 @@ namespace NGitLab.Mock
 
         public Commit Commit(User user, string message)
         {
-            return Commit(user, message, targetBranch: null, new[] { File.CreateFromText("test.txt", Guid.NewGuid().ToString()) });
+            return Commit(user, message, targetBranch: null, new[] { File.CreateFromText("test.txt", Guid.NewGuid().ToString()) }, Enumerable.Empty<string>());
         }
 
         public Commit Commit(User user, string message, IEnumerable<File> files)
@@ -166,6 +166,11 @@ namespace NGitLab.Mock
         }
 
         public Commit Commit(User user, string message, string targetBranch, IEnumerable<File> files)
+        {
+            return Commit(user, message, targetBranch, files, Enumerable.Empty<string>());
+        }
+
+        public Commit Commit(User user, string message, string targetBranch, IEnumerable<File> files, IEnumerable<string> submodules)
         {
             var repository = GetGitRepository();
             if (targetBranch != null)
@@ -179,6 +184,11 @@ namespace NGitLab.Mock
                 Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
                 System.IO.File.WriteAllBytes(fullPath, file.Content);
                 repository.Index.Add(file.Path);
+            }
+
+            foreach (var submodule in submodules)
+            {
+                repository.Index.Add(submodule);
             }
 
             repository.Index.Write();


### PR DESCRIPTION
NB:
- LibGit2Sharp does not support adding sub modules, using git command line instead (see https://github.com/libgit2/libgit2sharp/pull/1501)
- `-c protocol.file.allow=always` is needed as otherwise we get `git fatal: transport 'file' not allowed`