### PR TITLE
Remove the default `target_project_id` when creating merge request

### DIFF
--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -11,13 +11,11 @@ namespace NGitLab.Impl
     public class MergeRequestClient : IMergeRequestClient
     {
         private readonly API _api;
-        private readonly int _projectId;
         private readonly string _projectPath;
 
         public MergeRequestClient(API api, int projectId)
         {
             _api = api;
-            _projectId = projectId;
             _projectPath = Project.Url + "/" + projectId.ToStringInvariant();
         }
 
@@ -88,8 +86,6 @@ namespace NGitLab.Impl
         {
             if (mergeRequest == null)
                 throw new ArgumentNullException(nameof(mergeRequest));
-
-            mergeRequest.TargetProjectId ??= _projectId;
 
             return _api
                 .Post().With(mergeRequest)


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/merge_requests.html#create-mr

Attribute `target_project_id` is not required. GitLab will create the merge request for the current project by default. (It's already specified in the URL)

I removed the redundant codes to get ready for a new feature that supports the string type `projectId` for each client in NGitLab (includes `MergeRequestClient`, `IssueClient`, and so on).

I will open the pull request for the new feature as soon as possible after this pull request has merged.