### PR TITLE
Add TimeStatsAsync to MergeRequestClient

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -675,6 +675,11 @@ namespace NGitLab.Mock.Clients
             throw new NotImplementedException();
         }
 
+        public Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public IMergeRequestDiscussionClient Discussions(int mergeRequestIid)
         {
             AssertProjectId();

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -675,7 +675,7 @@ namespace NGitLab.Mock.Clients
             throw new NotImplementedException();
         }
 
-        public Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default)
+        public Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -66,6 +66,7 @@ namespace NGitLab
         /// <returns>The time tracking statistics of the merge request.</returns>
         Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default);
 
+        /// <summary>
         /// Gets the resource label events.
         ///
         /// url like GET /projects/:id/merge_requests/:merge_request_iid/resource_label_events

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -62,9 +62,8 @@ namespace NGitLab
         /// <summary>
         /// Get time tracking statistics
         /// </summary>
-        /// <param name="projectId">The project id.</param>
         /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
         /// <returns>The time tracking statistics of the merge request.</returns>
-        Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default);
+        Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default);
     }
 }

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -58,5 +58,13 @@ namespace NGitLab
         IMergeRequestApprovalClient ApprovalClient(int mergeRequestIid);
 
         IEnumerable<Issue> ClosesIssues(int mergeRequestIid);
+
+        /// <summary>
+        /// Get time tracking statistics
+        /// </summary>
+        /// <param name="projectId">The project id.</param>
+        /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
+        /// <returns>The time tracking statistics of the merge request.</returns>
+        Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default);
     }
 }

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -10,6 +10,8 @@ namespace NGitLab.Impl
 {
     public class MergeRequestClient : IMergeRequestClient
     {
+        private const string TimeStatsUrl = "/projects/{0}/merge_requests/{1}/time_stats";
+
         private readonly API _api;
         private readonly string _projectPath;
 
@@ -150,6 +152,11 @@ namespace NGitLab.Impl
         public GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(int mergeRequestIid)
         {
             return _api.Get().GetAllAsync<MergeRequestVersion>(_projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions");
+        }
+
+        public Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default)
+        {
+            return _api.Get().ToAsync<TimeStats>(string.Format(CultureInfo.InvariantCulture, TimeStatsUrl, projectId, mergeRequestIid), cancellationToken);
         }
 
         public IMergeRequestCommentClient Comments(int mergeRequestIid) => new MergeRequestCommentClient(_api, _projectPath, mergeRequestIid);

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -10,8 +10,6 @@ namespace NGitLab.Impl
 {
     public class MergeRequestClient : IMergeRequestClient
     {
-        private const string TimeStatsUrl = "/projects/{0}/merge_requests/{1}/time_stats";
-
         private readonly API _api;
         private readonly string _projectPath;
 
@@ -154,9 +152,9 @@ namespace NGitLab.Impl
             return _api.Get().GetAllAsync<MergeRequestVersion>(_projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions");
         }
 
-        public Task<TimeStats> TimeStatsAsync(int projectId, int mergeRequestIid, CancellationToken cancellationToken = default)
+        public Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default)
         {
-            return _api.Get().ToAsync<TimeStats>(string.Format(CultureInfo.InvariantCulture, TimeStatsUrl, projectId, mergeRequestIid), cancellationToken);
+            return _api.Get().ToAsync<TimeStats>(_projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/time_stats", cancellationToken);
         }
 
         public IMergeRequestCommentClient Comments(int mergeRequestIid) => new MergeRequestCommentClient(_api, _projectPath, mergeRequestIid);

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -354,7 +354,7 @@ NGitLab.IMergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.Rebase
 NGitLab.IMergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
 NGitLab.IMergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.TimeStatsAsync(int projectId, int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.IMergeRequestClient.TimeStatsAsync(int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
 NGitLab.IMergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestCommentClient
 NGitLab.IMergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment
@@ -616,7 +616,7 @@ NGitLab.Impl.MergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.Re
 NGitLab.Impl.MergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
 NGitLab.Impl.MergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.TimeStatsAsync(int projectId, int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.Impl.MergeRequestClient.TimeStatsAsync(int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
 NGitLab.Impl.MergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestCommentClient
 NGitLab.Impl.MergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -354,6 +354,7 @@ NGitLab.IMergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.Rebase
 NGitLab.IMergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
 NGitLab.IMergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.TimeStatsAsync(int projectId, int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
 NGitLab.IMergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestCommentClient
 NGitLab.IMergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment
@@ -615,6 +616,7 @@ NGitLab.Impl.MergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.Re
 NGitLab.Impl.MergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
 NGitLab.Impl.MergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.TimeStatsAsync(int projectId, int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
 NGitLab.Impl.MergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestCommentClient
 NGitLab.Impl.MergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment


### PR DESCRIPTION
Adds `TimeStatsAsync` to `MergeRequestClient` allowing fetching time stats for merge requests via

```csharp
var timestats = await _gitLabClient.MergeRequests.TimeStatsAsync(mergeRequest.ProjectId, mergeRequest.Iid, CancellationToken.None);
```

Closes #538 