### PR TITLE
Replace recent [Obsolete] additions with [EditorBrowsable]

### DIFF
--- a/NGitLab/IGitLabClient.cs
+++ b/NGitLab/IGitLabClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab
@@ -85,7 +84,7 @@ namespace NGitLab
 
         IMilestoneClient GetMilestone(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as groupId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IMilestoneClient GetGroupMilestone(int groupId);
 
         IMilestoneClient GetGroupMilestone(GroupId groupId);
@@ -138,7 +137,7 @@ namespace NGitLab
 
         IProjectBadgeClient GetProjectBadgeClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as groupId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IGroupBadgeClient GetGroupBadgeClient(int groupId);
 
         IGroupBadgeClient GetGroupBadgeClient(GroupId groupId);
@@ -148,7 +147,7 @@ namespace NGitLab
 
         IProjectVariableClient GetProjectVariableClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as groupId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IGroupVariableClient GetGroupVariableClient(int groupId);
 
         IGroupVariableClient GetGroupVariableClient(GroupId groupId);
@@ -163,7 +162,7 @@ namespace NGitLab
 
         IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as groupId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ISearchClient GetGroupSearchClient(int groupId);
 
         public ISearchClient GetGroupSearchClient(GroupId groupId);

--- a/NGitLab/IGitLabClient.cs
+++ b/NGitLab/IGitLabClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab
@@ -36,7 +37,7 @@ namespace NGitLab
         /// <summary>
         /// Returns the events that occurred in the specified project.
         /// </summary>
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IEventClient GetProjectEvents(int projectId);
 
         /// <summary>
@@ -44,42 +45,42 @@ namespace NGitLab
         /// </summary>
         IEventClient GetProjectEvents(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IRepositoryClient GetRepository(int projectId);
 
         IRepositoryClient GetRepository(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         ICommitClient GetCommits(int projectId);
 
         ICommitClient GetCommits(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         ICommitStatusClient GetCommitStatus(int projectId);
 
         ICommitStatusClient GetCommitStatus(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IPipelineClient GetPipelines(int projectId);
 
         IPipelineClient GetPipelines(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         ITriggerClient GetTriggers(int projectId);
 
         ITriggerClient GetTriggers(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IJobClient GetJobs(int projectId);
 
         IJobClient GetJobs(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IMergeRequestClient GetMergeRequest(int projectId);
 
         IMergeRequestClient GetMergeRequest(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IMilestoneClient GetMilestone(int projectId);
 
         IMilestoneClient GetMilestone(ProjectId projectId);
@@ -89,7 +90,7 @@ namespace NGitLab
 
         IMilestoneClient GetGroupMilestone(GroupId groupId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IReleaseClient GetReleases(int projectId);
 
         IReleaseClient GetReleases(ProjectId projectId);
@@ -112,27 +113,27 @@ namespace NGitLab
 
         ISearchClient AdvancedSearch { get; }
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IProjectIssueNoteClient GetProjectIssueNoteClient(int projectId);
 
         IProjectIssueNoteClient GetProjectIssueNoteClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IEnvironmentClient GetEnvironmentClient(int projectId);
 
         IEnvironmentClient GetEnvironmentClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IClusterClient GetClusterClient(int projectId);
 
         IClusterClient GetClusterClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IWikiClient GetWikiClient(int projectId);
 
         IWikiClient GetWikiClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IProjectBadgeClient GetProjectBadgeClient(int projectId);
 
         IProjectBadgeClient GetProjectBadgeClient(ProjectId projectId);
@@ -142,7 +143,7 @@ namespace NGitLab
 
         IGroupBadgeClient GetGroupBadgeClient(GroupId groupId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IProjectVariableClient GetProjectVariableClient(int projectId);
 
         IProjectVariableClient GetProjectVariableClient(ProjectId projectId);
@@ -152,12 +153,12 @@ namespace NGitLab
 
         IGroupVariableClient GetGroupVariableClient(GroupId groupId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(int projectId);
 
         IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(ProjectId projectId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         IProtectedBranchClient GetProtectedBranchClient(int projectId);
 
         IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId);
@@ -167,7 +168,7 @@ namespace NGitLab
 
         public ISearchClient GetGroupSearchClient(GroupId groupId);
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ISearchClient GetProjectSearchClient(int projectId);
 
         public ISearchClient GetProjectSearchClient(ProjectId projectId);

--- a/NGitLab/Impl/ClusterClient.cs
+++ b/NGitLab/Impl/ClusterClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl
@@ -9,7 +9,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _environmentsPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ClusterClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/CommitClient.cs
+++ b/NGitLab/Impl/CommitClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Net;
 using NGitLab.Models;
 
@@ -9,7 +10,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _repoPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CommitClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/CommitStatusClient.cs
+++ b/NGitLab/Impl/CommitStatusClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl
@@ -10,7 +10,7 @@ namespace NGitLab.Impl
         private readonly string _statusCreatePath;
         private readonly string _statusPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public CommitStatusClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/EnvironmentClient.cs
+++ b/NGitLab/Impl/EnvironmentClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Extensions;
@@ -12,7 +13,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _environmentsPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public EnvironmentClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/JobClient.cs
+++ b/NGitLab/Impl/JobClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _jobsPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public JobClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ namespace NGitLab.Impl
         private readonly string _projectPath;
         private readonly API _api;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public MergeRequestClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -15,7 +16,7 @@ namespace NGitLab.Impl
         private readonly string _projectPath;
         private readonly string _pipelinesPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public PipelineClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/ProjectIssueNoteClient.cs
+++ b/NGitLab/Impl/ProjectIssueNoteClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl
@@ -12,7 +12,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _projectId;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProjectIssueNoteClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/ProjectLevelApprovalRulesClient.cs
+++ b/NGitLab/Impl/ProjectLevelApprovalRulesClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -10,7 +10,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _approvalRulesUrl;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ProjectLevelApprovalRulesClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/ProtectedBranchClient.cs
+++ b/NGitLab/Impl/ProtectedBranchClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using NGitLab.Extensions;
 using NGitLab.Models;
 
 namespace NGitLab.Impl

--- a/NGitLab/Impl/ReleaseClient.cs
+++ b/NGitLab/Impl/ReleaseClient.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NGitLab.Extensions;
 using NGitLab.Models;
 
 namespace NGitLab.Impl

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace NGitLab.Impl
         private readonly string _repoPath;
         private readonly string _projectPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public RepositoryClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/TriggerClient.cs
+++ b/NGitLab/Impl/TriggerClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -10,7 +10,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _triggersPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TriggerClient(API api, int projectId)
             : this(api, (long)projectId)
         {

--- a/NGitLab/Impl/WikiClient.cs
+++ b/NGitLab/Impl/WikiClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Net;
 using NGitLab.Models;
 
@@ -10,7 +11,7 @@ namespace NGitLab.Impl
         private readonly API _api;
         private readonly string _projectPath;
 
-        [Obsolete("Use long or namespaced path string as projectId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public WikiClient(API api, int projectId)
             : this(api, (long)projectId)
         {


### PR DESCRIPTION
Recent changes to deprecate `int` project IDs in the API in favor of `long` IDs may result in several warnings in consuming projects. This is notably true because `NGitLab.Models.Project.Id` is still an `int`...

To reduce the noise for now, replace  
`[Obsolete("Use long or namespaced path string as projectId instead.")]`  
with  
`[EditorBrowsable(EditorBrowsableState.Never)]`