### PR TITLE
Add runner registration/delete mock

### DIFF
--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -71,7 +71,7 @@ namespace NGitLab.Mock.Clients
 
                 if (projects.Take(2).Count() > 1)
                 {
-                    throw new GitLabException("Bad Request. Runner is enabled in multiple projects");
+                    throw new GitLabBadRequestException("Runner is enabled in multiple projects");
                 }
 
                 var project = GetProject(projects.Single().Id, ProjectPermission.Edit);

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -69,7 +69,7 @@ namespace NGitLab.Mock.Clients
                     throw new GitLabBadRequestException("Runner is not found in any project");
                 }
 
-                if (projects.Take(2).Count() > 1)
+                if (projects.Skip(1).Any())
                 {
                     throw new GitLabBadRequestException("Runner is enabled in multiple projects");
                 }
@@ -142,7 +142,7 @@ namespace NGitLab.Mock.Clients
 
                 if (project.EnabledRunners.Contains(runnerReference))
                 {
-                    throw new GitLabException("Bad Request. Runner has already been taken");
+                    throw new GitLabBadRequestException("Runner has already been taken");
                 }
 
                 project.EnabledRunners.Add(runnerReference);

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -190,7 +190,7 @@ namespace NGitLab.Mock.Clients
         {
             using (Context.BeginOperationScope())
             {
-                var project = Server.AllProjects.SingleOrDefault(p => p.RunnersToken == request.Token);
+                var project = Server.AllProjects.SingleOrDefault(p => string.Equals(p.RunnersToken, request.Token, StringComparison.Ordinal));
                 var runner = project.AddRunner(null, request.Description, request.Active ?? false, request.Locked ?? true, false, request.RunUntagged ?? false);
                 return runner.ToClientRunner(Context.User);
             }

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -66,7 +66,7 @@ namespace NGitLab.Mock.Clients
                 var projects = Server.AllProjects.Where(p => p.EnabledRunners.Any(r => r.Id == runnerId));
                 if (!projects.Any())
                 {
-                    throw new GitLabException("Bad Request. Runner is not found in any project");
+                    throw new GitLabBadRequestException("Runner is not found in any project");
                 }
 
                 if (projects.Take(2).Count() > 1)

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -27,6 +27,7 @@ namespace NGitLab.Mock
         private int _lastResourceLabelEventId = 10000;
         private int _lastResourceMilestoneEventId = 10000;
         private int _lastResourceStateEventId = 10000;
+        private int _lastTokenId = 10000;
 
         public event EventHandler ClientOperation;
 
@@ -130,9 +131,21 @@ namespace NGitLab.Mock
 
         internal int GetNewResourceStateEventId() => Interlocked.Increment(ref _lastResourceStateEventId);
 
+        internal string GetNewRunnerToken() => MakeToken(Convert.ToString(Interlocked.Increment(ref _lastTokenId)));
+
         internal string MakeUrl(string relativeUrl)
         {
             return new Uri(Url, relativeUrl).AbsoluteUri;
+        }
+
+        internal string MakeToken(string id, string prefix = "")
+        {
+            return prefix + id.PadLeft(20, '0');
+        }
+
+        internal string MakeRegistrationToken()
+        {
+            return MakeToken("GR1348941");
         }
 
         internal void RaiseOnClientOperation()

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -28,6 +28,7 @@ namespace NGitLab.Mock
         private int _lastResourceMilestoneEventId = 10000;
         private int _lastResourceStateEventId = 10000;
         private int _lastTokenId = 10000;
+        private int _lastRegistrationTokenId = 10000;
 
         public event EventHandler ClientOperation;
 
@@ -133,6 +134,8 @@ namespace NGitLab.Mock
 
         internal string GetNewRunnerToken() => MakeToken(Convert.ToString(Interlocked.Increment(ref _lastTokenId)));
 
+        internal string GetNewRegistrationToken() => MakeRegistrationToken(Convert.ToString(Interlocked.Increment(ref _lastRegistrationTokenId)));
+
         internal string MakeUrl(string relativeUrl)
         {
             return new Uri(Url, relativeUrl).AbsoluteUri;
@@ -143,9 +146,9 @@ namespace NGitLab.Mock
             return prefix + id.PadLeft(20, '0');
         }
 
-        internal string MakeRegistrationToken()
+        internal string MakeRegistrationToken(string id)
         {
-            return MakeToken("GR1348941");
+            return MakeToken(id, "GR1348941");
         }
 
         internal void RaiseOnClientOperation()

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -141,13 +141,14 @@ namespace NGitLab.Mock
             return new Uri(Url, relativeUrl).AbsoluteUri;
         }
 
-        internal string MakeToken(string id, string prefix = "")
+        internal static string MakeToken(string id, string prefix = "")
         {
             return prefix + id.PadLeft(20, '0');
         }
 
-        internal string MakeRegistrationToken(string id)
+        internal static string MakeRegistrationToken(string id)
         {
+            // Prefix is hardcoded: https://gitlab.com/gitlab-org/gitlab/-/issues/388379
             return MakeToken(id, "GR1348941");
         }
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -33,7 +33,6 @@ namespace NGitLab.Mock
             Releases = new ReleaseCollection(this);
             ProtectedBranches = new ProtectedBranchCollection(this);
             ApprovalsBeforeMerge = 0;
-            RunnersToken = Server.MakeRegistrationToken();
         }
 
         public int Id { get; set; }
@@ -150,7 +149,7 @@ namespace NGitLab.Mock
 
         public ProtectedBranchCollection ProtectedBranches { get; }
 
-        public string RunnersToken { get; }
+        public string RunnersToken { get; set; }
 
         public void Remove()
         {

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -33,6 +33,7 @@ namespace NGitLab.Mock
             Releases = new ReleaseCollection(this);
             ProtectedBranches = new ProtectedBranchCollection(this);
             ApprovalsBeforeMerge = 0;
+            RunnersToken = Server.MakeRegistrationToken();
         }
 
         public int Id { get; set; }
@@ -148,6 +149,8 @@ namespace NGitLab.Mock
         public ProjectStatistics Statistics { get; set; }
 
         public ProtectedBranchCollection ProtectedBranches { get; }
+
+        public string RunnersToken { get; }
 
         public void Remove()
         {
@@ -345,6 +348,11 @@ namespace NGitLab.Mock
             return mr;
         }
 
+        public bool RemoveRunner(int runnerId)
+        {
+            return RegisteredRunners.Remove(runnerId);
+        }
+
         public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, int id)
         {
             var runner = new Runner
@@ -372,6 +380,11 @@ namespace NGitLab.Mock
         public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared)
         {
             return AddRunner(name, description, active, locked, isShared, runUntagged: false, default);
+        }
+
+        public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged)
+        {
+            return AddRunner(name, description, active, locked, isShared, runUntagged, default);
         }
 
         public Project Fork(User user)

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -149,7 +149,7 @@ namespace NGitLab.Mock
 
         public ProtectedBranchCollection ProtectedBranches { get; }
 
-        public string RunnersToken { get; set; }
+        public string RunnersToken { get; internal set; }
 
         public void Remove()
         {

--- a/NGitLab.Mock/ProjectCollection.cs
+++ b/NGitLab.Mock/ProjectCollection.cs
@@ -32,6 +32,8 @@ namespace NGitLab.Mock
                 project.Id = Server.GetNewProjectId();
             }
 
+            project.RunnersToken ??= Server.GetNewRegistrationToken();
+
             base.Add(project);
         }
     }

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -864,7 +864,6 @@ NGitLab.Mock.Project.Repository.get -> NGitLab.Mock.Repository
 NGitLab.Mock.Project.RepositoryAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Project.RepositoryAccessLevel.set -> void
 NGitLab.Mock.Project.RunnersToken.get -> string
-NGitLab.Mock.Project.RunnersToken.set -> void
 NGitLab.Mock.Project.SshUrl.get -> string
 NGitLab.Mock.Project.Statistics.get -> NGitLab.Models.ProjectStatistics
 NGitLab.Mock.Project.Statistics.set -> void

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -785,6 +785,7 @@ NGitLab.Mock.Project
 NGitLab.Mock.Project.AccessibleMergeRequests.get -> bool
 NGitLab.Mock.Project.AccessibleMergeRequests.set -> void
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared) -> NGitLab.Mock.Runner
+NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, int id) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.get -> bool
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.set -> void
@@ -858,9 +859,11 @@ NGitLab.Mock.Project.ProtectedBranches.get -> NGitLab.Mock.ProtectedBranchCollec
 NGitLab.Mock.Project.RegisteredRunners.get -> NGitLab.Mock.RunnerCollection
 NGitLab.Mock.Project.Releases.get -> NGitLab.Mock.ReleaseCollection
 NGitLab.Mock.Project.Remove() -> void
+NGitLab.Mock.Project.RemoveRunner(int runnerId) -> bool
 NGitLab.Mock.Project.Repository.get -> NGitLab.Mock.Repository
 NGitLab.Mock.Project.RepositoryAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Project.RepositoryAccessLevel.set -> void
+NGitLab.Mock.Project.RunnersToken.get -> string
 NGitLab.Mock.Project.SshUrl.get -> string
 NGitLab.Mock.Project.Statistics.get -> NGitLab.Models.ProjectStatistics
 NGitLab.Mock.Project.Statistics.set -> void
@@ -1085,6 +1088,7 @@ NGitLab.Mock.Runner.Token.set -> void
 NGitLab.Mock.Runner.Version.get -> string
 NGitLab.Mock.Runner.Version.set -> void
 NGitLab.Mock.RunnerCollection
+NGitLab.Mock.RunnerCollection.Remove(int id) -> bool
 NGitLab.Mock.RunnerCollection.RunnerCollection(NGitLab.Mock.Project parent) -> void
 NGitLab.Mock.RunnerRef
 NGitLab.Mock.RunnerRef.Id.get -> int

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -864,6 +864,7 @@ NGitLab.Mock.Project.Repository.get -> NGitLab.Mock.Repository
 NGitLab.Mock.Project.RepositoryAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Project.RepositoryAccessLevel.set -> void
 NGitLab.Mock.Project.RunnersToken.get -> string
+NGitLab.Mock.Project.RunnersToken.set -> void
 NGitLab.Mock.Project.SshUrl.get -> string
 NGitLab.Mock.Project.Statistics.get -> NGitLab.Models.ProjectStatistics
 NGitLab.Mock.Project.Statistics.set -> void

--- a/NGitLab.Mock/RunnerCollection.cs
+++ b/NGitLab.Mock/RunnerCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace NGitLab.Mock
 {
@@ -22,7 +23,15 @@ namespace NGitLab.Mock
                 item.Id = Server.GetNewRunnerId();
             }
 
+            item.Token ??= Server.GetNewRunnerToken();
+
             base.Add(item);
+        }
+
+        public bool Remove(int id)
+        {
+            var r = this.SingleOrDefault(r => r.Id == id);
+            return Remove(r);
         }
     }
 }


### PR DESCRIPTION
We implemented the Register/Delete logic for the runner in the NGitLab Mock project. We needed these to unit test some use cases of runner registration.

We added the token registration properties in the project even though we are aware that it will be soon removed from the API : https://docs.gitlab.com/runner/register/#register-with-a-runner-registration-token-deprecated

