### PR TITLE
Put Microsoft NuGet packages into their own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,8 @@ updates:
       interval: weekly
     rebase-strategy: auto
     open-pull-requests-limit: 20
+    groups:
+      ms-dependencies:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"


### PR DESCRIPTION
Recent publishing of `System.*` and `Microsoft.*` NuGet packages for .NET 8 has resulted in way too many dependabot PRs...

The grouping of those packages should result, the next time around, into a single PR.