### PR TITLE
Fix SHA1 comparison in mock that used case-sensitive string comparison

### DIFF
--- a/NGitLab.Mock/Clients/LibGit2SharpExtensions.cs
+++ b/NGitLab.Mock/Clients/LibGit2SharpExtensions.cs
@@ -9,7 +9,7 @@ namespace NGitLab.Mock.Clients
     {
         public static Commit ToCommitClient(this LibGit2Sharp.Commit commit, Project project)
         {
-            var commitInfo = project.CommitInfos.SingleOrDefault(c => string.Equals(c.Sha, commit.Sha, StringComparison.Ordinal));
+            var commitInfo = project.CommitInfos.SingleOrDefault(c => string.Equals(c.Sha, commit.Sha, StringComparison.OrdinalIgnoreCase));
             return new Commit
             {
                 AuthoredDate = commit.Author.When.UtcDateTime,

--- a/NGitLab.Mock/Clients/LibGit2SharpExtensions.cs
+++ b/NGitLab.Mock/Clients/LibGit2SharpExtensions.cs
@@ -9,7 +9,8 @@ namespace NGitLab.Mock.Clients
     {
         public static Commit ToCommitClient(this LibGit2Sharp.Commit commit, Project project)
         {
-            var commitInfo = project.CommitInfos.SingleOrDefault(c => string.Equals(c.Sha, commit.Sha, StringComparison.OrdinalIgnoreCase));
+            var commitSha = new Sha1(commit.Sha);
+            var commitInfo = project.CommitInfos.SingleOrDefault(c => commitSha.Equals(new Sha1(c.Sha)));
             return new Commit
             {
                 AuthoredDate = commit.Author.When.UtcDateTime,


### PR DESCRIPTION
Use `Sha1` type to compare 2 SHA1s instead of strings