### PR TITLE
Fix adding the wrong scope parameter.

### DIFF
--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -84,7 +84,7 @@ namespace NGitLab.Impl
         private string CreateGetJobsUrl(PipelineJobQuery query)
         {
             var url = $"{_pipelinesPath}/{query.PipelineId.ToStringInvariant()}/jobs";
-            url = Utils.AddParameter(url, "scope", query.Scope);
+            url = Utils.AddArrayParameter(url, "scope", query.Scope);
             url = Utils.AddParameter(url, "include_retried", query.IncludeRetried);
             return url;
         }
@@ -213,7 +213,7 @@ namespace NGitLab.Impl
         private string CreateGetBridgesUrl(PipelineBridgeQuery query)
         {
             var url = $"{_pipelinesPath}/{query.PipelineId.ToStringInvariant()}/bridges";
-            url = Utils.AddParameter(url, "scope", query.Scope);
+            url = Utils.AddArrayParameter(url, "scope", query.Scope);
             return url;
         }
 

--- a/NGitLab/Impl/Utils.cs
+++ b/NGitLab/Impl/Utils.cs
@@ -29,6 +29,21 @@ namespace NGitLab.Impl
             return Equals(values, null) ? url : AddParameterInternal(url, parameterName, string.Join(",", values));
         }
 
+        public static string AddArrayParameter(string url, string parameterName, string[] values)
+        {
+            if (Equals(values, null))
+            {
+                return url;
+            }
+
+            foreach (var value in values)
+            {
+                url = AddParameterInternal(url, $"{parameterName}[]", value);
+            }
+
+            return url;
+        }
+
         public static string AddOrderBy(string url, string orderBy = null, bool supportKeysetPagination = true)
         {
             if (supportKeysetPagination && (string.IsNullOrEmpty(orderBy) || string.Equals(orderBy, "id", StringComparison.Ordinal)))


### PR DESCRIPTION
When using the `PipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query)` method, I encountered the following error:
```
NGitLab.GitLabException : GitLab server returned an error (BadRequest): scope does not have a valid value. Original call: Get http://localhost:48624/api/v4/projects/12/pipelines/11/jobs?scope=System.String%5B%5D
```

I resolved it by referring to the examples provided in the documentation:

- [List Pipeline Trigger Jobs](https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-trigger-jobs)
- [List Pipeline Jobs](https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs)