### PR TITLE
Add Merge Error field on Merge Request Model

### DIFF
--- a/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/Models/MergeRequest.cs
@@ -147,5 +147,8 @@ public class MergeRequest
     [JsonPropertyName("detailed_merge_status")]
     public DynamicEnum<DetailedMergeStatus> DetailedMergeStatus { get; set; }
 
+    [JsonPropertyName("merge_error")]
+    public string MergeError { get; set; }
+
     public override string ToString() => $"!{Id.ToStringInvariant()}: {Title}";
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2234,6 +2234,8 @@ NGitLab.Models.MergeRequest.Labels -> string[]
 NGitLab.Models.MergeRequest.MergeCommitSha -> string
 NGitLab.Models.MergeRequest.MergedAt -> System.DateTime?
 NGitLab.Models.MergeRequest.MergedBy -> NGitLab.Models.User
+NGitLab.Models.MergeRequest.MergeError.get -> string
+NGitLab.Models.MergeRequest.MergeError.set -> void
 NGitLab.Models.MergeRequest.MergeRequest() -> void
 NGitLab.Models.MergeRequest.MergeStatus -> string
 NGitLab.Models.MergeRequest.MergeWhenPipelineSucceeds -> bool


### PR DESCRIPTION
Adds the "merge_error" field, that gets field when rebasing / merging through the API fails for any reason

During a rebase through the API, it seems to be the only field indicating that the rebase request has failed: [Documentation](https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request)