### PR TITLE
Improve NUnit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -260,6 +260,9 @@ dotnet_diagnostic.SA1101.severity = none
 # SA1116: Split parameters should start on line after declaration
 dotnet_diagnostic.SA1116.severity = silent
 
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = suggestion
+
 # SA1122: Use string.Empty for empty strings
 dotnet_diagnostic.SA1122.severity = none
 

--- a/NGitLab.Mock.Tests/BranchesMockTests.cs
+++ b/NGitLab.Mock.Tests/BranchesMockTests.cs
@@ -21,22 +21,22 @@ namespace NGitLab.Mock.Tests
 
             var branches = branchClient.Search("main").ToList();
             var expectedBranch = branches.Single();
-            Assert.AreEqual("main", expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo("main"));
 
             branches = branchClient.Search("^main$").ToList();
             expectedBranch = branches.Single();
-            Assert.AreEqual("main", expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo("main"));
 
             branches = branchClient.Search("^branch").ToList();
             expectedBranch = branches.Single();
-            Assert.AreEqual("branch_1", expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo("branch_1"));
 
             branches = branchClient.Search("1$").ToList();
             expectedBranch = branches.Single();
-            Assert.AreEqual("branch_1", expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo("branch_1"));
 
             branches = branchClient.Search("foobar").ToList();
-            Assert.IsEmpty(branches);
+            Assert.That(branches, Is.Empty);
         }
     }
 }

--- a/NGitLab.Mock.Tests/CommitsMockTests.cs
+++ b/NGitLab.Mock.Tests/CommitsMockTests.cs
@@ -20,7 +20,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var commit = client.GetCommits(1).GetCommit("branch-01");
 
-            Assert.AreEqual("Create branch", commit.Message.TrimEnd('\r', '\n'));
+            Assert.That(commit.Message.TrimEnd('\r', '\n'), Is.EqualTo("Create branch"));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var commit = client.GetCommits(1).GetCommit("1.0.0");
 
-            Assert.AreEqual("Changes with tag", commit.Message.TrimEnd('\r', '\n'));
+            Assert.That(commit.Message.TrimEnd('\r', '\n'), Is.EqualTo("Changes with tag"));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace NGitLab.Mock.Tests
             var tags = client.GetRepository(1).Tags.All.ToArray();
 
             Assert.That(tags, Has.One.Items);
-            Assert.AreEqual("1.0.0", tags[0].Name);
+            Assert.That(tags[0].Name, Is.EqualTo("1.0.0"));
         }
 
         [Test]
@@ -72,11 +72,11 @@ namespace NGitLab.Mock.Tests
             var commitFromBranch1 = repository.GetCommits("branch_1").FirstOrDefault();
             var commitFromBranch2 = repository.GetCommits("branch_2").FirstOrDefault();
 
-            Assert.NotNull(commitFromBranch1);
-            Assert.NotNull(commitFromBranch2);
-            Assert.IsNotEmpty(commitFromBranch1.Parents);
-            Assert.IsNotEmpty(commitFromBranch2.Parents);
-            Assert.AreEqual(commitFromBranch1.Parents[0], commitFromBranch2.Parents[0]);
+            Assert.That(commitFromBranch1, Is.Not.Null);
+            Assert.That(commitFromBranch2, Is.Not.Null);
+            Assert.That(commitFromBranch1.Parents, Is.Not.Empty);
+            Assert.That(commitFromBranch2.Parents, Is.Not.Empty);
+            Assert.That(commitFromBranch2.Parents[0], Is.EqualTo(commitFromBranch1.Parents[0]));
         }
 
         [Test]
@@ -98,11 +98,11 @@ namespace NGitLab.Mock.Tests
             var intermediateCommits = repository.GetCommits("main..branch_1");
 
             // Assert
-            CollectionAssert.AreEqual(new[]
+            Assert.That(intermediateCommits.Select(c => c.Title), Is.EqualTo(new[]
             {
                 "Yet another commit for branch_1",
                 "Commit for branch_1",
-            }, intermediateCommits.Select(c => c.Title));
+            }).AsCollection);
         }
 
         [Test]
@@ -118,14 +118,14 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var repository = client.GetRepository(1);
             var commitFromBranch1 = repository.GetCommits("branch_1").FirstOrDefault();
-            Assert.NotNull(commitFromBranch1);
+            Assert.That(commitFromBranch1, Is.Not.Null);
 
             var cherryPicked = client.GetCommits(1).CherryPick(new CommitCherryPick
             {
                 Sha = commitFromBranch1.Id,
                 Branch = "main",
             });
-            Assert.NotNull(cherryPicked);
+            Assert.That(cherryPicked, Is.Not.Null);
         }
     }
 }

--- a/NGitLab.Mock.Tests/ConfigTests.cs
+++ b/NGitLab.Mock.Tests/ConfigTests.cs
@@ -40,33 +40,33 @@ namespace NGitLab.Mock.Tests
             project.Permissions.Add(new Permission(user, AccessLevel.Owner));
 
             var config = server.ToConfig();
-            Assert.IsNotNull(config);
+            Assert.That(config, Is.Not.Null);
 
             Assert.That(config.Users, Has.One.Items);
-            Assert.AreEqual("user1", config.Users[0].Username);
+            Assert.That(config.Users[0].Username, Is.EqualTo("user1"));
             Assert.That(config.Groups, Has.One.Items);
-            Assert.AreEqual("unit-tests", config.Groups[0].Name);
+            Assert.That(config.Groups[0].Name, Is.EqualTo("unit-tests"));
             Assert.That(config.Projects, Has.One.Items);
-            Assert.AreEqual("test-project", config.Projects[0].Name);
-            Assert.AreEqual("unit-tests", config.Projects[0].Namespace);
-            Assert.AreEqual("Test project", config.Projects[0].Description);
-            Assert.AreEqual("default", config.Projects[0].DefaultBranch);
-            Assert.AreEqual(VisibilityLevel.Public, config.Projects[0].Visibility);
+            Assert.That(config.Projects[0].Name, Is.EqualTo("test-project"));
+            Assert.That(config.Projects[0].Namespace, Is.EqualTo("unit-tests"));
+            Assert.That(config.Projects[0].Description, Is.EqualTo("Test project"));
+            Assert.That(config.Projects[0].DefaultBranch, Is.EqualTo("default"));
+            Assert.That(config.Projects[0].Visibility, Is.EqualTo(VisibilityLevel.Public));
             Assert.That(config.Projects[0].Labels, Has.One.Items);
-            Assert.AreEqual("label1", config.Projects[0].Labels[0].Name);
+            Assert.That(config.Projects[0].Labels[0].Name, Is.EqualTo("label1"));
             Assert.That(config.Projects[0].Issues, Has.One.Items);
-            Assert.AreEqual("Issue #1", config.Projects[0].Issues[0].Title);
-            Assert.AreEqual("My issue", config.Projects[0].Issues[0].Description);
-            Assert.AreEqual("user1", config.Projects[0].Issues[0].Author);
+            Assert.That(config.Projects[0].Issues[0].Title, Is.EqualTo("Issue #1"));
+            Assert.That(config.Projects[0].Issues[0].Description, Is.EqualTo("My issue"));
+            Assert.That(config.Projects[0].Issues[0].Author, Is.EqualTo("user1"));
             Assert.That(config.Projects[0].Issues[0].Labels, Has.One.Items);
-            Assert.AreEqual("label1", config.Projects[0].Issues[0].Labels[0]);
+            Assert.That(config.Projects[0].Issues[0].Labels[0], Is.EqualTo("label1"));
             Assert.That(config.Projects[0].MergeRequests, Has.One.Items);
-            Assert.AreEqual("Merge request #1", config.Projects[0].MergeRequests[0].Title);
-            Assert.AreEqual("My merge request", config.Projects[0].MergeRequests[0].Description);
-            Assert.AreEqual("user1", config.Projects[0].MergeRequests[0].Author);
+            Assert.That(config.Projects[0].MergeRequests[0].Title, Is.EqualTo("Merge request #1"));
+            Assert.That(config.Projects[0].MergeRequests[0].Description, Is.EqualTo("My merge request"));
+            Assert.That(config.Projects[0].MergeRequests[0].Author, Is.EqualTo("user1"));
             Assert.That(config.Projects[0].Permissions, Has.One.Items);
-            Assert.AreEqual("user1", config.Projects[0].Permissions[0].User);
-            Assert.AreEqual(AccessLevel.Owner, config.Projects[0].Permissions[0].Level);
+            Assert.That(config.Projects[0].Permissions[0].User, Is.EqualTo("user1"));
+            Assert.That(config.Projects[0].Permissions[0].Level, Is.EqualTo(AccessLevel.Owner));
         }
 
         [Test]
@@ -84,30 +84,30 @@ namespace NGitLab.Mock.Tests
                 .WithProject("project-2");
 
             var content = config.Serialize();
-            Assert.IsNotEmpty(content);
+            Assert.That(content, Is.Not.Empty);
 
             var config2 = GitLabConfig.Deserialize(content);
-            Assert.IsNotNull(config2);
+            Assert.That(config2, Is.Not.Null);
 
             Assert.That(config2.Users, Has.One.Items);
-            Assert.AreEqual("user1", config2.Users[0].Username);
+            Assert.That(config2.Users[0].Username, Is.EqualTo("user1"));
             Assert.That(config2.Projects, Has.Exactly(2).Items);
-            Assert.AreEqual("project-1", config2.Projects[0].Name);
-            Assert.AreEqual("Project #1", config2.Projects[0].Description);
-            Assert.AreEqual(VisibilityLevel.Public, config2.Projects[0].Visibility);
+            Assert.That(config2.Projects[0].Name, Is.EqualTo("project-1"));
+            Assert.That(config2.Projects[0].Description, Is.EqualTo("Project #1"));
+            Assert.That(config2.Projects[0].Visibility, Is.EqualTo(VisibilityLevel.Public));
             Assert.That(config2.Projects[0].Commits, Has.Exactly(2).Items);
-            Assert.AreEqual("Initial commit", config2.Projects[0].Commits[0].Message);
-            Assert.AreEqual("Create branch", config2.Projects[0].Commits[1].Message);
+            Assert.That(config2.Projects[0].Commits[0].Message, Is.EqualTo("Initial commit"));
+            Assert.That(config2.Projects[0].Commits[1].Message, Is.EqualTo("Create branch"));
             Assert.That(config2.Projects[0].Issues, Has.One.Items);
-            Assert.AreEqual("Issue #1", config2.Projects[0].Issues[0].Title);
+            Assert.That(config2.Projects[0].Issues[0].Title, Is.EqualTo("Issue #1"));
             Assert.That(config2.Projects[0].MergeRequests, Has.One.Items);
-            Assert.AreEqual("Merge request #1", config2.Projects[0].MergeRequests[0].Title);
+            Assert.That(config2.Projects[0].MergeRequests[0].Title, Is.EqualTo("Merge request #1"));
             Assert.That(config2.Projects[0].Permissions, Has.One.Items);
-            Assert.AreEqual("user1", config2.Projects[0].Permissions[0].User);
-            Assert.AreEqual("project-2", config2.Projects[1].Name);
+            Assert.That(config2.Projects[0].Permissions[0].User, Is.EqualTo("user1"));
+            Assert.That(config2.Projects[1].Name, Is.EqualTo("project-2"));
 
             using var server = config2.BuildServer();
-            Assert.IsNotNull(server);
+            Assert.That(server, Is.Not.Null);
         }
 
         [Test]
@@ -125,15 +125,15 @@ namespace NGitLab.Mock.Tests
                         .WithPipeline("C1", p => p.WithJob().WithJob()));
 
             using var server = config.BuildServer();
-            Assert.IsNotNull(server);
+            Assert.That(server, Is.Not.Null);
 
             var project1 = server.AllProjects.FirstOrDefault();
-            Assert.IsNotNull(project1);
+            Assert.That(project1, Is.Not.Null);
 
             project1.Jobs.Should().BeEquivalentTo(new[] { new { Id = 1 }, new { Id = 2 }, new { Id = 3 } });
 
             var project2 = server.AllProjects.LastOrDefault();
-            Assert.IsNotNull(project2);
+            Assert.That(project2, Is.Not.Null);
 
             project2.Jobs.Should().BeEquivalentTo(new[] { new { Id = 4 }, new { Id = 5 } });
         }

--- a/NGitLab.Mock.Tests/GlobalUsings.cs
+++ b/NGitLab.Mock.Tests/GlobalUsings.cs
@@ -1,5 +1,0 @@
-﻿// This is needed for quick migration from NUnit 3.x -> 4.x
-// https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html#use-global-using-aliases
-global using Assert = NUnit.Framework.Legacy.ClassicAssert;
-global using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
-global using StringAssert = NUnit.Framework.Legacy.StringAssert;

--- a/NGitLab.Mock.Tests/GroupsMockTests.cs
+++ b/NGitLab.Mock.Tests/GroupsMockTests.cs
@@ -21,7 +21,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var group = await client.Groups.GetByIdAsync(1);
 
-            Assert.AreEqual("G1", group.Name, "Subgroups found are invalid");
+            Assert.That(group.Name, Is.EqualTo("G1"), "Subgroups found are invalid");
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var group = await client.Groups.GetByFullPathAsync("name3");
 
-            Assert.AreEqual("name3", group.FullPath, "Subgroups found are invalid");
+            Assert.That(group.FullPath, Is.EqualTo("name3"), "Subgroups found are invalid");
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var group = client.Groups.GetSubgroupsByIdAsync(12, new Models.SubgroupQuery { });
 
-            Assert.AreEqual(2, group.Count(), "Subgroups found are invalid");
+            Assert.That(group.Count(), Is.EqualTo(2), "Subgroups found are invalid");
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var group = client.Groups.GetSubgroupsByFullPathAsync("parentgroup1", new Models.SubgroupQuery { });
 
-            Assert.AreEqual(2, group.Count(), "Subgroups found are invalid");
+            Assert.That(group.Count(), Is.EqualTo(2), "Subgroups found are invalid");
         }
     }
 }

--- a/NGitLab.Mock.Tests/IssuesMockTests.cs
+++ b/NGitLab.Mock.Tests/IssuesMockTests.cs
@@ -21,8 +21,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var issues = client.Issues.Get(new IssueQuery { Scope = "created_by_me" }).ToArray();
 
-            Assert.AreEqual(1, issues.Length, "Issues count is invalid");
-            Assert.AreEqual("Issue 1", issues[0].Title, "Issue found is invalid");
+            Assert.That(issues, Has.Length.EqualTo(1), "Issues count is invalid");
+            Assert.That(issues[0].Title, Is.EqualTo("Issue 1"), "Issue found is invalid");
         }
 
         [Test]
@@ -39,8 +39,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var issues = client.Issues.Get(new IssueQuery { Scope = "assigned_to_me" }).ToArray();
 
-            Assert.AreEqual(1, issues.Length, "Issues count is invalid");
-            Assert.AreEqual("Issue 2", issues[0].Title, "Issue found is invalid");
+            Assert.That(issues, Has.Length.EqualTo(1), "Issues count is invalid");
+            Assert.That(issues[0].Title, Is.EqualTo("Issue 2"), "Issue found is invalid");
         }
 
         [Test]
@@ -68,8 +68,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
 
             var issue = client.Issues.GetById(10001);
-            Assert.AreEqual(5, issue.IssueId);
-            Assert.AreEqual("Issue title", issue.Title);
+            Assert.That(issue.IssueId, Is.EqualTo(5));
+            Assert.That(issue.Title, Is.EqualTo("Issue title"));
         }
 
         [Test]
@@ -102,16 +102,16 @@ namespace NGitLab.Mock.Tests
             });
 
             var resourceMilestoneEvents = issuesClient.ResourceMilestoneEvents(projectId: 1, issueIid: 5).ToList();
-            Assert.AreEqual(3, resourceMilestoneEvents.Count);
+            Assert.That(resourceMilestoneEvents, Has.Count.EqualTo(3));
 
             var removeMilestoneEvents = resourceMilestoneEvents.Where(e => e.Action == ResourceMilestoneEventAction.Remove).ToArray();
-            Assert.AreEqual(1, removeMilestoneEvents.Length);
-            Assert.AreEqual(1, removeMilestoneEvents[0].Milestone.Id);
+            Assert.That(removeMilestoneEvents, Has.Length.EqualTo(1));
+            Assert.That(removeMilestoneEvents[0].Milestone.Id, Is.EqualTo(1));
 
             var addMilestoneEvents = resourceMilestoneEvents.Where(e => e.Action == ResourceMilestoneEventAction.Add).ToArray();
-            Assert.AreEqual(2, addMilestoneEvents.Length);
-            Assert.AreEqual(1, addMilestoneEvents[0].Milestone.Id);
-            Assert.AreEqual(2, addMilestoneEvents[1].Milestone.Id);
+            Assert.That(addMilestoneEvents, Has.Length.EqualTo(2));
+            Assert.That(addMilestoneEvents[0].Milestone.Id, Is.EqualTo(1));
+            Assert.That(addMilestoneEvents[1].Milestone.Id, Is.EqualTo(2));
         }
     }
 }

--- a/NGitLab.Mock.Tests/LabelsMockTests.cs
+++ b/NGitLab.Mock.Tests/LabelsMockTests.cs
@@ -21,9 +21,9 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var labels = client.Labels.ForProject(1).ToArray();
 
-            Assert.AreEqual(2, labels.Length, "Labels count is invalid");
-            Assert.IsTrue(labels.Any(x => string.Equals(x.Name, "test1", StringComparison.Ordinal)), "Label test1 not found");
-            Assert.IsTrue(labels.Any(x => string.Equals(x.Name, "test2", StringComparison.Ordinal)), "Label test2 not found");
+            Assert.That(labels, Has.Length.EqualTo(2), "Labels count is invalid");
+            Assert.That(labels.Any(x => string.Equals(x.Name, "test1", StringComparison.Ordinal)), Is.True, "Label test1 not found");
+            Assert.That(labels.Any(x => string.Equals(x.Name, "test2", StringComparison.Ordinal)), Is.True, "Label test2 not found");
         }
 
         [Test]
@@ -38,8 +38,8 @@ namespace NGitLab.Mock.Tests
             client.Labels.Create(new LabelCreate { Id = 1, Name = "test1" });
             var labels = client.Labels.ForProject(1).ToArray();
 
-            Assert.AreEqual(1, labels.Length, "Labels count is invalid");
-            Assert.AreEqual("test1", labels[0].Name, "Label not found");
+            Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
+            Assert.That(labels[0].Name, Is.EqualTo("test1"), "Label not found");
         }
 
         [Test]
@@ -55,8 +55,8 @@ namespace NGitLab.Mock.Tests
             client.Labels.Edit(new LabelEdit { Id = 1, Name = "test1", NewName = "test2" });
             var labels = client.Labels.ForProject(1).ToArray();
 
-            Assert.AreEqual(1, labels.Length, "Labels count is invalid");
-            Assert.AreEqual("test2", labels[0].Name, "Label not found");
+            Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
+            Assert.That(labels[0].Name, Is.EqualTo("test2"), "Label not found");
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NGitLab.Mock.Tests
             client.Labels.Delete(new LabelDelete { Id = 1, Name = "test1" });
             var labels = client.Labels.ForProject(1).ToArray();
 
-            Assert.AreEqual(0, labels.Length, "Labels count is invalid");
+            Assert.That(labels, Is.Empty, "Labels count is invalid");
         }
 
         [Test]
@@ -88,9 +88,9 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var labels = client.Labels.ForGroup(2).ToArray();
 
-            Assert.AreEqual(2, labels.Length, "Labels count is invalid");
-            Assert.IsTrue(labels.Any(x => string.Equals(x.Name, "test1", StringComparison.Ordinal)), "Label test1 not found");
-            Assert.IsTrue(labels.Any(x => string.Equals(x.Name, "test2", StringComparison.Ordinal)), "Label test2 not found");
+            Assert.That(labels, Has.Length.EqualTo(2), "Labels count is invalid");
+            Assert.That(labels.Any(x => string.Equals(x.Name, "test1", StringComparison.Ordinal)), Is.True, "Label test1 not found");
+            Assert.That(labels.Any(x => string.Equals(x.Name, "test2", StringComparison.Ordinal)), Is.True, "Label test2 not found");
         }
 
         [Test]
@@ -105,8 +105,8 @@ namespace NGitLab.Mock.Tests
             client.Labels.CreateGroupLabel(new LabelCreate { Id = 2, Name = "test1" });
             var labels = client.Labels.ForGroup(2).ToArray();
 
-            Assert.AreEqual(1, labels.Length, "Labels count is invalid");
-            Assert.AreEqual("test1", labels[0].Name, "Label not found");
+            Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
+            Assert.That(labels[0].Name, Is.EqualTo("test1"), "Label not found");
         }
 
         [Test]
@@ -122,8 +122,8 @@ namespace NGitLab.Mock.Tests
             client.Labels.EditGroupLabel(new LabelEdit { Id = 2, Name = "test1", NewName = "test2" });
             var labels = client.Labels.ForGroup(2).ToArray();
 
-            Assert.AreEqual(1, labels.Length, "Labels count is invalid");
-            Assert.AreEqual("test2", labels[0].Name, "Label not found");
+            Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
+            Assert.That(labels[0].Name, Is.EqualTo("test2"), "Label not found");
         }
     }
 }

--- a/NGitLab.Mock.Tests/LintCITests.cs
+++ b/NGitLab.Mock.Tests/LintCITests.cs
@@ -36,7 +36,7 @@ public class LintCITests
         });
 
         // Assert
-        Assert.IsFalse(result.Valid);
-        Assert.AreEqual(expectedError, result.Errors.Single());
+        Assert.That(result.Valid, Is.False);
+        Assert.That(result.Errors.Single(), Is.EqualTo(expectedError));
     }
 }

--- a/NGitLab.Mock.Tests/MembersMockTests.cs
+++ b/NGitLab.Mock.Tests/MembersMockTests.cs
@@ -21,7 +21,7 @@ namespace NGitLab.Mock.Tests
                 ? client.Members.OfGroup("2")
                 : client.Members.OfGroup("2", includeInheritedMembers: false);
 
-            Assert.AreEqual(1, members.Count(), "Membership found are invalid");
+            Assert.That(members.Count(), Is.EqualTo(1), "Membership found are invalid");
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var members = client.Members.OfGroup("2", includeInheritedMembers: true);
 
-            Assert.AreEqual(2, members.Count(), "Membership found are invalid");
+            Assert.That(members.Count(), Is.EqualTo(2), "Membership found are invalid");
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NGitLab.Mock.Tests
                 ? client.Members.OfProject("1")
                 : client.Members.OfProject("1", includeInheritedMembers: false);
 
-            Assert.AreEqual(1, members.Count(), "Membership found are invalid");
+            Assert.That(members.Count(), Is.EqualTo(1), "Membership found are invalid");
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var members = client.Members.OfProject("1", includeInheritedMembers: true);
 
-            Assert.AreEqual(3, members.Count(), "Membership found are invalid");
+            Assert.That(members.Count(), Is.EqualTo(3), "Membership found are invalid");
         }
     }
 }

--- a/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
+++ b/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
@@ -23,8 +23,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { Scope = "created_by_me" }).ToArray();
 
-            Assert.AreEqual(1, mergeRequests.Length, "Merge requests count is invalid");
-            Assert.AreEqual("Merge request 1", mergeRequests[0].Title, "Merge request found is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "Merge requests count is invalid");
+            Assert.That(mergeRequests[0].Title, Is.EqualTo("Merge request 1"), "Merge request found is invalid");
         }
 
         [Test]
@@ -41,8 +41,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { Scope = "assigned_to_me" }).ToArray();
 
-            Assert.AreEqual(1, mergeRequests.Length, "Merge requests count is invalid");
-            Assert.AreEqual("Merge request 2", mergeRequests[0].Title, "Merge request found is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "Merge requests count is invalid");
+            Assert.That(mergeRequests[0].Title, Is.EqualTo("Merge request 2"), "Merge request found is invalid");
         }
 
         [Test]
@@ -59,8 +59,8 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient("user1");
             var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { ApproverIds = new[] { 1 } }).ToArray();
 
-            Assert.AreEqual(1, mergeRequests.Length, "Merge requests count is invalid");
-            Assert.AreEqual("Merge request 2", mergeRequests[0].Title, "Merge request found is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "Merge requests count is invalid");
+            Assert.That(mergeRequests[0].Title, Is.EqualTo("Merge request 2"), "Merge request found is invalid");
         }
 
         [Test]
@@ -83,8 +83,8 @@ namespace NGitLab.Mock.Tests
             var client = gitLabServer.CreateClient(user1);
             var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { Scope = "assigned_to_me" }).ToArray();
 
-            Assert.AreEqual(1, mergeRequests.Length, "Merge requests count is invalid");
-            Assert.AreEqual("Merge request 2", mergeRequests[0].Title, "Merge request found is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "Merge requests count is invalid");
+            Assert.That(mergeRequests[0].Title, Is.EqualTo("Merge request 2"), "Merge request found is invalid");
         }
 
         [Test]
@@ -103,8 +103,8 @@ namespace NGitLab.Mock.Tests
                 Assignees = new[] { new UserRef(user1), new UserRef(user2) },
             };
 
-            Assert.AreEqual(1, mergeRequestSingle.Assignees.Count, "Merge request assignees count invalid");
-            Assert.AreEqual("user1", mergeRequestTwo.Assignee.UserName, "Merge request assignee is invalid");
+            Assert.That(mergeRequestSingle.Assignees, Has.Count.EqualTo(1), "Merge request assignees count invalid");
+            Assert.That(mergeRequestTwo.Assignee.UserName, Is.EqualTo("user1"), "Merge request assignee is invalid");
         }
 
         [TestCase(false)]
@@ -148,16 +148,16 @@ namespace NGitLab.Mock.Tests
             });
 
             // Assert
-            Assert.IsFalse(modelMr.HasConflicts);
-            Assert.AreEqual(0, modelMr.DivergedCommitsCount);
-            Assert.IsNotNull(modelMr.DiffRefs?.BaseSha);
-            Assert.AreEqual(modelMr.DiffRefs.BaseSha, modelMr.DiffRefs.StartSha);
-            Assert.AreEqual("merged", modelMr.State);
+            Assert.That(modelMr.HasConflicts, Is.False);
+            Assert.That(modelMr.DivergedCommitsCount, Is.EqualTo(0));
+            Assert.That(modelMr.DiffRefs?.BaseSha, Is.Not.Null);
+            Assert.That(modelMr.DiffRefs.StartSha, Is.EqualTo(modelMr.DiffRefs.BaseSha));
+            Assert.That(modelMr.State, Is.EqualTo("merged"));
 
-            Assert.IsFalse(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.False,
                 "Since the merge succeeded and 'ShouldRemoveSourceBranch' was set, 'to-be-merged' branch should be gone");
 
-            Assert.IsFalse(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.False,
                 "Since the merge succeeded and 'ShouldRemoveSourceBranch' was set, 'to-be-merged' branch should be gone");
         }
 
@@ -202,17 +202,17 @@ namespace NGitLab.Mock.Tests
                 MergeWhenPipelineSucceeds = mr.HeadPipeline != null,
                 ShouldRemoveSourceBranch = true,
             }));
-            Assert.AreEqual(HttpStatusCode.MethodNotAllowed, exception.StatusCode);
-            Assert.IsTrue(exception.Message.Equals("The MR cannot be merged with method 'ff': the source branch must first be rebased", StringComparison.Ordinal));
+            Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.MethodNotAllowed));
+            Assert.That(exception.Message.Equals("The MR cannot be merged with method 'ff': the source branch must first be rebased", StringComparison.Ordinal), Is.True);
 
-            Assert.IsFalse(mr.HasConflicts);
-            Assert.AreEqual(1, mr.DivergedCommitsCount);
-            Assert.AreNotEqual(mr.BaseSha, mr.StartSha);
+            Assert.That(mr.HasConflicts, Is.False);
+            Assert.That(mr.DivergedCommitsCount, Is.EqualTo(1));
+            Assert.That(mr.StartSha, Is.Not.EqualTo(mr.BaseSha));
 
-            Assert.IsTrue(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.True,
                 "Since the merge failed, 'to-be-merged' branch should still be there");
 
-            Assert.IsTrue(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.True,
                 "Since the merge failed, 'to-be-merged' branch should still be there");
         }
 
@@ -258,17 +258,17 @@ namespace NGitLab.Mock.Tests
                 MergeWhenPipelineSucceeds = mr.HeadPipeline != null,
                 ShouldRemoveSourceBranch = true,
             }));
-            Assert.AreEqual(HttpStatusCode.NotAcceptable, exception.StatusCode);
-            Assert.IsTrue(exception.Message.Equals("The merge request has some conflicts and cannot be merged", StringComparison.Ordinal));
+            Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.NotAcceptable));
+            Assert.That(exception.Message.Equals("The merge request has some conflicts and cannot be merged", StringComparison.Ordinal), Is.True);
 
-            Assert.IsTrue(mr.HasConflicts);
-            Assert.AreEqual(1, mr.DivergedCommitsCount);
-            Assert.AreNotEqual(mr.BaseSha, mr.StartSha);
+            Assert.That(mr.HasConflicts, Is.True);
+            Assert.That(mr.DivergedCommitsCount, Is.EqualTo(1));
+            Assert.That(mr.StartSha, Is.Not.EqualTo(mr.BaseSha));
 
-            Assert.IsTrue(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(targetProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.True,
                 "Since the merge failed, 'to-be-merged' branch should still be there");
 
-            Assert.IsTrue(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)),
+            Assert.That(sourceProject.Repository.GetAllBranches().Any(b => b.FriendlyName.EndsWith("to-be-merged", StringComparison.Ordinal)), Is.True,
                 "Since the merge failed, 'to-be-merged' branch should still be there");
         }
 
@@ -285,10 +285,10 @@ namespace NGitLab.Mock.Tests
             commit = project.Repository.Commit(user, "another test");
 
             var mr = project.CreateMergeRequest(user, "A great title", "A great description", project.DefaultBranch, branch);
-            Assert.IsNull(mr.HeadPipeline, "No pipeline created yet on the source branch");
+            Assert.That(mr.HeadPipeline, Is.Null, "No pipeline created yet on the source branch");
 
             var pipeline = project.Pipelines.Add(branch, JobStatus.Success, user);
-            Assert.AreEqual(pipeline, mr.HeadPipeline, "A pipeline was just created on the source branch");
+            Assert.That(mr.HeadPipeline, Is.EqualTo(pipeline), "A pipeline was just created on the source branch");
         }
 
         [Test]
@@ -310,13 +310,13 @@ namespace NGitLab.Mock.Tests
             mrClient.Reopen(mergeRequest.Iid);
 
             var resourceStateEvents = mrClient.ResourceStateEventsAsync(projectId: projectId, mergeRequestIid: mergeRequest.Iid).ToArray();
-            Assert.AreEqual(2, resourceStateEvents.Length);
+            Assert.That(resourceStateEvents, Has.Length.EqualTo(2));
 
             var closeStateEvents = resourceStateEvents.Where(e => string.Equals(e.State, "closed", StringComparison.Ordinal)).ToArray();
-            Assert.AreEqual(1, closeStateEvents.Length);
+            Assert.That(closeStateEvents, Has.Length.EqualTo(1));
 
             var reopenMilestoneEvents = resourceStateEvents.Where(e => string.Equals(e.State, "reopened", StringComparison.Ordinal)).ToArray();
-            Assert.AreEqual(1, reopenMilestoneEvents.Length);
+            Assert.That(reopenMilestoneEvents, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -358,13 +358,13 @@ namespace NGitLab.Mock.Tests
              * 3. Remove third
              */
             var resourceLabelEvents = mrClient.ResourceLabelEventsAsync(projectId: projectId, mergeRequestIid: mergeRequest.Iid).ToArray();
-            Assert.AreEqual(6, resourceLabelEvents.Length);
+            Assert.That(resourceLabelEvents, Has.Length.EqualTo(6));
 
             var addLabelEvents = resourceLabelEvents.Where(e => e.Action == ResourceLabelEventAction.Add).ToArray();
-            Assert.AreEqual(4, addLabelEvents.Length);
+            Assert.That(addLabelEvents, Has.Length.EqualTo(4));
 
             var removeLabelEvents = resourceLabelEvents.Where(e => e.Action == ResourceLabelEventAction.Remove).ToArray();
-            Assert.AreEqual(2, removeLabelEvents.Length);
+            Assert.That(removeLabelEvents, Has.Length.EqualTo(2));
         }
 
         [Test]
@@ -401,16 +401,16 @@ namespace NGitLab.Mock.Tests
              * 2. Add milestone 2
              */
             var resourceMilestoneEvents = mrClient.ResourceMilestoneEventsAsync(projectId: projectId, mergeRequestIid: mergeRequest.Iid).ToArray();
-            Assert.AreEqual(3, resourceMilestoneEvents.Length);
+            Assert.That(resourceMilestoneEvents, Has.Length.EqualTo(3));
 
             var removeMilestoneEvents = resourceMilestoneEvents.Where(e => e.Action == ResourceMilestoneEventAction.Remove).ToArray();
-            Assert.AreEqual(1, removeMilestoneEvents.Length);
-            Assert.AreEqual(milestones[0].Id, removeMilestoneEvents[0].Milestone.Id);
+            Assert.That(removeMilestoneEvents, Has.Length.EqualTo(1));
+            Assert.That(removeMilestoneEvents[0].Milestone.Id, Is.EqualTo(milestones[0].Id));
 
             var addMilestoneEvents = resourceMilestoneEvents.Where(e => e.Action == ResourceMilestoneEventAction.Add).ToArray();
-            Assert.AreEqual(2, addMilestoneEvents.Length);
-            Assert.AreEqual(milestones[0].Id, addMilestoneEvents[0].Milestone.Id);
-            Assert.AreEqual(milestones[1].Id, addMilestoneEvents[1].Milestone.Id);
+            Assert.That(addMilestoneEvents, Has.Length.EqualTo(2));
+            Assert.That(addMilestoneEvents[0].Milestone.Id, Is.EqualTo(milestones[0].Id));
+            Assert.That(addMilestoneEvents[1].Milestone.Id, Is.EqualTo(milestones[1].Id));
         }
     }
 }

--- a/NGitLab.Mock.Tests/MilestonesMockTests.cs
+++ b/NGitLab.Mock.Tests/MilestonesMockTests.cs
@@ -21,9 +21,9 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var milestones = client.GetMilestone(1).All.ToArray();
 
-            Assert.AreEqual(2, milestones.Length, "Milestones count is invalid");
-            Assert.IsTrue(milestones.Any(x => string.Equals(x.Title, "Milestone 1", StringComparison.Ordinal)), "Milestone 'Milestone 1' not found");
-            Assert.IsTrue(milestones.Any(x => string.Equals(x.Title, "Milestone 2", StringComparison.Ordinal)), "Milestone 'Milestone 2' not found");
+            Assert.That(milestones, Has.Length.EqualTo(2), "Milestones count is invalid");
+            Assert.That(milestones.Any(x => string.Equals(x.Title, "Milestone 1", StringComparison.Ordinal)), Is.True, "Milestone 'Milestone 1' not found");
+            Assert.That(milestones.Any(x => string.Equals(x.Title, "Milestone 2", StringComparison.Ordinal)), Is.True, "Milestone 'Milestone 2' not found");
         }
 
         [Test]
@@ -38,8 +38,8 @@ namespace NGitLab.Mock.Tests
             client.GetMilestone(1).Create(new MilestoneCreate { Title = "Milestone 1" });
             var milestones = client.GetMilestone(1).All.ToArray();
 
-            Assert.AreEqual(1, milestones.Length, "Milestones count is invalid");
-            Assert.AreEqual("Milestone 1", milestones[0].Title, "Milestone 'Milestone 1' not found");
+            Assert.That(milestones, Has.Length.EqualTo(1), "Milestones count is invalid");
+            Assert.That(milestones[0].Title, Is.EqualTo("Milestone 1"), "Milestone 'Milestone 1' not found");
         }
 
         [Test]
@@ -55,8 +55,8 @@ namespace NGitLab.Mock.Tests
             client.GetMilestone(1).Update(1, new MilestoneUpdate { Title = "Milestone 2" });
             var milestones = client.GetMilestone(1).All.ToArray();
 
-            Assert.AreEqual(1, milestones.Length, "Milestones count is invalid");
-            Assert.AreEqual("Milestone 2", milestones[0].Title, "Milestone 'Milestone 2' not found");
+            Assert.That(milestones, Has.Length.EqualTo(1), "Milestones count is invalid");
+            Assert.That(milestones[0].Title, Is.EqualTo("Milestone 2"), "Milestone 'Milestone 2' not found");
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NGitLab.Mock.Tests
             client.GetMilestone(1).Delete(1);
             var milestones = client.GetMilestone(1).All.ToArray();
 
-            Assert.AreEqual(0, milestones.Length, "Milestones count is invalid");
+            Assert.That(milestones, Is.Empty, "Milestones count is invalid");
         }
 
         [Test]
@@ -89,15 +89,15 @@ namespace NGitLab.Mock.Tests
             var activeMilestones = client.GetMilestone(1).AllInState(Models.MilestoneState.active).ToArray();
             var closedMilestones = client.GetMilestone(1).AllInState(Models.MilestoneState.closed).ToArray();
 
-            Assert.AreEqual(0, activeMilestones.Length, "Active milestones count is invalid");
-            Assert.AreEqual(1, closedMilestones.Length, "Closed milestones count is invalid");
+            Assert.That(activeMilestones, Is.Empty, "Active milestones count is invalid");
+            Assert.That(closedMilestones, Has.Length.EqualTo(1), "Closed milestones count is invalid");
 
             client.GetMilestone(1).Activate(1);
             activeMilestones = client.GetMilestone(1).AllInState(Models.MilestoneState.active).ToArray();
             closedMilestones = client.GetMilestone(1).AllInState(Models.MilestoneState.closed).ToArray();
 
-            Assert.AreEqual(1, activeMilestones.Length, "Active milestones count is invalid");
-            Assert.AreEqual(0, closedMilestones.Length, "Closed milestones count is invalid");
+            Assert.That(activeMilestones, Has.Length.EqualTo(1), "Active milestones count is invalid");
+            Assert.That(closedMilestones, Is.Empty, "Closed milestones count is invalid");
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace NGitLab.Mock.Tests
 
             var client = server.CreateClient();
             var mergeRequests = client.GetMilestone(ProjectId).GetMergeRequests(MilestoneId).ToArray();
-            Assert.AreEqual(2, mergeRequests.Length, "Merge requests count is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(2), "Merge requests count is invalid");
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace NGitLab.Mock.Tests
 
             var client = server.CreateClient();
             var mergeRequests = client.GetGroupMilestone(projectId).GetMergeRequests(milestoneId).ToArray();
-            Assert.AreEqual(2, mergeRequests.Length, "Merge requests count is invalid");
+            Assert.That(mergeRequests, Has.Length.EqualTo(2), "Merge requests count is invalid");
         }
     }
 }

--- a/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
+++ b/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>

--- a/NGitLab.Mock.Tests/PipelineTests.cs
+++ b/NGitLab.Mock.Tests/PipelineTests.cs
@@ -20,7 +20,7 @@ namespace NGitLab.Mock.Tests
             job.Trace = "This is a trace\nWith Multiple line";
 
             var client = server.CreateClient();
-            Assert.AreEqual(job.Trace, await client.GetJobs(project.Id).GetTraceAsync(job.Id));
+            Assert.That(await client.GetJobs(project.Id).GetTraceAsync(job.Id), Is.EqualTo(job.Trace));
         }
 
         [Test]
@@ -47,12 +47,12 @@ namespace NGitLab.Mock.Tests
 
             var client = server.CreateClient();
             var summary = client.GetPipelines(project.Id).GetTestReportsSummary(pipeline.Id);
-            Assert.AreEqual(60, summary.Total.Time);
-            Assert.AreEqual(1157, summary.Total.Count);
-            Assert.AreEqual(1157, summary.Total.Success);
-            Assert.AreEqual(0, summary.Total.Skipped);
-            Assert.AreEqual(0, summary.Total.Failed);
-            Assert.AreEqual(0, summary.Total.Error);
+            Assert.That(summary.Total.Time, Is.EqualTo(60));
+            Assert.That(summary.Total.Count, Is.EqualTo(1157));
+            Assert.That(summary.Total.Success, Is.EqualTo(1157));
+            Assert.That(summary.Total.Skipped, Is.EqualTo(0));
+            Assert.That(summary.Total.Failed, Is.EqualTo(0));
+            Assert.That(summary.Total.Error, Is.EqualTo(0));
         }
 
         [TestCase(false)]
@@ -69,7 +69,7 @@ namespace NGitLab.Mock.Tests
             {
                 project.Repository.CreateAndCheckoutBranch(branch);
                 var commit2 = project.Repository.Commit(user, "another test");
-                Assert.AreNotEqual(commit.Sha, commit2.Sha);
+                Assert.That(commit2.Sha, Is.Not.EqualTo(commit.Sha));
                 commit = commit2;
             }
             else
@@ -79,7 +79,7 @@ namespace NGitLab.Mock.Tests
 
             var pipeline = project.Pipelines.Add(branch, JobStatus.Success, user);
 
-            Assert.AreEqual(new Sha1(commit.Sha), pipeline.Sha);
+            Assert.That(pipeline.Sha, Is.EqualTo(new Sha1(commit.Sha)));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace NGitLab.Mock.Tests
 
             var pipeline = project.Pipelines.Add(tag, JobStatus.Success, user);
 
-            Assert.AreEqual(new Sha1(commit.Sha), pipeline.Sha);
+            Assert.That(pipeline.Sha, Is.EqualTo(new Sha1(commit.Sha)));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace NGitLab.Mock.Tests
 
             var pipeline = project.Pipelines.Add("invalid_ref", JobStatus.Success, user);
 
-            Assert.AreEqual(default(Sha1), pipeline.Sha);
+            Assert.That(pipeline.Sha, Is.EqualTo(default(Sha1)));
         }
     }
 }

--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -20,9 +20,9 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var project = client.Projects["testgroup/Test"];
 
-            Assert.IsNotNull(project);
-            Assert.AreEqual("Test", project.Name);
-            Assert.AreEqual("testgroup", project.Namespace.FullPath);
+            Assert.That(project, Is.Not.Null);
+            Assert.That(project.Name, Is.EqualTo("Test"));
+            Assert.That(project.Namespace.FullPath, Is.EqualTo("testgroup"));
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace NGitLab.Mock.Tests
                 .WithProject("Test", clonePath: tempDir.FullPath)
                 .BuildServer();
 
-            Assert.IsTrue(Directory.Exists(tempDir.GetFullPath(".git")));
+            Assert.That(Directory.Exists(tempDir.GetFullPath(".git")), Is.True);
         }
 
         [Test]
@@ -51,11 +51,11 @@ namespace NGitLab.Mock.Tests
                             .WithSubModule("ModuleB")))
                 .BuildServer();
 
-            Assert.IsTrue(Directory.Exists(tempDir.GetFullPath(".git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/.git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/A.txt")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")));
+            Assert.That(Directory.Exists(tempDir.GetFullPath(".git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/.git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleA/A.txt")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")), Is.True);
         }
 
         [Test]
@@ -73,11 +73,11 @@ namespace NGitLab.Mock.Tests
                         => c.WithSubModule("ModuleB")))
                 .BuildServer();
 
-            Assert.IsTrue(Directory.Exists(tempDir.GetFullPath(".git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/.git")));
-            Assert.IsTrue(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/A.txt")));
+            Assert.That(Directory.Exists(tempDir.GetFullPath(".git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/.git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/B.txt")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/.git")), Is.True);
+            Assert.That(System.IO.File.Exists(tempDir.GetFullPath("ModuleB/ModuleA/A.txt")), Is.True);
         }
 
         [Test]
@@ -91,10 +91,10 @@ namespace NGitLab.Mock.Tests
             var client = server.CreateClient();
             var project = client.Projects["testgroup/Test"];
 
-            Assert.IsNotNull(project);
-            StringAssert.EndsWith($"testgroup{Path.DirectorySeparatorChar}test", project.SshUrl);
-            StringAssert.EndsWith($"testgroup{Path.DirectorySeparatorChar}test", project.HttpUrl);
-            StringAssert.EndsWith("testgroup/test", project.WebUrl);
+            Assert.That(project, Is.Not.Null);
+            Assert.That(project.SshUrl, Does.EndWith($"testgroup{Path.DirectorySeparatorChar}test"));
+            Assert.That(project.HttpUrl, Does.EndWith($"testgroup{Path.DirectorySeparatorChar}test"));
+            Assert.That(project.WebUrl, Does.EndWith("testgroup/test"));
         }
 
         [Test]
@@ -105,13 +105,13 @@ namespace NGitLab.Mock.Tests
             var project = user.Namespace.Projects.AddNew();
 
             var client = server.CreateClient(user);
-            Assert.IsEmpty(client.Projects.GetLanguages(project.Id.ToString(CultureInfo.InvariantCulture)));
+            Assert.That(client.Projects.GetLanguages(project.Id.ToString(CultureInfo.InvariantCulture)), Is.Empty);
 
             project.Repository.Commit(user, "dummy", new[] { File.CreateFromText("test.cs", "dummy"), File.CreateFromText("test.js", "dummy") });
             var languages = client.Projects.GetLanguages(project.Id.ToString(CultureInfo.InvariantCulture));
-            Assert.AreEqual(2, languages.Count);
-            Assert.AreEqual(0.5d, languages["C#"]);
-            Assert.AreEqual(0.5d, languages["JavaScript"]);
+            Assert.That(languages, Has.Count.EqualTo(2));
+            Assert.That(languages["C#"], Is.EqualTo(0.5d));
+            Assert.That(languages["JavaScript"], Is.EqualTo(0.5d));
         }
 
         [Test]
@@ -121,10 +121,10 @@ namespace NGitLab.Mock.Tests
             var user = server.Users.AddNew();
             var project = user.Namespace.Projects.AddNew();
 
-            Assert.IsTrue(project.ToClientProject(user).EmptyRepo);
+            Assert.That(project.ToClientProject(user).EmptyRepo, Is.True);
 
             project.Repository.Commit(user, "dummy");
-            Assert.IsFalse(project.ToClientProject(user).EmptyRepo);
+            Assert.That(project.ToClientProject(user).EmptyRepo, Is.False);
         }
 
         [Test]

--- a/NGitLab.Mock.Tests/ReleasesMockTests.cs
+++ b/NGitLab.Mock.Tests/ReleasesMockTests.cs
@@ -22,9 +22,9 @@ namespace NGitLab.Mock.Tests
             var releaseClient = client.GetReleases(project.Id);
             var singleRelease = releaseClient.All.SingleOrDefault();
 
-            Assert.IsNotNull(singleRelease);
-            Assert.AreEqual("1.2.3", singleRelease.TagName);
-            Assert.AreEqual($"{project.WebUrl}/-/releases/1.2.3", singleRelease.Links.Self);
+            Assert.That(singleRelease, Is.Not.Null);
+            Assert.That(singleRelease.TagName, Is.EqualTo("1.2.3"));
+            Assert.That(singleRelease.Links.Self, Is.EqualTo($"{project.WebUrl}/-/releases/1.2.3"));
         }
 
         [Test]
@@ -47,8 +47,8 @@ namespace NGitLab.Mock.Tests
                 Page = 2,
             }).SingleOrDefault();
 
-            Assert.IsNotNull(firstRelease);
-            Assert.AreEqual("1.2.3", firstRelease.TagName);
+            Assert.That(firstRelease, Is.Not.Null);
+            Assert.That(firstRelease.TagName, Is.EqualTo("1.2.3"));
         }
 
         [Test]
@@ -70,8 +70,8 @@ namespace NGitLab.Mock.Tests
                 Sort = "asc",
             }).First();
 
-            Assert.IsNotNull(firstRelease);
-            Assert.AreEqual("1.2.3", firstRelease.TagName);
+            Assert.That(firstRelease, Is.Not.Null);
+            Assert.That(firstRelease.TagName, Is.EqualTo("1.2.3"));
         }
 
         [Test]
@@ -93,8 +93,8 @@ namespace NGitLab.Mock.Tests
                 OrderBy = "created_at",
             }).First();
 
-            Assert.IsNotNull(firstRelease);
-            Assert.AreEqual("1.2.3", firstRelease.TagName);
+            Assert.That(firstRelease, Is.Not.Null);
+            Assert.That(firstRelease.TagName, Is.EqualTo("1.2.3"));
         }
     }
 }

--- a/NGitLab.Mock.Tests/TagTests.cs
+++ b/NGitLab.Mock.Tests/TagTests.cs
@@ -23,10 +23,10 @@ namespace NGitLab.Mock.Tests
 
             // Act/Assert
             var tag = await tagClient.GetByNameAsync("1.0.0");
-            Assert.AreEqual("1.0.0", tag.Name);
+            Assert.That(tag.Name, Is.EqualTo("1.0.0"));
 
             var ex = Assert.ThrowsAsync<GitLabException>(() => tagClient.GetByNameAsync("1.0.1"));
-            Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
     }
 }

--- a/NGitLab.Tests/BranchClientTests.cs
+++ b/NGitLab.Tests/BranchClientTests.cs
@@ -17,19 +17,19 @@ namespace NGitLab.Tests
             var branchClient = context.Client.GetRepository(project.Id).Branches;
             var currentUser = context.Client.Users.Current;
 
-            var masterBranch = branchClient[project.DefaultBranch];
-            Assert.That(masterBranch, Is.Not.Null);
+            var defaultBranch = branchClient[project.DefaultBranch];
+            Assert.That(defaultBranch, Is.Not.Null);
 
-            var commit = masterBranch.Commit;
+            var commit = defaultBranch.Commit;
             Assert.That(commit, Is.Not.Null);
 
             Assert.That(commit.Id.ToString(), Has.Length.EqualTo(40));
             Assert.That(commit.ShortId, Has.Length.GreaterThan(7));
 
             var fiveMinutesAgo = DateTime.UtcNow - TimeSpan.FromMinutes(5);
-            Assert.That(fiveMinutesAgo, Is.LessThan(commit.CreatedAt));
+            Assert.That(commit.CreatedAt, Is.GreaterThan(fiveMinutesAgo));
 
-            Assert.That(commit.Parents, Has.Length.GreaterThan(1));
+            Assert.That(commit.Parents, Has.Length.EqualTo(1));
 
             Assert.That(commit.Title, Is.EqualTo("add test file 2"));
             Assert.That(commit.Message, Is.EqualTo("add test file 2"));

--- a/NGitLab.Tests/BranchClientTests.cs
+++ b/NGitLab.Tests/BranchClientTests.cs
@@ -18,31 +18,31 @@ namespace NGitLab.Tests
             var currentUser = context.Client.Users.Current;
 
             var masterBranch = branchClient[project.DefaultBranch];
-            Assert.NotNull(masterBranch);
+            Assert.That(masterBranch, Is.Not.Null);
 
             var commit = masterBranch.Commit;
-            Assert.NotNull(commit);
+            Assert.That(commit, Is.Not.Null);
 
-            Assert.AreEqual(40, commit.Id.ToString().Length);
-            Assert.LessOrEqual(7, commit.ShortId.Length);
+            Assert.That(commit.Id.ToString(), Has.Length.EqualTo(40));
+            Assert.That(commit.ShortId, Has.Length.GreaterThan(7));
 
             var fiveMinutesAgo = DateTime.UtcNow - TimeSpan.FromMinutes(5);
-            Assert.Less(fiveMinutesAgo, commit.CreatedAt);
+            Assert.That(fiveMinutesAgo, Is.LessThan(commit.CreatedAt));
 
-            Assert.LessOrEqual(1, commit.Parents.Length);
+            Assert.That(commit.Parents, Has.Length.GreaterThan(1));
 
-            Assert.AreEqual("add test file 2", commit.Title);
-            Assert.AreEqual("add test file 2", commit.Message);
+            Assert.That(commit.Title, Is.EqualTo("add test file 2"));
+            Assert.That(commit.Message, Is.EqualTo("add test file 2"));
 
-            Assert.AreEqual(currentUser.Name, commit.AuthorName);
-            Assert.AreEqual(currentUser.Email, commit.AuthorEmail);
-            Assert.Less(fiveMinutesAgo, commit.AuthoredDate);
+            Assert.That(commit.AuthorName, Is.EqualTo(currentUser.Name));
+            Assert.That(commit.AuthorEmail, Is.EqualTo(currentUser.Email));
+            Assert.That(fiveMinutesAgo, Is.LessThan(commit.AuthoredDate));
 
-            Assert.AreEqual(currentUser.Name, commit.CommitterName);
-            Assert.AreEqual(currentUser.Email, commit.CommitterEmail);
-            Assert.Less(fiveMinutesAgo, commit.CommittedDate);
+            Assert.That(commit.CommitterName, Is.EqualTo(currentUser.Name));
+            Assert.That(commit.CommitterEmail, Is.EqualTo(currentUser.Email));
+            Assert.That(fiveMinutesAgo, Is.LessThan(commit.CommittedDate));
 
-            Assert.IsTrue(Uri.TryCreate(commit.WebUrl, UriKind.Absolute, out _));
+            Assert.That(Uri.TryCreate(commit.WebUrl, UriKind.Absolute, out _), Is.True);
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace NGitLab.Tests
 
             var branches = branchClient.Search(defaultBranch);
             var expectedBranch = branches.Single();
-            Assert.AreEqual(defaultBranch, expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo(defaultBranch));
 
             // This case only worked with GitLab 15.7 and later
             // https://gitlab.com/gitlab-org/gitlab/-/merge_requests/104451
@@ -69,18 +69,18 @@ namespace NGitLab.Tests
 
             branches = branchClient.Search($"^{defaultBranch[..^1]}");
             expectedBranch = branches.Single();
-            Assert.AreEqual(defaultBranch, expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo(defaultBranch));
 
             branches = branchClient.Search($"{defaultBranch[1..]}$");
             expectedBranch = branches.Single();
-            Assert.AreEqual(defaultBranch, expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo(defaultBranch));
 
             branches = branchClient.Search(defaultBranch[1..^1]);
             expectedBranch = branches.Single();
-            Assert.AreEqual(defaultBranch, expectedBranch.Name);
+            Assert.That(expectedBranch.Name, Is.EqualTo(defaultBranch));
 
             branches = branchClient.Search("foobar");
-            Assert.IsEmpty(branches);
+            Assert.That(branches, Is.Empty);
         }
     }
 }

--- a/NGitLab.Tests/CommitStatusTests.cs
+++ b/NGitLab.Tests/CommitStatusTests.cs
@@ -56,13 +56,13 @@ namespace NGitLab.Tests
 
                 var createdCommitStatus = CommitStatusClient.AddOrUpdate(commitStatus);
 
-                Assert.AreEqual(commitStatus.Ref, createdCommitStatus.Ref);
-                Assert.AreEqual(commitStatus.Coverage, createdCommitStatus.Coverage);
-                Assert.AreEqual(commitStatus.Description, createdCommitStatus.Description);
-                Assert.AreEqual(commitStatus.State, createdCommitStatus.Status);
-                Assert.AreEqual(commitStatus.Name, createdCommitStatus.Name);
-                Assert.AreEqual(commitStatus.TargetUrl, createdCommitStatus.TargetUrl);
-                Assert.IsTrue(string.Equals(commitStatus.CommitSha, createdCommitStatus.CommitSha, StringComparison.OrdinalIgnoreCase));
+                Assert.That(createdCommitStatus.Ref, Is.EqualTo(commitStatus.Ref));
+                Assert.That(createdCommitStatus.Coverage, Is.EqualTo(commitStatus.Coverage));
+                Assert.That(createdCommitStatus.Description, Is.EqualTo(commitStatus.Description));
+                Assert.That(createdCommitStatus.Status, Is.EqualTo(commitStatus.State));
+                Assert.That(createdCommitStatus.Name, Is.EqualTo(commitStatus.Name));
+                Assert.That(createdCommitStatus.TargetUrl, Is.EqualTo(commitStatus.TargetUrl));
+                Assert.That(string.Equals(commitStatus.CommitSha, createdCommitStatus.CommitSha, StringComparison.OrdinalIgnoreCase), Is.True);
 
                 return createdCommitStatus;
             }
@@ -90,7 +90,7 @@ namespace NGitLab.Tests
             var createdCommitStatus = context.AddOrUpdateCommitStatus();
 
             var commitStatus = context.CommitStatusClient.AllBySha(context.Commit.Id.ToString().ToLowerInvariant()).ToList();
-            Assert.IsNotNull(commitStatus.FirstOrDefault()?.Status);
+            Assert.That(commitStatus.FirstOrDefault()?.Status, Is.Not.Null);
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NGitLab.Tests
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(coverage: null);
 
-            Assert.AreEqual(commitStatus.Coverage, null);
+            Assert.That(commitStatus.Coverage, Is.Null);
         }
 
         [Test]
@@ -109,13 +109,13 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "pending");
-            Assert.AreEqual("pending", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("pending"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "running");
-            Assert.AreEqual("running", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("running"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "success");
-            Assert.AreEqual("success", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("success"));
         }
 
         [Test]
@@ -124,10 +124,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "pending");
-            Assert.AreEqual("pending", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("pending"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "failed");
-            Assert.AreEqual("failed", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("failed"));
         }
 
         [Test]
@@ -136,10 +136,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "pending");
-            Assert.AreEqual("pending", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("pending"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "canceled");
-            Assert.AreEqual("canceled", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("canceled"));
         }
 
         [Test]
@@ -148,10 +148,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "success");
-            Assert.AreEqual("success", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("success"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "pending");
-            Assert.AreEqual("pending", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("pending"));
         }
 
         [Test]
@@ -160,10 +160,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "success");
-            Assert.AreEqual("success", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("success"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "failed");
-            Assert.AreEqual("failed", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("failed"));
         }
 
         [Test]
@@ -172,10 +172,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "success");
-            Assert.AreEqual("success", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("success"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "canceled");
-            Assert.AreEqual("canceled", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("canceled"));
         }
 
         [Test]
@@ -184,10 +184,10 @@ namespace NGitLab.Tests
         {
             using var context = await CommitStatusTestContext.Create();
             var commitStatus = context.AddOrUpdateCommitStatus(state: "canceled");
-            Assert.AreEqual("canceled", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("canceled"));
 
             commitStatus = context.AddOrUpdateCommitStatus(state: "pending");
-            Assert.AreEqual("pending", commitStatus.Status);
+            Assert.That(commitStatus.Status, Is.EqualTo("pending"));
         }
     }
 }

--- a/NGitLab.Tests/CommitsTests.cs
+++ b/NGitLab.Tests/CommitsTests.cs
@@ -18,8 +18,8 @@ namespace NGitLab.Tests
             var project = context.CreateProject(initializeWithCommits: true);
 
             var commit = context.Client.GetCommits(project.Id).GetCommit(project.DefaultBranch);
-            Assert.IsNotNull(commit.Message);
-            Assert.IsNotNull(commit.ShortId);
+            Assert.That(commit.Message, Is.Not.Null);
+            Assert.That(commit.ShortId, Is.Not.Null);
         }
 
         [Test]
@@ -45,9 +45,9 @@ namespace NGitLab.Tests
             });
 
             var commit = context.Client.GetCommits(project.Id).GetCommit(project.DefaultBranch);
-            Assert.AreEqual(4, commit.Stats.Additions);
-            Assert.AreEqual(1, commit.Stats.Deletions);
-            Assert.AreEqual(5, commit.Stats.Total);
+            Assert.That(commit.Stats.Additions, Is.EqualTo(4));
+            Assert.That(commit.Stats.Deletions, Is.EqualTo(1));
+            Assert.That(commit.Stats.Total, Is.EqualTo(5));
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NGitLab.Tests
                 TimeSpan.FromSeconds(10));
 
             var mergeRequest = mergeRequests.Single();
-            Assert.AreEqual(mergeRequestTitle, mergeRequest.Title);
+            Assert.That(mergeRequest.Title, Is.EqualTo(mergeRequestTitle));
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace NGitLab.Tests
             });
 
             var latestCommit = commitClient.GetCommit(project.DefaultBranch);
-            Assert.AreEqual(cherryPickedCommit.Id, latestCommit.Id);
+            Assert.That(latestCommit.Id, Is.EqualTo(cherryPickedCommit.Id));
         }
     }
 }

--- a/NGitLab.Tests/CompareTests.cs
+++ b/NGitLab.Tests/CompareTests.cs
@@ -15,8 +15,8 @@ namespace NGitLab.Tests
             var project = context.CreateProject(initializeWithCommits: true);
             var compareResults = context.Client.GetRepository(project.Id).Compare(new CompareQuery(project.DefaultBranch, project.DefaultBranch));
 
-            Assert.IsNotNull(compareResults);
-            Assert.AreEqual(0, compareResults.Commits.Length);
+            Assert.That(compareResults, Is.Not.Null);
+            Assert.That(compareResults.Commits, Is.Empty);
         }
 
         [Test]
@@ -50,8 +50,8 @@ namespace NGitLab.Tests
 
             var compareResults = context.Client.GetRepository(project.Id).Compare(new CompareQuery(project.DefaultBranch, "devtest"));
 
-            Assert.IsNotNull(compareResults);
-            Assert.AreEqual(2, compareResults.Commits.Length);
+            Assert.That(compareResults, Is.Not.Null);
+            Assert.That(compareResults.Commits, Has.Length.EqualTo(2));
         }
 
         [Test]

--- a/NGitLab.Tests/ContributorsTests.cs
+++ b/NGitLab.Tests/ContributorsTests.cs
@@ -19,8 +19,8 @@ namespace NGitLab.Tests
             var currentUser = context.Client.Users.Current;
 
             var contributor = contributorsClient.All;
-            Assert.IsNotNull(contributor);
-            Assert.IsTrue(contributor.Any(x => string.Equals(x.Email, currentUser.Email, StringComparison.Ordinal)));
+            Assert.That(contributor, Is.Not.Null);
+            Assert.That(contributor.Any(x => string.Equals(x.Email, currentUser.Email, StringComparison.Ordinal)), Is.True);
         }
 
         [Test]
@@ -63,8 +63,8 @@ namespace NGitLab.Tests
 
             var contributors = await GitLabTestContext.RetryUntilAsync(() => contributorsClient.All.ToList(), c => c.Count >= 2, TimeSpan.FromMinutes(2));
 
-            Assert.IsTrue(contributors.Any(x => string.Equals(x.Email, currentUser.Email, StringComparison.Ordinal)));
-            Assert.IsTrue(contributors.Any(x => string.Equals(x.Email, userUpsert.Email, StringComparison.Ordinal)));
+            Assert.That(contributors.Any(x => string.Equals(x.Email, currentUser.Email, StringComparison.Ordinal)), Is.True);
+            Assert.That(contributors.Any(x => string.Equals(x.Email, userUpsert.Email, StringComparison.Ordinal)), Is.True);
 
             context.AdminClient.Users.Delete(user.Id);
         }

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -215,12 +215,12 @@ namespace NGitLab.Tests.Docker
             });
 
             var branch = client.GetRepository(project.Id).Branches.All.FirstOrDefault(b => string.Equals(b.Name, project.DefaultBranch, StringComparison.Ordinal));
-            Assert.NotNull(branch, $"Branch '{project.DefaultBranch}' should exist");
-            Assert.IsTrue(branch.Default, $"Branch '{project.DefaultBranch}' should be the default one");
+            Assert.That(branch, Is.Not.Null, $"Branch '{project.DefaultBranch}' should exist");
+            Assert.That(branch.Default, Is.True, $"Branch '{project.DefaultBranch}' should be the default one");
 
             branch = client.GetRepository(project.Id).Branches.All.FirstOrDefault(b => string.Equals(b.Name, BranchForMRName, StringComparison.Ordinal));
-            Assert.NotNull(branch, $"Branch '{BranchForMRName}' should exist");
-            Assert.IsFalse(branch.Protected, $"Branch '{BranchForMRName}' should not be protected");
+            Assert.That(branch, Is.Not.Null, $"Branch '{BranchForMRName}' should exist");
+            Assert.That(branch.Protected, Is.False, $"Branch '{BranchForMRName}' should not be protected");
 
             s_gitlabRetryPolicy.Execute(() => client.GetRepository(project.Id).Files.Update(new FileUpsert { Branch = BranchForMRName, CommitMessage = "test", Content = "test2", Path = "test.md" }));
 

--- a/NGitLab.Tests/EnvironmentsTests.cs
+++ b/NGitLab.Tests/EnvironmentsTests.cs
@@ -31,34 +31,34 @@ namespace NGitLab.Tests
             var newEnvNameExternalUrl = "https://www.example.com";
 
             // Validate environments doesn't exist yet
-            Assert.IsNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameNoUrl, StringComparison.Ordinal) || string.Equals(e.Name, newEnvNameWithUrl, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameNoUrl, StringComparison.Ordinal) || string.Equals(e.Name, newEnvNameWithUrl, StringComparison.Ordinal)), Is.Null);
 
             // Create  and check return value
             var env = envClient.Create(newEnvNameNoUrl, externalUrl: null);
-            StringAssert.AreEqualIgnoringCase(newEnvNameNoUrl, env.Name);
-            StringAssert.StartsWith(newEnvSlugNameNoUrlStart, env.Slug);
-            Assert.NotZero(env.Id);
-            Assert.IsNull(env.ExternalUrl);
+            Assert.That(env.Name, Is.EqualTo(newEnvNameNoUrl).IgnoreCase);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameNoUrlStart));
+            Assert.That(env.Id, Is.Not.Zero);
+            Assert.That(env.ExternalUrl, Is.Null);
 
             // Create newEnvNameWithUrl and check return value
             env = envClient.Create(newEnvNameWithUrl, newEnvNameExternalUrl);
-            StringAssert.AreEqualIgnoringCase(newEnvNameWithUrl, env.Name);
-            StringAssert.StartsWith(newEnvSlugNameWithUrlStart, env.Slug);
-            Assert.NotZero(env.Id);
-            StringAssert.AreEqualIgnoringCase(newEnvNameExternalUrl, env.ExternalUrl);
+            Assert.That(env.Name, Is.EqualTo(newEnvNameWithUrl).IgnoreCase);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameWithUrlStart));
+            Assert.That(env.Id, Is.Not.Zero);
+            Assert.That(env.ExternalUrl, Is.EqualTo(newEnvNameExternalUrl).IgnoreCase);
 
             // Validate new environment are present in All
             env = envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameNoUrl, StringComparison.Ordinal));
-            Assert.IsNotNull(env);
-            StringAssert.StartsWith(newEnvSlugNameNoUrlStart, env.Slug);
-            Assert.NotZero(env.Id);
-            Assert.IsNull(env.ExternalUrl);
+            Assert.That(env, Is.Not.Null);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameNoUrlStart));
+            Assert.That(env.Id, Is.Not.Zero);
+            Assert.That(env.ExternalUrl, Is.Null);
 
             env = envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameWithUrl, StringComparison.Ordinal));
-            Assert.IsNotNull(env);
-            StringAssert.StartsWith(newEnvSlugNameWithUrlStart, env.Slug);
-            Assert.NotZero(env.Id);
-            StringAssert.AreEqualIgnoringCase(newEnvNameExternalUrl, env.ExternalUrl);
+            Assert.That(env, Is.Not.Null);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameWithUrlStart));
+            Assert.That(env.Id, Is.Not.Zero);
+            Assert.That(env.ExternalUrl, Is.EqualTo(newEnvNameExternalUrl).IgnoreCase);
         }
 
         [Test]
@@ -75,28 +75,28 @@ namespace NGitLab.Tests
             var newEnvNameExternalUrlUpdated = "https://www.example.com/updated";
 
             // Validate environments doesn't exist yet
-            Assert.IsNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToEdit, StringComparison.Ordinal) || string.Equals(e.Name, newEnvNameUpdated, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToEdit, StringComparison.Ordinal) || string.Equals(e.Name, newEnvNameUpdated, StringComparison.Ordinal)), Is.Null);
 
             // Create newEnvNameToEdit
             var env = envClient.Create(newEnvNameToEdit, externalUrl: null);
             var initialEnvId = env.Id;
 
             // Validate newEnvNameToEdit is present
-            Assert.IsNotNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToEdit, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToEdit, StringComparison.Ordinal)), Is.Not.Null);
 
             // Edit and check return value
             env = envClient.Edit(initialEnvId, newEnvNameUpdated, newEnvNameExternalUrlUpdated);
-            StringAssert.AreEqualIgnoringCase(newEnvNameUpdated, env.Name);
-            StringAssert.StartsWith(newEnvSlugNameUpdatedStart, env.Slug);
-            Assert.AreEqual(initialEnvId, env.Id, "Environment Id should not change");
-            StringAssert.AreEqualIgnoringCase(newEnvNameExternalUrlUpdated, env.ExternalUrl);
+            Assert.That(env.Name, Is.EqualTo(newEnvNameUpdated).IgnoreCase);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameUpdatedStart));
+            Assert.That(env.Id, Is.EqualTo(initialEnvId), "Environment Id should not change");
+            Assert.That(env.ExternalUrl, Is.EqualTo(newEnvNameExternalUrlUpdated).IgnoreCase);
 
             // Validate update is effective
             env = envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameUpdated, StringComparison.Ordinal));
-            Assert.IsNotNull(env);
-            StringAssert.StartsWith(newEnvSlugNameUpdatedStart, env.Slug);
-            Assert.AreEqual(initialEnvId, env.Id, "Environment Id should not change");
-            StringAssert.AreEqualIgnoringCase(newEnvNameExternalUrlUpdated, env.ExternalUrl);
+            Assert.That(env, Is.Not.Null);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameUpdatedStart));
+            Assert.That(env.Id, Is.EqualTo(initialEnvId), "Environment Id should not change");
+            Assert.That(env.ExternalUrl, Is.EqualTo(newEnvNameExternalUrlUpdated).IgnoreCase);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NGitLab.Tests
             var newEnvNameToDelete = "env_test_name_to_delete";
 
             // Validate environment doesn't exist yet
-            Assert.IsNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal)), Is.Null);
 
             // Create newEnvNameToDelete
             var env = envClient.Create(newEnvNameToDelete, externalUrl: null);
@@ -118,8 +118,8 @@ namespace NGitLab.Tests
 
             // Validate newEnvNameToDelete is present & available
             env = envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal));
-            Assert.IsNotNull(env);
-            StringAssert.AreEqualIgnoringCase("available", env.State);
+            Assert.That(env, Is.Not.Null);
+            Assert.That(env.State, Is.EqualTo("available").IgnoreCase);
 
             // Trying to delete without stopping beforehand will throw...
             Assert.Throws<GitLabException>(() => envClient.Delete(initialEnvId));
@@ -127,13 +127,13 @@ namespace NGitLab.Tests
             // Stop
             envClient.Stop(initialEnvId);
             env = envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal));
-            StringAssert.AreEqualIgnoringCase("stopped", env.State);
+            Assert.That(env.State, Is.EqualTo("stopped").IgnoreCase);
 
             // Delete
             envClient.Delete(initialEnvId);
 
             // Validate delete is effective
-            Assert.IsNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToDelete, StringComparison.Ordinal)), Is.Null);
         }
 
         [Test]
@@ -148,24 +148,24 @@ namespace NGitLab.Tests
             var newEnvSlugNameToStopStart = GetSlugNameStart(newEnvNameToStop);
 
             // Validate environment doesn't exist yet
-            Assert.IsNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)), Is.Null);
 
             // Create newEnvNameToStop
             var env = envClient.Create(newEnvNameToStop, externalUrl: null);
             var initialEnvId = env.Id;
 
             // Validate newEnvNameToStop is present
-            Assert.IsNotNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)), Is.Not.Null);
 
             // Stop and check return value
             env = envClient.Stop(initialEnvId);
-            StringAssert.AreEqualIgnoringCase(newEnvNameToStop, env.Name);
-            StringAssert.StartsWith(newEnvSlugNameToStopStart, env.Slug);
-            Assert.AreEqual(initialEnvId, env.Id, "Environment Id should not change");
-            Assert.IsNull(env.ExternalUrl);
+            Assert.That(env.Name, Is.EqualTo(newEnvNameToStop).IgnoreCase);
+            Assert.That(env.Slug, Does.StartWith(newEnvSlugNameToStopStart));
+            Assert.That(env.Id, Is.EqualTo(initialEnvId), "Environment Id should not change");
+            Assert.That(env.ExternalUrl, Is.Null);
 
             // Validate environment is still present
-            Assert.IsNotNull(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)));
+            Assert.That(envClient.All.FirstOrDefault(e => string.Equals(e.Name, newEnvNameToStop, StringComparison.Ordinal)), Is.Not.Null);
         }
 
         [Test]
@@ -188,10 +188,10 @@ namespace NGitLab.Tests
             var availableEnvs = envClient.GetEnvironmentsAsync(new EnvironmentQuery { State = "available" });
 
             // Assert
-            Assert.AreEqual(2, envClient.All.Count());
+            Assert.That(envClient.All.Count(), Is.EqualTo(2));
             var availableEnvResult = availableEnvs.Single();
-            Assert.AreEqual(newEnvNameAvailable, availableEnvResult.Name);
-            Assert.AreEqual("available", availableEnvResult.State);
+            Assert.That(availableEnvResult.Name, Is.EqualTo(newEnvNameAvailable));
+            Assert.That(availableEnvResult.State, Is.EqualTo("available"));
         }
 
         [Test]
@@ -213,9 +213,9 @@ namespace NGitLab.Tests
             var prodEnvs = envClient.GetEnvironmentsAsync(new EnvironmentQuery { Name = prodEnvName });
 
             // Assert
-            Assert.AreEqual(2, envClient.All.Count());
+            Assert.That(envClient.All.Count(), Is.EqualTo(2));
             var availableEnvResult = prodEnvs.Single();
-            Assert.AreEqual(prodEnvName, availableEnvResult.Name);
+            Assert.That(availableEnvResult.Name, Is.EqualTo(prodEnvName));
         }
 
         [Test]
@@ -240,8 +240,8 @@ namespace NGitLab.Tests
             var devEnvs = envClient.GetEnvironmentsAsync(new EnvironmentQuery { Search = "dev" });
 
             // Assert
-            Assert.AreEqual(3, envClient.All.Count());
-            Assert.AreEqual(2, devEnvs.Count());
+            Assert.That(envClient.All.Count(), Is.EqualTo(3));
+            Assert.That(devEnvs.Count(), Is.EqualTo(2));
             Assert.That(devEnvs, Is.All.Matches<EnvironmentInfo>(e => e.Name.Contains("dev", StringComparison.Ordinal)));
         }
 
@@ -261,8 +261,8 @@ namespace NGitLab.Tests
             var devEnv = await envClient.GetByIdAsync(devEnvironment.Id);
 
             // Assert
-            Assert.NotNull(devEnv);
-            Assert.AreEqual(devEnvName, devEnv.Name);
+            Assert.That(devEnv, Is.Not.Null);
+            Assert.That(devEnv.Name, Is.EqualTo(devEnvName));
         }
     }
 }

--- a/NGitLab.Tests/FilesTests.cs
+++ b/NGitLab.Tests/FilesTests.cs
@@ -29,16 +29,16 @@ namespace NGitLab.Tests
             filesClient.Create(fileUpsert);
 
             var file = filesClient.Get(fileName, project.DefaultBranch);
-            Assert.IsNotNull(file);
-            Assert.AreEqual(fileName, file.Name);
-            Assert.AreEqual("test", file.DecodedContent);
+            Assert.That(file, Is.Not.Null);
+            Assert.That(file.Name, Is.EqualTo(fileName));
+            Assert.That(file.DecodedContent, Is.EqualTo("test"));
 
             fileUpsert.RawContent = "test2";
             filesClient.Update(fileUpsert);
 
             file = filesClient.Get(fileName, project.DefaultBranch);
-            Assert.IsNotNull(file);
-            Assert.AreEqual("test2", file.DecodedContent);
+            Assert.That(file, Is.Not.Null);
+            Assert.That(file.DecodedContent, Is.EqualTo("test2"));
 
             var fileDelete = new FileDelete
             {
@@ -73,19 +73,19 @@ namespace NGitLab.Tests
 
             var blameArray1 = filesClient.Blame(fileName, project.DefaultBranch);
 
-            Assert.AreEqual(1, blameArray1.Length);
-            Assert.IsNotNull(blameArray1);
+            Assert.That(blameArray1, Has.Length.EqualTo(1));
+            Assert.That(blameArray1, Is.Not.Null);
 
             var firstBlameInfo = blameArray1[0];
 
-            Assert.AreEqual(content1, string.Join(Environment.NewLine, firstBlameInfo.Lines));
-            Assert.AreEqual(fileUpsert1.CommitMessage, firstBlameInfo.Commit.Message);
-            Assert.NotNull(firstBlameInfo.Commit.CommittedDate);
-            Assert.IsNotEmpty(firstBlameInfo.Commit.AuthorEmail);
-            Assert.IsNotEmpty(firstBlameInfo.Commit.AuthorName);
-            Assert.IsNotEmpty(firstBlameInfo.Commit.CommitterEmail);
-            Assert.IsNotEmpty(firstBlameInfo.Commit.CommitterName);
-            Assert.NotNull(firstBlameInfo.Commit.AuthoredDate);
+            Assert.That(string.Join(Environment.NewLine, firstBlameInfo.Lines), Is.EqualTo(content1));
+            Assert.That(firstBlameInfo.Commit.Message, Is.EqualTo(fileUpsert1.CommitMessage));
+            Assert.That(firstBlameInfo.Commit.CommittedDate, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(firstBlameInfo.Commit.AuthorEmail, Is.Not.Empty);
+            Assert.That(firstBlameInfo.Commit.AuthorName, Is.Not.Empty);
+            Assert.That(firstBlameInfo.Commit.CommitterEmail, Is.Not.Empty);
+            Assert.That(firstBlameInfo.Commit.CommitterName, Is.Not.Empty);
+            Assert.That(firstBlameInfo.Commit.AuthoredDate, Is.Not.EqualTo(default(DateTime)));
 
             var content2 = "second line";
             var fileUpsert2 = new FileUpsert
@@ -100,19 +100,19 @@ namespace NGitLab.Tests
 
             var blameArray2 = filesClient.Blame(fileName, project.DefaultBranch);
 
-            Assert.AreEqual(2, blameArray2.Length);
-            Assert.AreEqual(firstBlameInfo, blameArray2[0]);
+            Assert.That(blameArray2, Has.Length.EqualTo(2));
+            Assert.That(blameArray2[0], Is.EqualTo(firstBlameInfo));
 
             var secondBlameInfo = blameArray2[1];
 
-            Assert.AreEqual(content2, string.Join(Environment.NewLine, secondBlameInfo.Lines));
-            Assert.AreEqual(fileUpsert2.CommitMessage, secondBlameInfo.Commit.Message);
-            Assert.NotNull(secondBlameInfo.Commit.CommittedDate);
-            Assert.IsNotEmpty(secondBlameInfo.Commit.AuthorEmail);
-            Assert.IsNotEmpty(secondBlameInfo.Commit.AuthorName);
-            Assert.IsNotEmpty(secondBlameInfo.Commit.CommitterEmail);
-            Assert.IsNotEmpty(secondBlameInfo.Commit.CommitterName);
-            Assert.NotNull(secondBlameInfo.Commit.AuthoredDate);
+            Assert.That(string.Join(Environment.NewLine, secondBlameInfo.Lines), Is.EqualTo(content2));
+            Assert.That(secondBlameInfo.Commit.Message, Is.EqualTo(fileUpsert2.CommitMessage));
+            Assert.That(secondBlameInfo.Commit.CommittedDate, Is.Not.EqualTo(default(DateTime)));
+            Assert.That(secondBlameInfo.Commit.AuthorEmail, Is.Not.Empty);
+            Assert.That(secondBlameInfo.Commit.AuthorName, Is.Not.Empty);
+            Assert.That(secondBlameInfo.Commit.CommitterEmail, Is.Not.Empty);
+            Assert.That(secondBlameInfo.Commit.CommitterName, Is.Not.Empty);
+            Assert.That(secondBlameInfo.Commit.AuthoredDate, Is.Not.EqualTo(default(DateTime)));
 
             var fileDelete = new FileDelete
             {
@@ -145,8 +145,8 @@ namespace NGitLab.Tests
 
             var initialBlame = filesClient.Blame(fileName, project.DefaultBranch);
 
-            Assert.IsNotNull(initialBlame);
-            Assert.AreEqual(1, initialBlame.Length);
+            Assert.That(initialBlame, Is.Not.Null);
+            Assert.That(initialBlame, Has.Length.EqualTo(1));
 
             var initialBlameInfo = initialBlame[0];
 
@@ -163,8 +163,8 @@ namespace NGitLab.Tests
 
             var blameById = filesClient.Blame(fileName, initialBlameInfo.Commit.Id.ToString());
 
-            Assert.AreEqual(1, blameById.Length);
-            Assert.AreEqual(initialBlameInfo, blameById[0]);
+            Assert.That(blameById, Has.Length.EqualTo(1));
+            Assert.That(blameById[0], Is.EqualTo(initialBlameInfo));
 
             var fileDelete = new FileDelete
             {
@@ -197,18 +197,15 @@ namespace NGitLab.Tests
 
             var realBlame = filesClient.Blame(fileName, project.DefaultBranch);
 
-            Assert.IsNotNull(realBlame);
-            Assert.AreEqual(1, realBlame.Length);
+            Assert.That(realBlame, Is.Not.Null);
+            Assert.That(realBlame, Has.Length.EqualTo(1));
 
             var realBlameInfo = realBlame[0];
 
             var dummyBlameInfo = new Blame();
 
-            Assert.AreNotEqual(dummyBlameInfo, realBlameInfo);
-            Assert.AreNotEqual(realBlameInfo, null);
-            Assert.AreNotEqual(null, realBlameInfo);
-            Assert.AreEqual(realBlameInfo, realBlameInfo);
-            Assert.AreEqual(dummyBlameInfo, dummyBlameInfo);
+            Assert.That(realBlameInfo, Is.Not.EqualTo(dummyBlameInfo));
+            Assert.That(realBlameInfo, Is.Not.Null);
 
             var fileDelete = new FileDelete
             {
@@ -239,8 +236,8 @@ namespace NGitLab.Tests
             filesClient.Create(fileUpsert);
 
             var file = filesClient.Get(fileName, project.DefaultBranch);
-            Assert.AreEqual("77u/YQ==", file.Content);
-            Assert.AreEqual("a", file.DecodedContent);
+            Assert.That(file.Content, Is.EqualTo("77u/YQ=="));
+            Assert.That(file.DecodedContent, Is.EqualTo("a"));
         }
     }
 }

--- a/NGitLab.Tests/GitLabChangeDiffCounterTests.cs
+++ b/NGitLab.Tests/GitLabChangeDiffCounterTests.cs
@@ -37,8 +37,8 @@ namespace NGitLab.Tests
             };
             var unitUnderTest = new GitLabChangeDiffCounter();
             var diffStats = unitUnderTest.Compute(mrChange);
-            Assert.AreEqual(53, diffStats.AddedLines);
-            Assert.AreEqual(2, diffStats.DeletedLines);
+            Assert.That(diffStats.AddedLines, Is.EqualTo(53));
+            Assert.That(diffStats.DeletedLines, Is.EqualTo(2));
         }
     }
 }

--- a/NGitLab.Tests/GitLabCredentialsTests.cs
+++ b/NGitLab.Tests/GitLabCredentialsTests.cs
@@ -20,7 +20,7 @@ namespace NGitLab.Tests
         public void Constructor_should_complete_api_version_when_not_set(string url, string expectedUrl)
         {
             var gitLabCredentials = new GitLabCredentials(url, "my_token");
-            Assert.AreEqual(expectedUrl, gitLabCredentials.HostUrl);
+            Assert.That(gitLabCredentials.HostUrl, Is.EqualTo(expectedUrl));
         }
     }
 }

--- a/NGitLab.Tests/GlobalUsings.cs
+++ b/NGitLab.Tests/GlobalUsings.cs
@@ -1,5 +1,0 @@
-﻿// This is needed for quick migration from NUnit 3.x -> 4.x
-// https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html#use-global-using-aliases
-global using Assert = NUnit.Framework.Legacy.ClassicAssert;
-global using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
-global using StringAssert = NUnit.Framework.Legacy.StringAssert;

--- a/NGitLab.Tests/GraphQLTests.cs
+++ b/NGitLab.Tests/GraphQLTests.cs
@@ -26,7 +26,7 @@ namespace NGitLab.Tests
 }",
             }));
 
-            StringAssert.Contains("Field 'unknownProperty' doesn't exist on type 'Project'", exception.Message);
+            Assert.That(exception.Message, Does.Contain("Field 'unknownProperty' doesn't exist on type 'Project'"));
         }
 
         [Test]
@@ -51,7 +51,7 @@ query($path: ID!)
                 },
             });
 
-            Assert.AreEqual("gid://gitlab/Project/" + project.Id.ToStringInvariant(), response.Project.Id);
+            Assert.That(response.Project.Id, Is.EqualTo("gid://gitlab/Project/" + project.Id.ToStringInvariant()));
         }
 
         private sealed class ProjectResponse

--- a/NGitLab.Tests/GroupBadgeClientTests.cs
+++ b/NGitLab.Tests/GroupBadgeClientTests.cs
@@ -23,9 +23,9 @@ namespace NGitLab.Tests
                 LinkUrl = "http://dummy/image.html",
             });
 
-            Assert.AreEqual(BadgeKind.Group, badge.Kind);
-            Assert.AreEqual("http://dummy/image.png", badge.ImageUrl);
-            Assert.AreEqual("http://dummy/image.html", badge.LinkUrl);
+            Assert.That(badge.Kind, Is.EqualTo(BadgeKind.Group));
+            Assert.That(badge.ImageUrl, Is.EqualTo("http://dummy/image.png"));
+            Assert.That(badge.LinkUrl, Is.EqualTo("http://dummy/image.html"));
 
             // Update
             badge = groupBadgeClient.Update(badge.Id, new BadgeUpdate
@@ -34,22 +34,22 @@ namespace NGitLab.Tests
                 LinkUrl = "http://dummy/image_edit.html",
             });
 
-            Assert.AreEqual(BadgeKind.Group, badge.Kind);
-            Assert.AreEqual("http://dummy/image_edit.png", badge.ImageUrl);
-            Assert.AreEqual("http://dummy/image_edit.html", badge.LinkUrl);
+            Assert.That(badge.Kind, Is.EqualTo(BadgeKind.Group));
+            Assert.That(badge.ImageUrl, Is.EqualTo("http://dummy/image_edit.png"));
+            Assert.That(badge.LinkUrl, Is.EqualTo("http://dummy/image_edit.html"));
 
             // Delete
             groupBadgeClient.Delete(badge.Id);
 
             var badges = groupBadgeClient.All.ToList();
-            Assert.IsEmpty(badges);
+            Assert.That(badges, Is.Empty);
 
             // All
             groupBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image1.png", LinkUrl = "http://dummy/image1.html", });
             groupBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image2.png", LinkUrl = "http://dummy/image2.html", });
             groupBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image3.png", LinkUrl = "http://dummy/image3.html", });
             badges = groupBadgeClient.All.ToList();
-            Assert.AreEqual(3, badges.Count);
+            Assert.That(badges, Has.Count.EqualTo(3));
         }
     }
 }

--- a/NGitLab.Tests/GroupVariableClientTests.cs
+++ b/NGitLab.Tests/GroupVariableClientTests.cs
@@ -24,9 +24,9 @@ namespace NGitLab.Tests
                 Protected = true,
             });
 
-            Assert.AreEqual("My_Key", variable.Key);
-            Assert.AreEqual("My value", variable.Value);
-            Assert.AreEqual(true, variable.Protected);
+            Assert.That(variable.Key, Is.EqualTo("My_Key"));
+            Assert.That(variable.Value, Is.EqualTo("My value"));
+            Assert.That(variable.Protected, Is.EqualTo(true));
 
             // Update
             variable = groupVariableClient.Update(variable.Key, new VariableUpdate
@@ -35,22 +35,22 @@ namespace NGitLab.Tests
                 Protected = false,
             });
 
-            Assert.AreEqual("My_Key", variable.Key);
-            Assert.AreEqual("My value edited", variable.Value);
-            Assert.AreEqual(false, variable.Protected);
+            Assert.That(variable.Key, Is.EqualTo("My_Key"));
+            Assert.That(variable.Value, Is.EqualTo("My value edited"));
+            Assert.That(variable.Protected, Is.EqualTo(false));
 
             // Delete
             groupVariableClient.Delete(variable.Key);
 
             var variables = groupVariableClient.All.ToList();
-            Assert.IsEmpty(variables);
+            Assert.That(variables, Is.Empty);
 
             // All
             groupVariableClient.Create(new VariableCreate { Key = "Variable1", Value = "test" });
             groupVariableClient.Create(new VariableCreate { Key = "Variable2", Value = "test" });
             groupVariableClient.Create(new VariableCreate { Key = "Variable3", Value = "test" });
             variables = groupVariableClient.All.ToList();
-            Assert.AreEqual(3, variables.Count);
+            Assert.That(variables, Has.Count.EqualTo(3));
         }
     }
 }

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests
             var groupClient = context.Client.Groups;
             var group = context.CreateGroup();
 
-            Assert.IsNotEmpty(groupClient.Accessible);
+            Assert.That(groupClient.Accessible, Is.Not.Empty);
         }
 
         [Test]
@@ -32,9 +32,9 @@ namespace NGitLab.Tests
             var project = context.Client.Projects.Create(new ProjectCreate { Name = "test", NamespaceId = group.Id.ToString(CultureInfo.InvariantCulture) });
 
             group = groupClient[group.Id];
-            Assert.IsNotNull(group);
-            Assert.IsNotEmpty(group.Projects);
-            Assert.AreEqual(project.Id, group.Projects[0].Id);
+            Assert.That(group, Is.Not.Null);
+            Assert.That(group.Projects, Is.Not.Empty);
+            Assert.That(group.Projects[0].Id, Is.EqualTo(project.Id));
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace NGitLab.Tests
             var group = context.CreateGroup();
 
             group = groupClient[group.FullPath];
-            Assert.IsNotNull(group);
+            Assert.That(group, Is.Not.Null);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace NGitLab.Tests
 
             // Search
             var searchedGroup = groupClient.Search(group.Name).Single();
-            Assert.AreEqual(group.Id, searchedGroup.Id);
+            Assert.That(searchedGroup.Id, Is.EqualTo(group.Id));
 
             // Delete (operation is asynchronous so we have to retry until the project is deleted)
             // Group can be marked for deletion (https://docs.gitlab.com/ee/user/admin_area/settings/visibility_and_access_controls.html#default-deletion-adjourned-period-premium-only)
@@ -91,7 +91,7 @@ namespace NGitLab.Tests
             var groupQueryNull = new GroupQuery();
 
             // Act & Assert
-            Assert.NotNull(groupClient.Get(groupQueryNull).Take(10).ToList());
+            Assert.That(groupClient.Get(groupQueryNull).Take(10).ToList(), Is.Not.Null);
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace NGitLab.Tests
             // Assert
             foreach (var skippedGroup in skippedGroupIds)
             {
-                Assert.False(resultSkip.Any(group => group.Id == skippedGroup), $"Group {skippedGroup} found in results");
+                Assert.That(resultSkip.Any(group => group.Id == skippedGroup), Is.False, $"Group {skippedGroup} found in results");
             }
         }
 
@@ -136,7 +136,7 @@ namespace NGitLab.Tests
             var result = groupClient.Get(groupQueryNull).Count(g => string.Equals(g.Name, group1.Name, StringComparison.Ordinal));
 
             // Assert
-            Assert.AreEqual(1, result);
+            Assert.That(result, Is.EqualTo(1));
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace NGitLab.Tests
             var result = groupClient.Get(groupQueryAllAvailable);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -188,9 +188,9 @@ namespace NGitLab.Tests
             var resultById = groupClient.Get(groupQueryOrderById);
 
             // Assert
-            Assert.IsTrue(resultByName.Any());
-            Assert.IsTrue(resultByPath.Any());
-            Assert.IsTrue(resultById.Any());
+            Assert.That(resultByName.Any(), Is.True);
+            Assert.That(resultByPath.Any(), Is.True);
+            Assert.That(resultById.Any(), Is.True);
         }
 
         [Test]
@@ -216,8 +216,8 @@ namespace NGitLab.Tests
             var resultDesc = groupClient.Get(groupQueryDesc);
 
             // Assert
-            Assert.IsTrue(resultAsc.Any());
-            Assert.IsTrue(resultDesc.Any());
+            Assert.That(resultAsc.Any(), Is.True);
+            Assert.That(resultDesc.Any(), Is.True);
         }
 
         [Test]
@@ -237,7 +237,7 @@ namespace NGitLab.Tests
             var result = groupClient.Get(groupQueryWithStats);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -257,7 +257,7 @@ namespace NGitLab.Tests
             var result = groupClient.Get(groupQueryWithCustomAttributes);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -277,7 +277,7 @@ namespace NGitLab.Tests
             var result = groupClient.Get(groupQueryOwned);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -317,11 +317,11 @@ namespace NGitLab.Tests
             var result50 = groupClient.Get(groupQuery50);
 
             // Assert
-            Assert.IsTrue(result10.Any());
-            Assert.IsTrue(result20.Any());
-            Assert.IsTrue(result30.Any());
-            Assert.IsTrue(result40.Any());
-            Assert.IsTrue(result50.Any());
+            Assert.That(result10.Any(), Is.True);
+            Assert.That(result20.Any(), Is.True);
+            Assert.That(result30.Any(), Is.True);
+            Assert.That(result40.Any(), Is.True);
+            Assert.That(result50.Any(), Is.True);
         }
 
         [Test]
@@ -342,12 +342,12 @@ namespace NGitLab.Tests
             }).ToArray();
 
             group = groupClient[group.Id];
-            Assert.IsNotNull(group);
-            Assert.IsNotEmpty(projects);
+            Assert.That(group, Is.Not.Null);
+            Assert.That(projects, Is.Not.Empty);
 
             var projectResult = projects.Single();
-            Assert.AreEqual(project.Id, projectResult.Id);
-            Assert.True(projectResult.Archived);
+            Assert.That(projectResult.Id, Is.EqualTo(project.Id));
+            Assert.That(projectResult.Archived, Is.True);
         }
 
         [Test]
@@ -368,11 +368,11 @@ namespace NGitLab.Tests
             }).ToArray();
 
             group = groupClient[group.Id];
-            Assert.IsNotNull(group);
-            Assert.IsNotEmpty(projects);
+            Assert.That(group, Is.Not.Null);
+            Assert.That(projects, Is.Not.Empty);
 
             var projectResult = projects.Single();
-            Assert.AreEqual(project.Id, projectResult.Id);
+            Assert.That(projectResult.Id, Is.EqualTo(project.Id));
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace NGitLab.Tests
             var subGroupThree = context.CreateGroup(configure: group => group.ParentId = parentGroupTwo.Id);
 
             var subgroups = groupClient.GetSubgroupsByIdAsync(parentGroupOne.Id);
-            Assert.AreEqual(2, subgroups.Count());
+            Assert.That(subgroups.Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -406,7 +406,7 @@ namespace NGitLab.Tests
             var subGroupThree = context.CreateGroup(configure: group => group.ParentId = parentGroupTwo.Id);
 
             var subgroups = groupClient.GetSubgroupsByFullPathAsync(parentGroupOne.FullPath);
-            Assert.AreEqual(2, subgroups.Count());
+            Assert.That(subgroups.Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -430,7 +430,7 @@ namespace NGitLab.Tests
             // Assert
             foreach (var skippedGroup in skippedGroupIds)
             {
-                Assert.False(resultSkip.Any(group => group.Id == skippedGroup), $"Group {skippedGroup} found in results");
+                Assert.That(resultSkip.Any(group => group.Id == skippedGroup), Is.False, $"Group {skippedGroup} found in results");
             }
         }
 
@@ -455,7 +455,7 @@ namespace NGitLab.Tests
             // Assert
             foreach (var skippedGroup in skippedGroupIds)
             {
-                Assert.False(resultSkip.Any(group => group.Id == skippedGroup), $"Group {skippedGroup} found in results");
+                Assert.That(resultSkip.Any(group => group.Id == skippedGroup), Is.False, $"Group {skippedGroup} found in results");
             }
         }
 
@@ -481,7 +481,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQuery).Count(g => string.Equals(g.Name, subGroupOne.Name, StringComparison.Ordinal));
 
             // Assert
-            Assert.AreEqual(1, result);
+            Assert.That(result, Is.EqualTo(1));
         }
 
         [Test]
@@ -506,7 +506,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQuery).Count(g => string.Equals(g.Name, subGroupOne.Name, StringComparison.Ordinal));
 
             // Assert
-            Assert.AreEqual(1, result);
+            Assert.That(result, Is.EqualTo(1));
         }
 
         [Test]
@@ -531,7 +531,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryAllAvailable);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -556,7 +556,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryAllAvailable);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -591,9 +591,9 @@ namespace NGitLab.Tests
             var resultById = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryOrderById);
 
             // Assert
-            Assert.IsTrue(resultByName.Any());
-            Assert.IsTrue(resultByPath.Any());
-            Assert.IsTrue(resultById.Any());
+            Assert.That(resultByName.Any(), Is.True);
+            Assert.That(resultByPath.Any(), Is.True);
+            Assert.That(resultById.Any(), Is.True);
         }
 
         [Test]
@@ -628,9 +628,9 @@ namespace NGitLab.Tests
             var resultById = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryOrderById);
 
             // Assert
-            Assert.IsTrue(resultByName.Any());
-            Assert.IsTrue(resultByPath.Any());
-            Assert.IsTrue(resultById.Any());
+            Assert.That(resultByName.Any(), Is.True);
+            Assert.That(resultByPath.Any(), Is.True);
+            Assert.That(resultById.Any(), Is.True);
         }
 
         [Test]
@@ -660,8 +660,8 @@ namespace NGitLab.Tests
             var resultDesc = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryDesc);
 
             // Assert
-            Assert.IsTrue(resultAsc.Any());
-            Assert.IsTrue(resultDesc.Any());
+            Assert.That(resultAsc.Any(), Is.True);
+            Assert.That(resultDesc.Any(), Is.True);
         }
 
         [Test]
@@ -691,8 +691,8 @@ namespace NGitLab.Tests
             var resultDesc = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryDesc);
 
             // Assert
-            Assert.IsTrue(resultAsc.Any());
-            Assert.IsTrue(resultDesc.Any());
+            Assert.That(resultAsc.Any(), Is.True);
+            Assert.That(resultDesc.Any(), Is.True);
         }
 
         [Test]
@@ -716,7 +716,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryWithStats);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -740,7 +740,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryWithStats);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -764,7 +764,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryWithCustomAttributes);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -788,7 +788,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryWithCustomAttributes);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -812,7 +812,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryOwned);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -836,7 +836,7 @@ namespace NGitLab.Tests
             var result = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryOwned);
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -880,11 +880,11 @@ namespace NGitLab.Tests
             var resultOwner = groupClient.GetSubgroupsByIdAsync(parentGroup.Id, groupQueryOwner);
 
             // Assert
-            Assert.IsTrue(resultGuest.Any());
-            Assert.IsTrue(resultReporter.Any());
-            Assert.IsTrue(resultDeveloper.Any());
-            Assert.IsTrue(resultMantainer.Any());
-            Assert.IsTrue(resultOwner.Any());
+            Assert.That(resultGuest.Any(), Is.True);
+            Assert.That(resultReporter.Any(), Is.True);
+            Assert.That(resultDeveloper.Any(), Is.True);
+            Assert.That(resultMantainer.Any(), Is.True);
+            Assert.That(resultOwner.Any(), Is.True);
         }
 
         [Test]
@@ -928,11 +928,11 @@ namespace NGitLab.Tests
             var resultOwner = groupClient.GetSubgroupsByFullPathAsync(parentGroup.FullPath, groupQueryOwner);
 
             // Assert
-            Assert.IsTrue(resultGuest.Any());
-            Assert.IsTrue(resultReporter.Any());
-            Assert.IsTrue(resultDeveloper.Any());
-            Assert.IsTrue(resultMantainer.Any());
-            Assert.IsTrue(resultOwner.Any());
+            Assert.That(resultGuest.Any(), Is.True);
+            Assert.That(resultReporter.Any(), Is.True);
+            Assert.That(resultDeveloper.Any(), Is.True);
+            Assert.That(resultMantainer.Any(), Is.True);
+            Assert.That(resultOwner.Any(), Is.True);
         }
     }
 }

--- a/NGitLab.Tests/HttpRequestorTests.cs
+++ b/NGitLab.Tests/HttpRequestorTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests
             // Make sure at least 1 project exists
             using var context = await GitLabTestContext.CreateAsync();
             var project = context.CreateProject();
-            Assert.NotNull(project);
+            Assert.That(project, Is.Not.Null);
         }
 
         [Test]
@@ -32,8 +32,8 @@ namespace NGitLab.Tests
 
             Assert.Throws<GitLabException>(() => httpRequestor.Execute("invalidUrl"));
             Assert.That(requestOptions.ShouldRetryCalled, Is.True);
-            Assert.That(requestOptions.HandledRequests.Count, Is.EqualTo(2));
-            Assert.IsNull(requestOptions.HttpRequestSudoHeader);
+            Assert.That(requestOptions.HandledRequests, Has.Count.EqualTo(2));
+            Assert.That(requestOptions.HttpRequestSudoHeader, Is.Null);
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace NGitLab.Tests
             var httpRequestor = new HttpRequestor(context.DockerContainer.GitLabUrl.ToString(), context.DockerContainer.Credentials.UserToken, MethodType.Get, requestOptions);
             Assert.Throws<GitLabException>(() => httpRequestor.Execute("invalidUrl"));
 
-            Assert.AreEqual(TimeSpan.FromMinutes(2).TotalMilliseconds, requestOptions.HandledRequests.Single().Timeout);
+            Assert.That(requestOptions.HandledRequests.Single().Timeout, Is.EqualTo(TimeSpan.FromMinutes(2).TotalMilliseconds));
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace NGitLab.Tests
             var httpRequestor = new HttpRequestor(context.DockerContainer.GitLabUrl.ToString(), context.DockerContainer.Credentials.UserToken, MethodType.Get, requestOptions);
 
             Assert.Throws<GitLabException>(() => httpRequestor.Execute("invalidUrl"));
-            Assert.AreEqual("UserToImpersonate", requestOptions.HttpRequestSudoHeader);
+            Assert.That(requestOptions.HttpRequestSudoHeader, Is.EqualTo("UserToImpersonate"));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace NGitLab.Tests
             });
 
             // Assert
-            Assert.AreEqual(commonUserSession.Username, issue.Author.Username);
+            Assert.That(issue.Author.Username, Is.EqualTo(commonUserSession.Username));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace NGitLab.Tests
             });
 
             // Assert
-            Assert.AreEqual(commonUserSession.Id, issue.Author.Id);
+            Assert.That(issue.Author.Id, Is.EqualTo(commonUserSession.Id));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace NGitLab.Tests
 
             // Assert
             var actualHeaderValue = context.LastRequest.Headers[HttpRequestHeader.Authorization];
-            Assert.AreEqual(expectedHeaderValue, actualHeaderValue);
+            Assert.That(actualHeaderValue, Is.EqualTo(expectedHeaderValue));
         }
 
         private sealed class MockRequestOptions : RequestOptions

--- a/NGitLab.Tests/Impl/DynamicEnumTests.cs
+++ b/NGitLab.Tests/Impl/DynamicEnumTests.cs
@@ -7,10 +7,10 @@ namespace NGitLab.Tests.Impl
         [Test]
         public void Test_comparison()
         {
-            Assert.AreEqual(new DynamicEnum<MockEnum>(MockEnum.A), MockEnum.A);
-            Assert.AreNotEqual(new DynamicEnum<MockEnum>(MockEnum.A), MockEnum.B);
-            Assert.AreEqual(new DynamicEnum<MockEnum>("unknown").StringValue, "unknown");
-            Assert.AreNotEqual(new DynamicEnum<MockEnum>("unknown").StringValue, "other");
+            Assert.That(new DynamicEnum<MockEnum>(MockEnum.A), Is.EqualTo(MockEnum.A));
+            Assert.That(new DynamicEnum<MockEnum>(MockEnum.A), Is.Not.EqualTo(MockEnum.B));
+            Assert.That(new DynamicEnum<MockEnum>("unknown").StringValue, Is.EqualTo("unknown"));
+            Assert.That(new DynamicEnum<MockEnum>("unknown").StringValue, Is.Not.EqualTo("other"));
         }
 
         public enum MockEnum

--- a/NGitLab.Tests/Impl/JsonConverterTests.cs
+++ b/NGitLab.Tests/Impl/JsonConverterTests.cs
@@ -20,12 +20,12 @@ namespace NGitLab.Tests.Impl
 }";
             var obj = Serializer.Deserialize<MyDataContract>(json);
 
-            Assert.NotNull(obj);
-            Assert.AreEqual(false, obj.SomeBool);
-            Assert.AreEqual(DateTime.MinValue, obj.SomeDateTime);
-            Assert.AreEqual(0.0, obj.SomeDouble);
-            Assert.AreEqual(0, obj.SomeInt32);
-            Assert.AreEqual(0L, obj.SomeInt64);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.SomeBool, Is.EqualTo(false));
+            Assert.That(obj.SomeDateTime, Is.EqualTo(DateTime.MinValue));
+            Assert.That(obj.SomeDouble, Is.EqualTo(0.0));
+            Assert.That(obj.SomeInt32, Is.EqualTo(0));
+            Assert.That(obj.SomeInt64, Is.EqualTo(0L));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace NGitLab.Tests.Impl
         {
             var json = @"{ ""a_uint32"": null }";
             var ex = Assert.Throws<JsonException>(() => Serializer.Deserialize<MyDataContract>(json));
-            StringAssert.StartsWith("The JSON value could not be converted to System.UInt32.", ex.Message);
+            Assert.That(ex.Message, Does.StartWith("The JSON value could not be converted to System.UInt32."));
         }
 
         [Test]
@@ -41,8 +41,8 @@ namespace NGitLab.Tests.Impl
         {
             var json = @"{ ""an_int32"": ""1234"" }";
             var obj = Serializer.Deserialize<MyDataContract>(json);
-            Assert.NotNull(obj);
-            Assert.AreEqual(1234, obj.SomeInt32);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.SomeInt32, Is.EqualTo(1234));
         }
 
         [Test]
@@ -50,8 +50,8 @@ namespace NGitLab.Tests.Impl
         {
             var json = @"{ ""an_int64"": ""-1234"" }";
             var obj = Serializer.Deserialize<MyDataContract>(json);
-            Assert.NotNull(obj);
-            Assert.AreEqual(-1234L, obj.SomeInt64);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.SomeInt64, Is.EqualTo(-1234L));
         }
 
         [Test]
@@ -59,8 +59,8 @@ namespace NGitLab.Tests.Impl
         {
             var json = @"{ ""a_double"": ""-1234.5"" }";
             var obj = Serializer.Deserialize<MyDataContract>(json);
-            Assert.NotNull(obj);
-            Assert.AreEqual(-1234.5d, obj.SomeDouble);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.SomeDouble, Is.EqualTo(-1234.5d));
         }
 
         [TestCase("2022-01-12", DateTimeKind.Unspecified)]
@@ -70,9 +70,9 @@ namespace NGitLab.Tests.Impl
         {
             var json = $@"{{ ""a_date_time"": ""{input}"" }}";
             var obj = Serializer.Deserialize<MyDataContract>(json);
-            Assert.NotNull(obj);
-            Assert.AreEqual(kind, obj.SomeDateTime.Kind);
-            Assert.AreEqual(new DateTime(2022, 1, 12).Date, obj.SomeDateTime.Date);
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.SomeDateTime.Kind, Is.EqualTo(kind));
+            Assert.That(obj.SomeDateTime.Date, Is.EqualTo(new DateTime(2022, 1, 12).Date));
         }
 
         public class MyDataContract

--- a/NGitLab.Tests/IssueTests.cs
+++ b/NGitLab.Tests/IssueTests.cs
@@ -24,7 +24,7 @@ namespace NGitLab.Tests
                 State = IssueState.opened,
             }).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(2, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -40,8 +40,8 @@ namespace NGitLab.Tests
 
             var issue = adminIssuesClient.GetById(issue1.Id);
 
-            Assert.AreEqual(issue1.Id, issue.Id);
-            Assert.AreEqual(issue1.IssueId, issue.IssueId);
+            Assert.That(issue.Id, Is.EqualTo(issue1.Id));
+            Assert.That(issue.IssueId, Is.EqualTo(issue1.IssueId));
         }
 
         [Test]
@@ -60,8 +60,8 @@ namespace NGitLab.Tests
                 State = IssueState.opened,
             }).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(1, issues.Count);
-            Assert.AreEqual(issue1.Id, issues[0].Id);
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Id, Is.EqualTo(issue1.Id));
         }
 
         [Test]
@@ -80,8 +80,8 @@ namespace NGitLab.Tests
                 State = IssueState.opened,
             }).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(1, issues.Count);
-            Assert.AreEqual(issue2.Id, issues[0].Id);
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Id, Is.EqualTo(issue2.Id));
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NGitLab.Tests
                 Confidential = true,
             }).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(2, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace NGitLab.Tests
                 Confidential = false,
             }).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(1, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace NGitLab.Tests
 
             var issues = issuesClient.Get(new IssueQuery()).Where(i => i.ProjectId == project.Id).ToList();
 
-            Assert.AreEqual(3, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(3));
         }
 
         [Test]
@@ -154,8 +154,8 @@ namespace NGitLab.Tests
                 State = IssueState.opened,
             }).ToList();
 
-            Assert.AreEqual(1, issues.Count);
-            Assert.AreEqual(issue2.Id, issues[0].Id);
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues[0].Id, Is.EqualTo(issue2.Id));
         }
 
         [Test]
@@ -180,10 +180,10 @@ namespace NGitLab.Tests
             var issue2 = issuesClient.Create(new IssueCreate { ProjectId = project.Id, Title = "title2", AssigneeId = context.Client.Users.Current.Id });
 
             var issues = issuesClient.ForProject(project.Id).ToList();
-            Assert.AreEqual(2, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(2));
 
             issues = issuesClient.Get(project.Id, new IssueQuery()).ToList();
-            Assert.AreEqual(2, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(2));
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace NGitLab.Tests
             var issue1 = issuesClient.Create(new IssueCreate { ProjectId = project.Id, Title = "title1" });
 
             var issues = issuesClient.ForProject(project.Id).ToList();
-            Assert.AreEqual(1, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(1));
 
             var testLabel = "test";
             var updatedIssue = issues[0];
@@ -215,15 +215,15 @@ namespace NGitLab.Tests
             });
 
             var resourceLabelEvents = issuesClient.ResourceLabelEvents(project.Id, updatedIssue.IssueId).ToList();
-            Assert.AreEqual(2, resourceLabelEvents.Count);
+            Assert.That(resourceLabelEvents, Has.Count.EqualTo(2));
 
             var addLabelEvent = resourceLabelEvents.First(e => e.Action == ResourceLabelEventAction.Add);
-            Assert.AreEqual(testLabel, addLabelEvent.Label.Name);
-            Assert.AreEqual(ResourceLabelEventAction.Add, addLabelEvent.Action);
+            Assert.That(addLabelEvent.Label.Name, Is.EqualTo(testLabel));
+            Assert.That(addLabelEvent.Action, Is.EqualTo(ResourceLabelEventAction.Add));
 
             var removeLabelEvent = resourceLabelEvents.First(e => e.Action == ResourceLabelEventAction.Remove);
-            Assert.AreEqual(testLabel, removeLabelEvent.Label.Name);
-            Assert.AreEqual(ResourceLabelEventAction.Remove, removeLabelEvent.Action);
+            Assert.That(removeLabelEvent.Label.Name, Is.EqualTo(testLabel));
+            Assert.That(removeLabelEvent.Action, Is.EqualTo(ResourceLabelEventAction.Remove));
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace NGitLab.Tests
             var issue1 = issuesClient.Create(new IssueCreate { ProjectId = project.Id, Title = "title1" });
 
             var issues = issuesClient.ForProject(project.Id).ToList();
-            Assert.AreEqual(1, issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(1));
 
             var milestoneClient = context.Client.GetMilestone(project.Id);
             var milestone1 = milestoneClient.Create(new MilestoneCreate { Title = "TestMilestone", Description = "Milestone for Testing", StartDate = "2020-01-27T05:07:12.573Z", DueDate = "2020-05-26T05:07:12.573Z" });
@@ -257,17 +257,17 @@ namespace NGitLab.Tests
             });
 
             var resourceLabelEvents = issuesClient.ResourceMilestoneEvents(project.Id, updatedIssue.IssueId).ToList();
-            Assert.AreEqual(2, resourceLabelEvents.Count);
+            Assert.That(resourceLabelEvents, Has.Count.EqualTo(2));
 
             var addMilestoneEvent = resourceLabelEvents.First(e => e.Action == ResourceMilestoneEventAction.Add);
-            Assert.AreEqual(milestone1.Id, addMilestoneEvent.Milestone.Id);
-            Assert.AreEqual(milestone1.Title, addMilestoneEvent.Milestone.Title);
-            Assert.AreEqual(ResourceMilestoneEventAction.Add, addMilestoneEvent.Action);
+            Assert.That(addMilestoneEvent.Milestone.Id, Is.EqualTo(milestone1.Id));
+            Assert.That(addMilestoneEvent.Milestone.Title, Is.EqualTo(milestone1.Title));
+            Assert.That(addMilestoneEvent.Action, Is.EqualTo(ResourceMilestoneEventAction.Add));
 
             var removeMilestoneEvent = resourceLabelEvents.First(e => e.Action == ResourceMilestoneEventAction.Remove);
-            Assert.AreEqual(milestone1.Id, removeMilestoneEvent.Milestone.Id);
-            Assert.AreEqual(milestone1.Title, addMilestoneEvent.Milestone.Title);
-            Assert.AreEqual(ResourceMilestoneEventAction.Remove, removeMilestoneEvent.Action);
+            Assert.That(removeMilestoneEvent.Milestone.Id, Is.EqualTo(milestone1.Id));
+            Assert.That(addMilestoneEvent.Milestone.Title, Is.EqualTo(milestone1.Title));
+            Assert.That(removeMilestoneEvent.Action, Is.EqualTo(ResourceMilestoneEventAction.Remove));
         }
 
         [Test]
@@ -281,7 +281,7 @@ namespace NGitLab.Tests
             var initialDueDate = new DateTime(2022, 1, 1);
             var issue1 = issuesClient.Create(new IssueCreate { ProjectId = project.Id, Title = "title1", DueDate = initialDueDate });
             var issue = issuesClient.Get(project.Id, issue1.IssueId);
-            Assert.AreEqual(initialDueDate, issue1.DueDate);
+            Assert.That(issue1.DueDate, Is.EqualTo(initialDueDate));
 
             var updatedDueDate = new DateTime(2022, 2, 1);
             var updatedIssue = issuesClient.Edit(new IssueEdit
@@ -291,7 +291,7 @@ namespace NGitLab.Tests
                 DueDate = updatedDueDate,
             });
 
-            Assert.AreEqual(updatedDueDate, updatedIssue.DueDate);
+            Assert.That(updatedIssue.DueDate, Is.EqualTo(updatedDueDate));
         }
 
         [Test]
@@ -305,11 +305,11 @@ namespace NGitLab.Tests
             var issue1 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title1" });
             var issue2 = await issuesClient.CreateAsync(new IssueCreate { ProjectId = project.Id, Title = "title2", Description = "related to #1" });
             var linked = issuesClient.CreateLinkBetweenIssues(project.Id, issue1.IssueId, project.Id, issue2.IssueId);
-            Assert.IsTrue(linked, "Expected true for create Link between issues");
+            Assert.That(linked, Is.True, "Expected true for create Link between issues");
             var issues = issuesClient.LinkedToAsync(project.Id, issue1.IssueId).ToList();
 
             // for now, no API to link issues so not links exist but API should not throw
-            Assert.AreEqual(1, issues.Count, "Expected 1. Got {0}", issues.Count);
+            Assert.That(issues, Has.Count.EqualTo(1), $"Expected 1. Got {issues.Count}");
         }
     }
 }

--- a/NGitLab.Tests/JobTests.cs
+++ b/NGitLab.Tests/JobTests.cs
@@ -91,8 +91,8 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 }),
                 jobs => jobs.Any(), TimeSpan.FromMinutes(2));
 
-            Assert.That(jobs.First().Status == JobStatus.Canceled, Is.True);
-            Assert.That(jobs.Last().Status == JobStatus.Pending, Is.True);
+            Assert.That(jobs.First().Status, Is.EqualTo(JobStatus.Canceled));
+            Assert.That(jobs.Last().Status, Is.EqualTo(JobStatus.Pending));
         }
 
         [Test]

--- a/NGitLab.Tests/JobTests.cs
+++ b/NGitLab.Tests/JobTests.cs
@@ -56,7 +56,7 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
             var project = context.CreateProject();
             AddGitLabCiFile(context.Client, project);
             var jobs = await GitLabTestContext.RetryUntilAsync(() => context.Client.GetJobs(project.Id).GetJobs(JobScopeMask.Pending), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
-            Assert.AreEqual(JobStatus.Pending, jobs.First().Status);
+            Assert.That(jobs.First().Status, Is.EqualTo(JobStatus.Pending));
         }
 
         [Test]
@@ -67,7 +67,7 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
             var project = context.CreateProject();
             AddGitLabCiFile(context.Client, project, manualAction: true);
             var jobs = await GitLabTestContext.RetryUntilAsync(() => context.Client.GetJobs(project.Id).GetJobs(JobScopeMask.Manual), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
-            Assert.AreEqual(JobStatus.Manual, jobs.First().Status);
+            Assert.That(jobs.First().Status, Is.EqualTo(JobStatus.Manual));
         }
 
         [Test]
@@ -91,8 +91,8 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 }),
                 jobs => jobs.Any(), TimeSpan.FromMinutes(2));
 
-            Assert.IsTrue(jobs.First().Status == JobStatus.Canceled);
-            Assert.IsTrue(jobs.Last().Status == JobStatus.Pending);
+            Assert.That(jobs.First().Status == JobStatus.Canceled, Is.True);
+            Assert.That(jobs.Last().Status == JobStatus.Pending, Is.True);
         }
 
         [Test]
@@ -105,14 +105,14 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
             AddGitLabCiFile(context.Client, project, manualAction: true);
             var jobs = await GitLabTestContext.RetryUntilAsync(() => jobsClient.GetJobs(JobScopeMask.Manual), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
             var job = jobs.Single();
-            Assert.AreEqual(JobStatus.Manual, job.Status);
+            Assert.That(job.Status, Is.EqualTo(JobStatus.Manual));
 
             var playedJob = jobsClient.RunAction(job.Id, JobAction.Play);
 
-            Assert.AreEqual(job.Id, playedJob.Id);
-            Assert.AreEqual(job.Pipeline.Id, playedJob.Pipeline.Id);
-            Assert.AreEqual(job.Commit.Id, playedJob.Commit.Id);
-            Assert.AreEqual(JobStatus.Pending, playedJob.Status);
+            Assert.That(playedJob.Id, Is.EqualTo(job.Id));
+            Assert.That(playedJob.Pipeline.Id, Is.EqualTo(job.Pipeline.Id));
+            Assert.That(playedJob.Commit.Id, Is.EqualTo(job.Commit.Id));
+            Assert.That(playedJob.Status, Is.EqualTo(JobStatus.Pending));
         }
 
         [Test]
@@ -132,9 +132,9 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
 
             var retriedJob = jobsClient.RunAction(job.Id, JobAction.Retry);
 
-            Assert.AreNotEqual(job.Id, retriedJob.Id);
-            Assert.AreEqual(job.Pipeline.Id, retriedJob.Pipeline.Id);
-            Assert.AreEqual(job.Commit.Id, retriedJob.Commit.Id);
+            Assert.That(retriedJob.Id, Is.Not.EqualTo(job.Id));
+            Assert.That(retriedJob.Pipeline.Id, Is.EqualTo(job.Pipeline.Id));
+            Assert.That(retriedJob.Commit.Id, Is.EqualTo(job.Commit.Id));
         }
 
         [Test]
@@ -150,9 +150,9 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
 
             var job2 = jobsClient.Get(job.Id);
 
-            Assert.AreEqual(job.Id, job2.Id); // Same Job
-            Assert.AreEqual(job.Pipeline.Id, job2.Pipeline.Id); // Same Pipeline
-            Assert.AreEqual(job.Commit.Id, job2.Commit.Id); // Same Commit
+            Assert.That(job2.Id, Is.EqualTo(job.Id)); // Same Job
+            Assert.That(job2.Pipeline.Id, Is.EqualTo(job.Pipeline.Id)); // Same Pipeline
+            Assert.That(job2.Commit.Id, Is.EqualTo(job.Commit.Id)); // Same Commit
         }
 
         [Test]
@@ -197,11 +197,11 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 AddGitLabCiFile(context.Client, project);
                 var jobs = await GitLabTestContext.RetryUntilAsync(() => jobsClient.GetJobs(JobScopeMask.Success), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
                 var job = jobs.Single();
-                Assert.AreEqual(JobStatus.Success, job.Status);
+                Assert.That(job.Status, Is.EqualTo(JobStatus.Success));
 
                 var artifacts = jobsClient.GetJobArtifacts(job.Id);
 
-                Assert.IsNotEmpty(artifacts);
+                Assert.That(artifacts, Is.Not.Empty);
             }
         }
 
@@ -217,13 +217,13 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 AddGitLabCiFile(context.Client, project);
                 var jobs = await GitLabTestContext.RetryUntilAsync(() => jobsClient.GetJobs(JobScopeMask.Success), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
                 var job = jobs.Single();
-                Assert.AreEqual(JobStatus.Success, job.Status);
+                Assert.That(job.Status, Is.EqualTo(JobStatus.Success));
 
                 var artifact = jobsClient.GetJobArtifact(job.Id, "file0.txt");
-                Assert.IsNotEmpty(artifact);
+                Assert.That(artifact, Is.Not.Empty);
 
                 var content = Encoding.ASCII.GetString(artifact).Trim();
-                Assert.AreEqual("test", content);
+                Assert.That(content, Is.EqualTo("test"));
             }
         }
 
@@ -239,7 +239,7 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 AddGitLabCiFile(context.Client, project);
                 var jobs = await GitLabTestContext.RetryUntilAsync(() => jobsClient.GetJobs(JobScopeMask.Success), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
                 var job = jobs.Single();
-                Assert.AreEqual(JobStatus.Success, job.Status);
+                Assert.That(job.Status, Is.EqualTo(JobStatus.Success));
 
                 var query = new JobArtifactQuery();
                 query.RefName = project.DefaultBranch;
@@ -247,10 +247,10 @@ build{i.ToString(CultureInfo.InvariantCulture)}:
                 query.ArtifactPath = "file0.txt";
 
                 var artifact = jobsClient.GetJobArtifact(query);
-                Assert.IsNotEmpty(artifact);
+                Assert.That(artifact, Is.Not.Empty);
 
                 var content = Encoding.ASCII.GetString(artifact).Trim();
-                Assert.AreEqual("test", content);
+                Assert.That(content, Is.EqualTo("test"));
             }
         }
     }

--- a/NGitLab.Tests/JsonTests.cs
+++ b/NGitLab.Tests/JsonTests.cs
@@ -24,7 +24,7 @@ namespace NGitLab.Tests
         public void DeserializeEnumWithEnumMemberAttribute_Ok(string value, TestEnum expectedValue)
         {
             var parsedValue = Serializer.Deserialize<TestEnum>('"' + value + '"');
-            Assert.AreEqual(expectedValue, parsedValue);
+            Assert.That(parsedValue, Is.EqualTo(expectedValue));
         }
 
         [TestCase("dfsf")]
@@ -41,7 +41,7 @@ namespace NGitLab.Tests
 
             TestContractV1 oldContractObject = null;
             Assert.DoesNotThrow(() => oldContractObject = Serializer.Deserialize<TestContractV1>(newContractJson));
-            Assert.NotNull(oldContractObject);
+            Assert.That(oldContractObject, Is.Not.Null);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NGitLab.Tests
 
             TestContractV2 newContractObject = null;
             Assert.DoesNotThrow(() => newContractObject = Serializer.Deserialize<TestContractV2>(oldContractJson));
-            Assert.NotNull(newContractObject);
+            Assert.That(newContractObject, Is.Not.Null);
         }
 
         public class TestContractV1

--- a/NGitLab.Tests/LintClientTests.cs
+++ b/NGitLab.Tests/LintClientTests.cs
@@ -37,9 +37,9 @@ build:
 
             var result = await context.Client.Lint.ValidateCIYamlContentAsync(project.Id.ToString(), ValidCIYaml, new(), CancellationToken.None);
 
-            Assert.True(result.Valid);
-            Assert.False(result.Errors.Any());
-            Assert.False(result.Warnings.Any());
+            Assert.That(result.Valid, Is.True);
+            Assert.That(result.Errors.Any(), Is.False);
+            Assert.That(result.Warnings.Any(), Is.False);
         }
 
         [Test]
@@ -52,9 +52,9 @@ build:
 
             var result = await context.Client.Lint.ValidateCIYamlContentAsync(project.Id.ToString(), InvalidCIYaml, new(), CancellationToken.None);
 
-            Assert.False(result.Valid);
-            Assert.True(result.Errors.Any());
-            Assert.False(result.Warnings.Any());
+            Assert.That(result.Valid, Is.False);
+            Assert.That(result.Errors.Any(), Is.True);
+            Assert.That(result.Warnings.Any(), Is.False);
         }
 
         [Test]
@@ -75,9 +75,9 @@ build:
 
             var result = await context.Client.Lint.ValidateProjectCIConfigurationAsync(project.Id.ToString(), new(), CancellationToken.None);
 
-            Assert.True(result.Valid);
-            Assert.False(result.Errors.Any());
-            Assert.False(result.Warnings.Any());
+            Assert.That(result.Valid, Is.True);
+            Assert.That(result.Errors.Any(), Is.False);
+            Assert.That(result.Warnings.Any(), Is.False);
         }
 
         [Test]
@@ -98,9 +98,9 @@ build:
 
             var result = await context.Client.Lint.ValidateProjectCIConfigurationAsync(project.Id.ToString(), new(), CancellationToken.None);
 
-            Assert.False(result.Valid);
-            Assert.True(result.Errors.Any());
-            Assert.False(result.Warnings.Any());
+            Assert.That(result.Valid, Is.False);
+            Assert.That(result.Errors.Any(), Is.True);
+            Assert.That(result.Warnings.Any(), Is.False);
         }
     }
 }

--- a/NGitLab.Tests/MembersClientTests.cs
+++ b/NGitLab.Tests/MembersClientTests.cs
@@ -30,8 +30,8 @@ namespace NGitLab.Tests
             });
 
             var projectUser = context.Client.Members.OfProject(projectId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)projectUser.AccessLevel);
-            Assert.AreEqual(expiresAt, projectUser.ExpiresAt?.ToString("yyyy-MM-dd"));
+            Assert.That((AccessLevel)projectUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
+            Assert.That(projectUser.ExpiresAt?.ToString("yyyy-MM-dd"), Is.EqualTo(expiresAt));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace NGitLab.Tests
                 UserId = user.Id.ToString(CultureInfo.InvariantCulture),
             });
             var projectUser = context.Client.Members.OfProject(projectId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)projectUser.AccessLevel);
+            Assert.That((AccessLevel)projectUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
 
             // Update
             context.Client.Members.UpdateMemberOfProject(projectId, new ProjectMemberUpdate
@@ -59,7 +59,7 @@ namespace NGitLab.Tests
                 UserId = user.Id.ToString(CultureInfo.InvariantCulture),
             });
             projectUser = context.Client.Members.OfProject(projectId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Maintainer, (AccessLevel)projectUser.AccessLevel);
+            Assert.That((AccessLevel)projectUser.AccessLevel, Is.EqualTo(AccessLevel.Maintainer));
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NGitLab.Tests
 
             // Get
             var projectUser = context.Client.Members.GetMemberOfProject(projectId, user.Id.ToString(CultureInfo.InvariantCulture));
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)projectUser.AccessLevel);
+            Assert.That((AccessLevel)projectUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
         }
 
         [Test]
@@ -100,8 +100,8 @@ namespace NGitLab.Tests
             });
 
             var groupUser = context.Client.Members.OfGroup(groupId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)groupUser.AccessLevel);
-            Assert.AreEqual(expiresAt, groupUser.ExpiresAt?.ToString("yyyy-MM-dd"));
+            Assert.That((AccessLevel)groupUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
+            Assert.That(groupUser.ExpiresAt?.ToString("yyyy-MM-dd"), Is.EqualTo(expiresAt));
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace NGitLab.Tests
                 UserId = user.Id.ToString(CultureInfo.InvariantCulture),
             });
             var groupUser = context.Client.Members.OfGroup(groupId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)groupUser.AccessLevel);
+            Assert.That((AccessLevel)groupUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
 
             // Update
             context.Client.Members.UpdateMemberOfGroup(groupId, new GroupMemberUpdate
@@ -129,7 +129,7 @@ namespace NGitLab.Tests
                 UserId = user.Id.ToString(CultureInfo.InvariantCulture),
             });
             groupUser = context.Client.Members.OfGroup(groupId).Single(u => u.Id == user.Id);
-            Assert.AreEqual(AccessLevel.Maintainer, (AccessLevel)groupUser.AccessLevel);
+            Assert.That((AccessLevel)groupUser.AccessLevel, Is.EqualTo(AccessLevel.Maintainer));
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace NGitLab.Tests
 
             // Get
             var groupUser = context.Client.Members.GetMemberOfGroup(groupId, user.Id.ToString(CultureInfo.InvariantCulture));
-            Assert.AreEqual(AccessLevel.Developer, (AccessLevel)groupUser.AccessLevel);
+            Assert.That((AccessLevel)groupUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
         }
     }
 }

--- a/NGitLab.Tests/MergeRequest/MergeRequestChangesClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestChangesClientTests.cs
@@ -22,13 +22,13 @@ namespace NGitLab.Tests
                 changes => changes.Any(),
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(1, changes.Length);
-            Assert.AreEqual(100644, changes[0].AMode);
-            Assert.AreEqual(100644, changes[0].BMode);
-            Assert.IsFalse(changes[0].DeletedFile);
-            Assert.IsFalse(changes[0].NewFile);
-            Assert.IsFalse(changes[0].RenamedFile);
-            Assert.AreEqual("@@ -1 +1 @@\n-test\n\\ No newline at end of file\n+test2\n\\ No newline at end of file\n", changes[0].Diff);
+            Assert.That(changes, Has.Length.EqualTo(1));
+            Assert.That(changes[0].AMode, Is.EqualTo(100644));
+            Assert.That(changes[0].BMode, Is.EqualTo(100644));
+            Assert.That(changes[0].DeletedFile, Is.False);
+            Assert.That(changes[0].NewFile, Is.False);
+            Assert.That(changes[0].RenamedFile, Is.False);
+            Assert.That(changes[0].Diff, Is.EqualTo("@@ -1 +1 @@\n-test\n\\ No newline at end of file\n+test2\n\\ No newline at end of file\n"));
         }
     }
 }

--- a/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
@@ -58,12 +58,12 @@ namespace NGitLab.Tests
 
             // Get all
             var comments = mergeRequestComments.All.ToArray();
-            CollectionAssert.IsNotEmpty(comments);
+            Assert.That(comments, Is.Not.Empty);
 
             // Delete
             mergeRequestComments.Delete(comment.Id);
             comments = mergeRequestComments.All.ToArray();
-            CollectionAssert.IsEmpty(comments);
+            Assert.That(comments, Is.Empty);
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace NGitLab.Tests
 
             context.Client.Projects.Archive(project.Id);
             var ex = Assert.Throws<GitLabException>(() => mergeRequestComments.Add(newComment));
-            Assert.AreEqual(ex.StatusCode, HttpStatusCode.Forbidden);
+            Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
         }
     }
 }

--- a/NGitLab.Tests/MergeRequest/MergeRequestDiscussionsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDiscussionsClientTests.cs
@@ -31,7 +31,7 @@ namespace NGitLab.Tests
             Assert.That(discussion.Notes[0].Resolved, Is.False);
 
             var discussions = mergeRequestDiscussions.All.ToArray();
-            CollectionAssert.IsNotEmpty(discussions);
+            Assert.That(discussions, Is.Not.Empty);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NGitLab.Tests
             var discussion = mergeRequestDiscussions.Add(newDiscussion);
 
             var gotDiscussion = await mergeRequestDiscussions.GetAsync(discussion.Id);
-            Assert.NotNull(gotDiscussion);
+            Assert.That(gotDiscussion, Is.Not.Null);
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace NGitLab.Tests
             var projectClient = context.Client.Projects;
             projectClient.Archive(project.Id);
             var ex = Assert.Throws<GitLabException>(() => mergeRequestDiscussions.Add(newDiscussion));
-            Assert.AreEqual(ex.StatusCode, HttpStatusCode.Forbidden);
+            Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
         }
 
         [Test]

--- a/NGitLab.Tests/Milestone/MilestoneClientTests.cs
+++ b/NGitLab.Tests/Milestone/MilestoneClientTests.cs
@@ -19,9 +19,9 @@ namespace NGitLab.Tests.Milestone
 
             var milestone = CreateMilestone(context, MilestoneScope.Projects, project.Id, "my-super-milestone");
 
-            Assert.AreEqual(milestone.Id, milestoneClient[milestone.Id].Id, "Test we can get a milestone by Id");
-            Assert.IsTrue(milestoneClient.All.Any(x => x.Id == milestone.Id), "Test 'All' accessor returns the milestone");
-            Assert.IsTrue(milestoneClient.AllInState(MilestoneState.active).Any(x => x.Id == milestone.Id), "Can return all active milestone");
+            Assert.That(milestoneClient[milestone.Id].Id, Is.EqualTo(milestone.Id), "Test we can get a milestone by Id");
+            Assert.That(milestoneClient.All.Any(x => x.Id == milestone.Id), Is.True, "Test 'All' accessor returns the milestone");
+            Assert.That(milestoneClient.AllInState(MilestoneState.active).Any(x => x.Id == milestone.Id), Is.True, "Can return all active milestone");
 
             milestone = UpdateMilestone(context, MilestoneScope.Projects, project.Id, milestone);
 
@@ -29,7 +29,7 @@ namespace NGitLab.Tests.Milestone
 
             milestone = CloseMilestone(context, MilestoneScope.Projects, project.Id, milestone);
 
-            Assert.IsTrue(milestoneClient.AllInState(MilestoneState.closed).Any(x => x.Id == milestone.Id), "Can return all closed milestone");
+            Assert.That(milestoneClient.AllInState(MilestoneState.closed).Any(x => x.Id == milestone.Id), Is.True, "Can return all closed milestone");
 
             milestone = ActivateMilestone(context, MilestoneScope.Projects, project.Id, milestone);
 
@@ -46,9 +46,9 @@ namespace NGitLab.Tests.Milestone
 
             var milestone = CreateMilestone(context, MilestoneScope.Groups, group.Id, "my-super-group-milestone");
 
-            Assert.AreEqual(milestone.Id, milestoneClient[milestone.Id].Id, "Test we can get a milestone by Id");
-            Assert.IsTrue(milestoneClient.All.Any(x => x.Id == milestone.Id), "Test 'All' accessor returns the milestone");
-            Assert.IsTrue(milestoneClient.AllInState(MilestoneState.active).Any(x => x.Id == milestone.Id), "Can return all active milestone");
+            Assert.That(milestoneClient[milestone.Id].Id, Is.EqualTo(milestone.Id), "Test we can get a milestone by Id");
+            Assert.That(milestoneClient.All.Any(x => x.Id == milestone.Id), Is.True, "Test 'All' accessor returns the milestone");
+            Assert.That(milestoneClient.AllInState(MilestoneState.active).Any(x => x.Id == milestone.Id), Is.True, "Can return all active milestone");
 
             milestone = UpdateMilestone(context, MilestoneScope.Groups, group.Id, milestone);
 
@@ -56,7 +56,7 @@ namespace NGitLab.Tests.Milestone
 
             milestone = CloseMilestone(context, MilestoneScope.Groups, group.Id, milestone);
 
-            Assert.IsTrue(milestoneClient.AllInState(MilestoneState.closed).Any(x => x.Id == milestone.Id), "Can return all closed milestone");
+            Assert.That(milestoneClient.AllInState(MilestoneState.closed).Any(x => x.Id == milestone.Id), Is.True, "Can return all closed milestone");
 
             milestone = ActivateMilestone(context, MilestoneScope.Groups, group.Id, milestone);
 
@@ -77,7 +77,7 @@ namespace NGitLab.Tests.Milestone
             mergeRequestClient.Update(mergeRequest.Iid, new MergeRequestUpdate { MilestoneId = milestone.Id });
 
             var mergeRequests = milestoneClient.GetMergeRequests(milestone.Id).ToArray();
-            Assert.AreEqual(1, mergeRequests.Length, "The query retrieved all merged requests that assigned to the milestone.");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "The query retrieved all merged requests that assigned to the milestone.");
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace NGitLab.Tests.Milestone
             mergeRequestClient.Update(mergeRequest.Iid, new MergeRequestUpdate { MilestoneId = milestone.Id });
 
             var mergeRequests = milestoneClient.GetMergeRequests(milestone.Id).ToArray();
-            Assert.AreEqual(1, mergeRequests.Length, "The query retrieved all merged requests that assigned to the milestone.");
+            Assert.That(mergeRequests, Has.Length.EqualTo(1), "The query retrieved all merged requests that assigned to the milestone.");
         }
 
         private static Models.Milestone CreateMilestone(GitLabTestContext context, MilestoneScope scope, int id, string title)

--- a/NGitLab.Tests/NGitLab.Tests.csproj
+++ b/NGitLab.Tests/NGitLab.Tests.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Microsoft.Playwright" Version="1.40.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Polly" Version="8.2.0" />

--- a/NGitLab.Tests/NamespacesTests.cs
+++ b/NGitLab.Tests/NamespacesTests.cs
@@ -18,8 +18,8 @@ namespace NGitLab.Tests
             var namespacesClient = context.Client.Namespaces;
 
             var groupSearch = namespacesClient.Accessible.FirstOrDefault(g => g.Path.Equals(group.Path, StringComparison.Ordinal));
-            Assert.IsNotNull(group);
-            Assert.AreEqual(Namespace.Type.Group, groupSearch.GetKind());
+            Assert.That(group, Is.Not.Null);
+            Assert.That(groupSearch.GetKind(), Is.EqualTo(Namespace.Type.Group));
         }
 
         [Test]
@@ -31,8 +31,8 @@ namespace NGitLab.Tests
             var namespacesClient = context.Client.Namespaces;
 
             var user = namespacesClient.Accessible.FirstOrDefault(g => g.Path.Equals(context.Client.Users.Current.Username, StringComparison.Ordinal));
-            Assert.IsNotNull(user);
-            Assert.AreEqual(Namespace.Type.User, user.GetKind());
+            Assert.That(user, Is.Not.Null);
+            Assert.That(user.GetKind(), Is.EqualTo(Namespace.Type.User));
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NGitLab.Tests
             var namespacesClient = context.Client.Namespaces;
 
             var ns = namespacesClient.Search(context.Client.Users.Current.Username).First();
-            Assert.AreEqual(Namespace.Type.User, ns.GetKind());
+            Assert.That(ns.GetKind(), Is.EqualTo(Namespace.Type.User));
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace NGitLab.Tests
             var namespacesClient = context.Client.Namespaces;
 
             var user = namespacesClient.Search(group.Name);
-            Assert.IsNotNull(user);
+            Assert.That(user, Is.Not.Null);
         }
     }
 }

--- a/NGitLab.Tests/PipelineTests.cs
+++ b/NGitLab.Tests/PipelineTests.cs
@@ -23,10 +23,10 @@ namespace NGitLab.Tests
             JobTests.AddGitLabCiFile(context.Client, project);
 
             var pipelines = await GitLabTestContext.RetryUntilAsync(() => pipelineClient.All, p => p.Any(), TimeSpan.FromSeconds(120));
-            Assert.IsNotEmpty(pipelines);
+            Assert.That(pipelines, Is.Not.Empty);
             foreach (var pipeline in pipelines)
             {
-                Assert.AreEqual(project.Id, pipeline.ProjectId);
+                Assert.That(pipeline.ProjectId, Is.EqualTo(project.Id));
             }
         }
 
@@ -58,7 +58,7 @@ namespace NGitLab.Tests
             });
 
             var pipelineFull = pipelineClient[pipeline.Id];
-            Assert.AreEqual(50, pipelineFull.Coverage);
+            Assert.That(pipelineFull.Coverage, Is.EqualTo(50));
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace NGitLab.Tests
             };
             var pipelinesFromQuery = await GitLabTestContext.RetryUntilAsync(() => pipelineClient.Search(query).ToList(), p => p.Any(), TimeSpan.FromSeconds(120));
 
-            Assert.IsTrue(pipelinesFromQuery.Any());
+            Assert.That(pipelinesFromQuery.Any(), Is.True);
         }
 
         [Test]
@@ -154,13 +154,13 @@ namespace NGitLab.Tests
             var variables = pipelineClient.GetVariables(pipeline.Id);
 
             var var1 = variables.SingleOrDefault(v => v.Key.Equals("Var1", StringComparison.Ordinal));
-            Assert.NotNull(var1);
+            Assert.That(var1, Is.Not.Null);
 
             var var2 = variables.SingleOrDefault(v => v.Key.Equals("Var2", StringComparison.Ordinal));
-            Assert.NotNull(var2);
+            Assert.That(var2, Is.Not.Null);
 
-            Assert.AreEqual("Value1", var1.Value);
-            Assert.AreEqual("+4+", var2.Value);
+            Assert.That(var1.Value, Is.EqualTo("Value1"));
+            Assert.That(var2.Value, Is.EqualTo("+4+"));
         }
 
         [Test]
@@ -182,29 +182,29 @@ namespace NGitLab.Tests
             var testReports = pipelineClient.GetTestReports(pipeline.Id);
             var summary = pipelineClient.GetTestReportsSummary(pipeline.Id);
 
-            Assert.NotNull(testReports);
-            Assert.NotNull(summary);
+            Assert.That(testReports, Is.Not.Null);
+            Assert.That(summary, Is.Not.Null);
 
-            Assert.AreEqual(0, testReports.TotalTime);
-            Assert.AreEqual(0, summary.Total.Time);
+            Assert.That(testReports.TotalTime, Is.EqualTo(0));
+            Assert.That(summary.Total.Time, Is.EqualTo(0));
 
-            Assert.AreEqual(0, testReports.TotalCount);
-            Assert.AreEqual(0, summary.Total.Count);
+            Assert.That(testReports.TotalCount, Is.EqualTo(0));
+            Assert.That(summary.Total.Count, Is.EqualTo(0));
 
-            Assert.AreEqual(0, testReports.SuccessCount);
-            Assert.AreEqual(0, summary.Total.Success);
+            Assert.That(testReports.SuccessCount, Is.EqualTo(0));
+            Assert.That(summary.Total.Success, Is.EqualTo(0));
 
-            Assert.AreEqual(0, testReports.FailedCount);
-            Assert.AreEqual(0, summary.Total.Failed);
+            Assert.That(testReports.FailedCount, Is.EqualTo(0));
+            Assert.That(summary.Total.Failed, Is.EqualTo(0));
 
-            Assert.AreEqual(0, testReports.SkippedCount);
-            Assert.AreEqual(0, summary.Total.Skipped);
+            Assert.That(testReports.SkippedCount, Is.EqualTo(0));
+            Assert.That(summary.Total.Skipped, Is.EqualTo(0));
 
-            Assert.AreEqual(0, testReports.ErrorCount);
-            Assert.AreEqual(0, summary.Total.Error);
+            Assert.That(testReports.ErrorCount, Is.EqualTo(0));
+            Assert.That(summary.Total.Error, Is.EqualTo(0));
 
-            Assert.IsEmpty(testReports.TestSuites);
-            Assert.IsEmpty(summary.TestSuites);
+            Assert.That(testReports.TestSuites, Is.Empty);
+            Assert.That(summary.TestSuites, Is.Empty);
         }
 
         [Test]
@@ -224,9 +224,9 @@ namespace NGitLab.Tests
 
             var variables = pipelineClient.GetVariables(pipeline.Id);
 
-            Assert.IsTrue(variables.Any(v =>
+            Assert.That(variables.Any(v =>
                 v.Key.Equals("Test", StringComparison.Ordinal) &&
-                v.Value.Equals("HelloWorld", StringComparison.Ordinal)));
+                v.Value.Equals("HelloWorld", StringComparison.Ordinal)), Is.True);
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace NGitLab.Tests
                 }, TimeSpan.FromMinutes(2));
 
                 var retriedPipeline = await pipelineClient.RetryAsync(pipeline.Id);
-                Assert.AreNotEqual(JobStatus.Failed, retriedPipeline.Status); // Should be created or running
+                Assert.That(retriedPipeline.Status, Is.Not.EqualTo(JobStatus.Failed)); // Should be created or running
             }
         }
     }

--- a/NGitLab.Tests/ProjectBadgeClientTests.cs
+++ b/NGitLab.Tests/ProjectBadgeClientTests.cs
@@ -21,7 +21,7 @@ namespace NGitLab.Tests
             badges.ForEach(b => projectBadgeClient.Delete(b.Id));
 
             badges = projectBadgeClient.ProjectsOnly.ToList();
-            Assert.IsEmpty(badges);
+            Assert.That(badges, Is.Empty);
 
             // Create
             var badge = projectBadgeClient.Create(new BadgeCreate
@@ -30,9 +30,9 @@ namespace NGitLab.Tests
                 LinkUrl = "http://dummy/image.html",
             });
 
-            Assert.AreEqual(BadgeKind.Project, badge.Kind);
-            Assert.AreEqual("http://dummy/image.png", badge.ImageUrl);
-            Assert.AreEqual("http://dummy/image.html", badge.LinkUrl);
+            Assert.That(badge.Kind, Is.EqualTo(BadgeKind.Project));
+            Assert.That(badge.ImageUrl, Is.EqualTo("http://dummy/image.png"));
+            Assert.That(badge.LinkUrl, Is.EqualTo("http://dummy/image.html"));
 
             // Update
             badge = projectBadgeClient.Update(badge.Id, new BadgeUpdate
@@ -41,22 +41,22 @@ namespace NGitLab.Tests
                 LinkUrl = "http://dummy/image_edit.html",
             });
 
-            Assert.AreEqual(BadgeKind.Project, badge.Kind);
-            Assert.AreEqual("http://dummy/image_edit.png", badge.ImageUrl);
-            Assert.AreEqual("http://dummy/image_edit.html", badge.LinkUrl);
+            Assert.That(badge.Kind, Is.EqualTo(BadgeKind.Project));
+            Assert.That(badge.ImageUrl, Is.EqualTo("http://dummy/image_edit.png"));
+            Assert.That(badge.LinkUrl, Is.EqualTo("http://dummy/image_edit.html"));
 
             // Delete
             projectBadgeClient.Delete(badge.Id);
 
             badges = projectBadgeClient.ProjectsOnly.ToList();
-            Assert.IsEmpty(badges);
+            Assert.That(badges, Is.Empty);
 
             // All
             projectBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image1.png", LinkUrl = "http://dummy/image1.html", });
             projectBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image2.png", LinkUrl = "http://dummy/image2.html", });
             projectBadgeClient.Create(new BadgeCreate { ImageUrl = "http://dummy/image3.png", LinkUrl = "http://dummy/image3.html", });
             badges = projectBadgeClient.ProjectsOnly.ToList();
-            Assert.AreEqual(3, badges.Count);
+            Assert.That(badges, Has.Count.EqualTo(3));
         }
     }
 }

--- a/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
+++ b/NGitLab.Tests/ProjectLevelApprovalRulesClientTests.cs
@@ -37,9 +37,9 @@ namespace NGitLab.Tests
 
             var approvalRule = projectLevelApprovalRulesClient.CreateProjectLevelRule(CreateTestApprovalRuleCreate(project, approvalRuleName, approvalRuleApprovalsRequired));
 
-            Assert.NotNull(approvalRule);
-            Assert.AreEqual(approvalRuleName, approvalRule.Name);
-            Assert.AreEqual(approvalRuleApprovalsRequired, approvalRule.ApprovalsRequired);
+            Assert.That(approvalRule, Is.Not.Null);
+            Assert.That(approvalRule.Name, Is.EqualTo(approvalRuleName));
+            Assert.That(approvalRule.ApprovalsRequired, Is.EqualTo(approvalRuleApprovalsRequired));
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace NGitLab.Tests
 
             projectLevelApprovalRulesClient.DeleteProjectLevelRule(approvalRule.RuleId);
 
-            Assert.AreEqual(0, projectLevelApprovalRulesClient.GetProjectLevelApprovalRules().Count);
+            Assert.That(projectLevelApprovalRulesClient.GetProjectLevelApprovalRules(), Is.Empty);
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace NGitLab.Tests
                         ApprovalsRequired = approvalRuleApprovalsRequired,
                     });
 
-            Assert.NotNull(approvalRule);
-            Assert.AreEqual(approvalRuleName, approvalRule.Name);
-            Assert.AreEqual(approvalRuleApprovalsRequired, approvalRule.ApprovalsRequired);
+            Assert.That(approvalRule, Is.Not.Null);
+            Assert.That(approvalRule.Name, Is.EqualTo(approvalRuleName));
+            Assert.That(approvalRule.ApprovalsRequired, Is.EqualTo(approvalRuleApprovalsRequired));
         }
 
         [Test]
@@ -100,9 +100,9 @@ namespace NGitLab.Tests
 
             var approvalRules = projectLevelApprovalRulesClient.GetProjectLevelApprovalRules();
 
-            Assert.AreEqual(1, approvalRules.Count);
-            Assert.AreEqual(firstApprovalRuleName, approvalRules[0].Name);
-            Assert.AreEqual(firstApprovalRuleApprovalsRequired, approvalRules[0].ApprovalsRequired);
+            Assert.That(approvalRules, Has.Count.EqualTo(1));
+            Assert.That(approvalRules[0].Name, Is.EqualTo(firstApprovalRuleName));
+            Assert.That(approvalRules[0].ApprovalsRequired, Is.EqualTo(firstApprovalRuleApprovalsRequired));
         }
 
         private static ApprovalRuleCreate CreateTestApprovalRuleCreate(Project project, string approvalRuleName, int approvalsRequired)

--- a/NGitLab.Tests/ProjectVariableClientTests.cs
+++ b/NGitLab.Tests/ProjectVariableClientTests.cs
@@ -24,9 +24,9 @@ namespace NGitLab.Tests
                 Protected = true,
             });
 
-            Assert.AreEqual("My_Key", variable.Key);
-            Assert.AreEqual("My value", variable.Value);
-            Assert.AreEqual(true, variable.Protected);
+            Assert.That(variable.Key, Is.EqualTo("My_Key"));
+            Assert.That(variable.Value, Is.EqualTo("My value"));
+            Assert.That(variable.Protected, Is.EqualTo(true));
 
             // Update
             variable = projectVariableClient.Update(variable.Key, new VariableUpdate
@@ -35,22 +35,22 @@ namespace NGitLab.Tests
                 Protected = false,
             });
 
-            Assert.AreEqual("My_Key", variable.Key);
-            Assert.AreEqual("My value edited", variable.Value);
-            Assert.AreEqual(false, variable.Protected);
+            Assert.That(variable.Key, Is.EqualTo("My_Key"));
+            Assert.That(variable.Value, Is.EqualTo("My value edited"));
+            Assert.That(variable.Protected, Is.EqualTo(false));
 
             // Delete
             projectVariableClient.Delete(variable.Key);
 
             var variables = projectVariableClient.All.ToList();
-            Assert.IsEmpty(variables);
+            Assert.That(variables, Is.Empty);
 
             // All
             projectVariableClient.Create(new VariableCreate { Key = "Variable1", Value = "test" });
             projectVariableClient.Create(new VariableCreate { Key = "Variable2", Value = "test" });
             projectVariableClient.Create(new VariableCreate { Key = "Variable3", Value = "test" });
             variables = projectVariableClient.All.ToList();
-            Assert.AreEqual(3, variables.Count);
+            Assert.That(variables, Has.Count.EqualTo(3));
         }
     }
 }

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -21,7 +21,7 @@ namespace NGitLab.Tests
             var projectClient = context.Client.Projects;
 
             var projectResult = await projectClient.GetByIdAsync(project.Id, new SingleProjectQuery(), CancellationToken.None);
-            Assert.AreEqual(project.Id, projectResult.Id);
+            Assert.That(projectResult.Id, Is.EqualTo(project.Id));
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace NGitLab.Tests
             var projectClient = context.Client.Projects;
 
             var projectResult = await projectClient.GetByNamespacedPathAsync(project.PathWithNamespace, new SingleProjectQuery(), CancellationToken.None);
-            Assert.AreEqual(project.Id, projectResult.Id);
+            Assert.That(projectResult.Id, Is.EqualTo(project.Id));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace NGitLab.Tests
                 projects.Add(item);
             }
 
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NGitLab.Tests
             var projectClient = context.Client.Projects;
 
             var projects = projectClient.Owned.Take(30).ToArray();
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NGitLab.Tests
 
             var projects = projectClient.Visible.Take(30).ToArray();
 
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace NGitLab.Tests
 
             var projects = projectClient.Accessible.Take(30).ToArray();
 
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NGitLab.Tests
             };
 
             var projects = projectClient.Get(query).Take(10).ToArray();
-            Assert.AreEqual(1, projects.Length);
+            Assert.That(projects, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NGitLab.Tests
                 Assert.Fail("No projects found.");
             }
 
-            projects.ForEach(p => Assert.IsNotNull(p.Statistics));
+            projects.ForEach(p => Assert.That(p.Statistics, Is.Not.Null));
         }
 
         [Test]
@@ -141,8 +141,8 @@ namespace NGitLab.Tests
                 Assert.Fail("No projects found.");
             }
 
-            projects.ForEach(p => Assert.IsNotNull(p.Links));
-            projects.ForEach(p => Assert.IsNotNull(p.MergeMethod));
+            projects.ForEach(p => Assert.That(p.Links, Is.Not.Null));
+            projects.ForEach(p => Assert.That(p.MergeMethod, Is.Not.Null));
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace NGitLab.Tests
 
             var projects = projectClient.Get(query).ToList();
 
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
         }
 
         [Test]
@@ -179,8 +179,8 @@ namespace NGitLab.Tests
 
             project = projectClient.GetById(project.Id, query);
 
-            Assert.IsNotNull(project);
-            Assert.IsNotNull(project.Statistics);
+            Assert.That(project, Is.Not.Null);
+            Assert.That(project.Statistics, Is.Not.Null);
         }
 
         [Test]
@@ -201,8 +201,8 @@ namespace NGitLab.Tests
 
             context.Client.GetRepository(project.Id).Files.Create(file);
             var languages = projectClient.GetLanguages(project.Id.ToString(CultureInfo.InvariantCulture));
-            Assert.That(languages.Count, Is.EqualTo(1));
-            StringAssert.AreEqualIgnoringCase("javascript", languages.First().Key);
+            Assert.That(languages, Has.Count.EqualTo(1));
+            Assert.That(languages.First().Key, Is.EqualTo("javascript").IgnoreCase);
             Assert.That(languages.First().Value, Is.EqualTo(100));
         }
 
@@ -223,7 +223,7 @@ namespace NGitLab.Tests
 
             var projects = projectClient.Get(query).Take(10).ToList();
 
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
             Assert.That(context.LastRequest.RequestUri.ToString(), Contains.Substring("per_page=5"));
         }
 
@@ -255,32 +255,32 @@ namespace NGitLab.Tests
 
             var createdProject = projectClient.Create(project);
 
-            Assert.AreEqual(project.Description, createdProject.Description);
-            Assert.AreEqual(project.IssuesEnabled, createdProject.IssuesEnabled);
-            Assert.AreEqual(project.MergeRequestsEnabled, createdProject.MergeRequestsEnabled);
-            Assert.AreEqual(project.Name, createdProject.Name);
-            Assert.AreEqual(project.VisibilityLevel, createdProject.VisibilityLevel);
-            CollectionAssert.AreEquivalent(expectedTopics, createdProject.Topics);
-            CollectionAssert.AreEquivalent(expectedTopics, createdProject.TagList);
-            Assert.AreEqual(RepositoryAccessLevel.Enabled, createdProject.RepositoryAccessLevel);
+            Assert.That(createdProject.Description, Is.EqualTo(project.Description));
+            Assert.That(createdProject.IssuesEnabled, Is.EqualTo(project.IssuesEnabled));
+            Assert.That(createdProject.MergeRequestsEnabled, Is.EqualTo(project.MergeRequestsEnabled));
+            Assert.That(createdProject.Name, Is.EqualTo(project.Name));
+            Assert.That(createdProject.VisibilityLevel, Is.EqualTo(project.VisibilityLevel));
+            Assert.That(createdProject.Topics, Is.EquivalentTo(expectedTopics));
+            Assert.That(createdProject.TagList, Is.EquivalentTo(expectedTopics));
+            Assert.That(createdProject.RepositoryAccessLevel, Is.EqualTo(RepositoryAccessLevel.Enabled));
 
             // Update
             expectedTopics = new List<string> { "Tag-3" };
             var updateOptions = new ProjectUpdate { Visibility = VisibilityLevel.Private, Topics = expectedTopics };
             var updatedProject = projectClient.Update(createdProject.Id.ToString(CultureInfo.InvariantCulture), updateOptions);
-            Assert.AreEqual(VisibilityLevel.Private, updatedProject.VisibilityLevel);
-            CollectionAssert.AreEquivalent(expectedTopics, updatedProject.Topics);
-            CollectionAssert.AreEquivalent(expectedTopics, updatedProject.TagList);
+            Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Private));
+            Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
+            Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
 
             updateOptions.Visibility = VisibilityLevel.Public;
             updateOptions.Topics = null;    // If Topics are null, the project's existing topics will remain
             updatedProject = projectClient.Update(createdProject.Id.ToString(CultureInfo.InvariantCulture), updateOptions);
-            Assert.AreEqual(VisibilityLevel.Public, updatedProject.VisibilityLevel);
-            CollectionAssert.AreEquivalent(expectedTopics, updatedProject.Topics);
-            CollectionAssert.AreEquivalent(expectedTopics, updatedProject.TagList);
+            Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Public));
+            Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
+            Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
 
             var updatedProject2 = projectClient.Update(createdProject.PathWithNamespace, new ProjectUpdate { Visibility = VisibilityLevel.Internal });
-            Assert.AreEqual(VisibilityLevel.Internal, updatedProject2.VisibilityLevel);
+            Assert.That(updatedProject2.VisibilityLevel, Is.EqualTo(VisibilityLevel.Internal));
 
             projectClient.Delete(createdProject.Id);
         }
@@ -307,7 +307,7 @@ namespace NGitLab.Tests
             var result = projectClient.Get(query).Take(10).ToArray();
 
             // Assert
-            Assert.IsTrue(result.Any());
+            Assert.That(result.Any(), Is.True);
         }
 
         [Test]
@@ -385,7 +385,7 @@ namespace NGitLab.Tests
             };
 
             var projects = projectClient.Get(query).Take(10).ToList();
-            CollectionAssert.IsNotEmpty(projects);
+            Assert.That(projects, Is.Not.Empty);
             Assert.That(projects.Select(p => p.LastActivityAt), Is.All.GreaterThan(date.UtcDateTime));
         }
 
@@ -401,7 +401,7 @@ namespace NGitLab.Tests
                 prj.Name = "Project_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture);
                 prj.VisibilityLevel = VisibilityLevel.Internal;
             });
-            Assert.IsTrue(createdProject.EmptyRepo);
+            Assert.That(createdProject.EmptyRepo, Is.True);
 
             context.Client.GetRepository(createdProject.Id).Files.Create(new FileUpsert
             {
@@ -412,7 +412,7 @@ namespace NGitLab.Tests
             });
 
             createdProject = projectClient[createdProject.Id];
-            Assert.IsFalse(createdProject.EmptyRepo);
+            Assert.That(createdProject.EmptyRepo, Is.False);
         }
 
         [Test]
@@ -444,7 +444,7 @@ namespace NGitLab.Tests
             var projects = projectClient.Get(query); // Get projects that have both required topics
 
             // Assert
-            Assert.AreEqual(2, projects.Count());
+            Assert.That(projects.Count(), Is.EqualTo(2));
 
             static string CreateTopic() => Guid.NewGuid().ToString("N");
         }
@@ -471,7 +471,7 @@ namespace NGitLab.Tests
             var createdProject = projectClient.Create(project);
 
             var expectedSquashOption = inputSquashOption ?? SquashOption.DefaultOff;
-            Assert.AreEqual(expectedSquashOption, createdProject.SquashOption);
+            Assert.That(createdProject.SquashOption, Is.EqualTo(expectedSquashOption));
 
             projectClient.Delete(createdProject.Id);
         }

--- a/NGitLab.Tests/ProtectedBranchTests.cs
+++ b/NGitLab.Tests/ProtectedBranchTests.cs
@@ -46,22 +46,22 @@ namespace NGitLab.Tests
             ProtectedBranchAndBranchProtectAreEquals(branchProtect, protectedBranchClient.GetProtectedBranch(branch.Name));
 
             // Get branches
-            Assert.IsNotEmpty(protectedBranchClient.GetProtectedBranches());
+            Assert.That(protectedBranchClient.GetProtectedBranches(), Is.Not.Empty);
             var protectedBranches = protectedBranchClient.GetProtectedBranches(branch.Name);
-            Assert.IsNotEmpty(protectedBranches);
+            Assert.That(protectedBranches, Is.Not.Empty);
             ProtectedBranchAndBranchProtectAreEquals(branchProtect, protectedBranches[0]);
 
             // Unprotect branch
             protectedBranchClient.UnprotectBranch(branch.Name);
-            Assert.IsEmpty(protectedBranchClient.GetProtectedBranches(branch.Name));
+            Assert.That(protectedBranchClient.GetProtectedBranches(branch.Name), Is.Empty);
         }
 
         private static void ProtectedBranchAndBranchProtectAreEquals(BranchProtect branchProtect, ProtectedBranch protectedBranch)
         {
-            Assert.AreEqual(branchProtect.BranchName, protectedBranch.Name);
-            Assert.AreEqual(branchProtect.PushAccessLevel, protectedBranch.PushAccessLevels[0].AccessLevel);
-            Assert.AreEqual(branchProtect.MergeAccessLevel, protectedBranch.MergeAccessLevels[0].AccessLevel);
-            Assert.AreEqual(branchProtect.AllowForcePush, protectedBranch.AllowForcePush);
+            Assert.That(protectedBranch.Name, Is.EqualTo(branchProtect.BranchName));
+            Assert.That(protectedBranch.PushAccessLevels[0].AccessLevel, Is.EqualTo(branchProtect.PushAccessLevel));
+            Assert.That(protectedBranch.MergeAccessLevels[0].AccessLevel, Is.EqualTo(branchProtect.MergeAccessLevel));
+            Assert.That(protectedBranch.AllowForcePush, Is.EqualTo(branchProtect.AllowForcePush));
         }
     }
 }

--- a/NGitLab.Tests/ProtectedTagTests.cs
+++ b/NGitLab.Tests/ProtectedTagTests.cs
@@ -17,11 +17,11 @@ namespace NGitLab.Tests
             var tagClient = context.Client.GetRepository(project.Id).Tags;
 
             var tag = tagClient.Create(new TagCreate { Name = "protectedTag", Ref = project.DefaultBranch });
-            Assert.False(tag.Protected);
+            Assert.That(tag.Protected, Is.False);
 
             var protectedTagClient = context.Client.GetProtectedTagClient(project.Id);
             var protectedTags = protectedTagClient.GetProtectedTagsAsync();
-            Assert.False(protectedTags.Any());
+            Assert.That(protectedTags.Any(), Is.False);
 
             await ProtectedTagTest(tag.Name, tag.Name, protectedTagClient, tagClient);
             await ProtectedTagTest("*", tag.Name, protectedTagClient, tagClient);
@@ -35,27 +35,27 @@ namespace NGitLab.Tests
                 CreateAccessLevel = AccessLevel.NoAccess,
             };
             var protectedTag = await protectedTagClient.ProtectTagAsync(tagProtect).ConfigureAwait(false);
-            Assert.AreEqual(protectedTag.Name, tagProtect.Name);
+            Assert.That(tagProtect.Name, Is.EqualTo(protectedTag.Name));
             var accessLevels = protectedTag.CreateAccessLevels.Select(level => level.AccessLevel).ToArray();
-            Assert.Contains(AccessLevel.NoAccess, accessLevels);
-            Assert.Contains(AccessLevel.Maintainer, accessLevels);
+            Assert.That(accessLevels, Does.Contain(AccessLevel.NoAccess));
+            Assert.That(accessLevels, Does.Contain(AccessLevel.Maintainer));
 
             var getProtectedTag = await protectedTagClient.GetProtectedTagAsync(tagProtectName).ConfigureAwait(false);
-            Assert.AreEqual(protectedTag.Name, getProtectedTag.Name);
+            Assert.That(getProtectedTag.Name, Is.EqualTo(protectedTag.Name));
             accessLevels = getProtectedTag.CreateAccessLevels.Select(level => level.AccessLevel).ToArray();
-            Assert.Contains(AccessLevel.NoAccess, accessLevels);
-            Assert.Contains(AccessLevel.Maintainer, accessLevels);
+            Assert.That(accessLevels, Does.Contain(AccessLevel.NoAccess));
+            Assert.That(accessLevels, Does.Contain(AccessLevel.Maintainer));
 
             var tag = await tagClient.GetByNameAsync(tagName).ConfigureAwait(false);
-            Assert.True(tag.Protected);
+            Assert.That(tag.Protected, Is.True);
 
             await protectedTagClient.UnprotectTagAsync(tagProtectName).ConfigureAwait(false);
 
             var protectedTags = protectedTagClient.GetProtectedTagsAsync();
-            Assert.False(protectedTags.Any());
+            Assert.That(protectedTags.Any(), Is.False);
 
             tag = await tagClient.GetByNameAsync(tag.Name).ConfigureAwait(false);
-            Assert.False(tag.Protected);
+            Assert.That(tag.Protected, Is.False);
         }
     }
 }

--- a/NGitLab.Tests/ReleaseClientTests.cs
+++ b/NGitLab.Tests/ReleaseClientTests.cs
@@ -30,14 +30,14 @@ namespace NGitLab.Tests.Release
                 Description = "test",
             });
 
-            Assert.AreEqual(ReleasesAccessLevel.Enabled, project.ReleasesAccessLevel);
+            Assert.That(project.ReleasesAccessLevel, Is.EqualTo(ReleasesAccessLevel.Enabled));
             Assert.That(release.TagName, Is.EqualTo("0.7"));
             Assert.That(release.Name, Is.EqualTo("0.7"));
             Assert.That(release.Description, Is.EqualTo("test"));
             Assert.That(release.Links.Self, Is.EqualTo($"{project.WebUrl}/-/releases/0.7"));
             Assert.That(release.Links.EditUrl, Is.EqualTo($"{project.WebUrl}/-/releases/0.7/edit"));
 
-            Assert.IsNotNull(releaseClient.GetAsync().FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)));
+            Assert.That(releaseClient.GetAsync().FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)), Is.Not.Null);
 
             release = releaseClient[tag.Name];
             Assert.That(release.TagName, Is.EqualTo("0.7"));
@@ -53,9 +53,9 @@ namespace NGitLab.Tests.Release
             Assert.That(release.Name, Is.EqualTo("0.7"));
             Assert.That(release.Description, Is.EqualTo("test updated"));
 
-            Assert.IsNotNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)));
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)), Is.Not.Null);
             tagsClient.Delete("0.7");
-            Assert.IsNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)));
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)), Is.Null);
         }
 
         [Test]
@@ -92,18 +92,18 @@ namespace NGitLab.Tests.Release
             });
             Assert.That(link.Name, Is.EqualTo("test link"));
             Assert.That(link.Url, Is.EqualTo("https://www.example.com"));
-            Assert.IsTrue(link.External);
+            Assert.That(link.External, Is.True);
 
             link = linksClient[link.Id.Value];
             Assert.That(link.Name, Is.EqualTo("test link"));
             Assert.That(link.Url, Is.EqualTo("https://www.example.com"));
-            Assert.IsTrue(link.External);
+            Assert.That(link.External, Is.True);
 
             linksClient.Delete(link.Id.Value);
-            Assert.IsNull(linksClient.All.FirstOrDefault(x => string.Equals(x.Name, "test link", StringComparison.Ordinal)));
+            Assert.That(linksClient.All.FirstOrDefault(x => string.Equals(x.Name, "test link", StringComparison.Ordinal)), Is.Null);
 
             tagsClient.Delete("0.7");
-            Assert.IsNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)));
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "0.7", StringComparison.Ordinal)), Is.Null);
         }
     }
 }

--- a/NGitLab.Tests/RepositoryClient/BranchClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/BranchClientTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests.RepositoryClient
             var project = context.CreateProject(initializeWithCommits: true);
             var branches = context.Client.GetRepository(project.Id).Branches;
 
-            CollectionAssert.IsNotEmpty(branches.All.ToArray());
+            Assert.That(branches.All.ToArray(), Is.Not.Empty);
         }
 
         [Test]
@@ -32,9 +32,9 @@ namespace NGitLab.Tests.RepositoryClient
 
             var branch = branches[project.DefaultBranch];
 
-            Assert.IsNotNull(branch);
-            Assert.IsNotNull(branch.Name);
-            Assert.IsTrue(branch.Default);
+            Assert.That(branch, Is.Not.Null);
+            Assert.That(branch.Name, Is.Not.Null);
+            Assert.That(branch.Default, Is.True);
         }
 
         [Test]
@@ -54,8 +54,8 @@ namespace NGitLab.Tests.RepositoryClient
             });
 
             var branch = branches[branchName];
-            Assert.IsNotNull(branch);
-            Assert.IsFalse(branch.Default);
+            Assert.That(branch, Is.Not.Null);
+            Assert.That(branch.Default, Is.False);
 
             branches.Protect(branchName);
 
@@ -82,7 +82,7 @@ namespace NGitLab.Tests.RepositoryClient
                 Ref = project.DefaultBranch,
             });
 
-            Assert.IsNotNull(branches[branchName]);
+            Assert.That(branches[branchName], Is.Not.Null);
 
             branches.Protect(branchName);
 
@@ -102,7 +102,7 @@ namespace NGitLab.Tests.RepositoryClient
             }
             catch (GitLabException ex)
             {
-                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+                Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
             }
         }
     }

--- a/NGitLab.Tests/RepositoryClient/ProjectHooksClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/ProjectHooksClientTests.cs
@@ -32,17 +32,17 @@ namespace NGitLab.Tests.RepositoryClient
             };
 
             var created = hooksClient.Create(toCreate);
-            Assert.That(hooksClient.All.ToArray().Length, Is.EqualTo(1));
+            Assert.That(hooksClient.All.ToArray(), Has.Length.EqualTo(1));
 
-            Assert.AreEqual(toCreate.MergeRequestsEvents, created.MergeRequestsEvents);
-            Assert.AreEqual(toCreate.PushEvents, created.PushEvents);
-            Assert.AreEqual(toCreate.IssuesEvents, created.IssuesEvents);
-            Assert.AreEqual(toCreate.JobEvents, created.JobEvents);
-            Assert.AreEqual(toCreate.NoteEvents, created.NoteEvents);
-            Assert.AreEqual(toCreate.PipelineEvents, created.PipelineEvents);
-            Assert.AreEqual(toCreate.TagPushEvents, created.TagPushEvents);
-            Assert.AreEqual(toCreate.EnableSslVerification, created.EnableSslVerification);
-            Assert.AreEqual(toCreate.Url, created.Url);
+            Assert.That(created.MergeRequestsEvents, Is.EqualTo(toCreate.MergeRequestsEvents));
+            Assert.That(created.PushEvents, Is.EqualTo(toCreate.PushEvents));
+            Assert.That(created.IssuesEvents, Is.EqualTo(toCreate.IssuesEvents));
+            Assert.That(created.JobEvents, Is.EqualTo(toCreate.JobEvents));
+            Assert.That(created.NoteEvents, Is.EqualTo(toCreate.NoteEvents));
+            Assert.That(created.PipelineEvents, Is.EqualTo(toCreate.PipelineEvents));
+            Assert.That(created.TagPushEvents, Is.EqualTo(toCreate.TagPushEvents));
+            Assert.That(created.EnableSslVerification, Is.EqualTo(toCreate.EnableSslVerification));
+            Assert.That(created.Url, Is.EqualTo(toCreate.Url));
 
             var toUpdate = new ProjectHookUpsert
             {
@@ -59,20 +59,20 @@ namespace NGitLab.Tests.RepositoryClient
             };
 
             var updated = hooksClient.Update(created.Id, toUpdate);
-            Assert.That(hooksClient.All.ToArray().Length, Is.EqualTo(1));
+            Assert.That(hooksClient.All.ToArray(), Has.Length.EqualTo(1));
 
-            Assert.AreEqual(toUpdate.MergeRequestsEvents, updated.MergeRequestsEvents);
-            Assert.AreEqual(toUpdate.PushEvents, updated.PushEvents);
-            Assert.AreEqual(toUpdate.IssuesEvents, updated.IssuesEvents);
-            Assert.AreEqual(toUpdate.JobEvents, updated.JobEvents);
-            Assert.AreEqual(toUpdate.NoteEvents, updated.NoteEvents);
-            Assert.AreEqual(toUpdate.PipelineEvents, updated.PipelineEvents);
-            Assert.AreEqual(toUpdate.TagPushEvents, updated.TagPushEvents);
-            Assert.AreEqual(toUpdate.EnableSslVerification, updated.EnableSslVerification);
-            Assert.AreEqual(toUpdate.Url, updated.Url);
+            Assert.That(updated.MergeRequestsEvents, Is.EqualTo(toUpdate.MergeRequestsEvents));
+            Assert.That(updated.PushEvents, Is.EqualTo(toUpdate.PushEvents));
+            Assert.That(updated.IssuesEvents, Is.EqualTo(toUpdate.IssuesEvents));
+            Assert.That(updated.JobEvents, Is.EqualTo(toUpdate.JobEvents));
+            Assert.That(updated.NoteEvents, Is.EqualTo(toUpdate.NoteEvents));
+            Assert.That(updated.PipelineEvents, Is.EqualTo(toUpdate.PipelineEvents));
+            Assert.That(updated.TagPushEvents, Is.EqualTo(toUpdate.TagPushEvents));
+            Assert.That(updated.EnableSslVerification, Is.EqualTo(toUpdate.EnableSslVerification));
+            Assert.That(updated.Url, Is.EqualTo(toUpdate.Url));
 
             hooksClient.Delete(updated.Id);
-            Assert.That(hooksClient.All.ToArray().Length, Is.EqualTo(0));
+            Assert.That(hooksClient.All.ToArray(), Is.Empty);
         }
     }
 }

--- a/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
@@ -79,8 +79,8 @@ namespace NGitLab.Tests.RepositoryClient
 
             var commits = context.RepositoryClient.Commits.ToArray();
 
-            Assert.AreEqual(commitCount, commits.Length);
-            CollectionAssert.AreEqual(context.Commits.Select(c => c.Message).Reverse(), commits.Select(c => c.Message));
+            Assert.That(commits, Has.Length.EqualTo(commitCount));
+            Assert.That(commits.Select(c => c.Message), Is.EqualTo(context.Commits.Select(c => c.Message).Reverse()).AsCollection);
         }
 
         [Test]
@@ -90,12 +90,12 @@ namespace NGitLab.Tests.RepositoryClient
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
             var defaultBranch = context.Project.DefaultBranch;
 
-            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits(defaultBranch));
-            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommits(defaultBranch, -1));
+            Assert.That(context.RepositoryClient.GetCommits(defaultBranch), Is.Not.Empty);
+            Assert.That(context.RepositoryClient.GetCommits(defaultBranch, -1), Is.Not.Empty);
 
             var commits = context.RepositoryClient.GetCommits(defaultBranch, 1).ToArray();
-            Assert.AreEqual(1, commits.Length);
-            Assert.AreEqual(context.Commits[1].Message, commits[0].Message);
+            Assert.That(commits, Has.Length.EqualTo(1));
+            Assert.That(commits[0].Message, Is.EqualTo(context.Commits[1].Message));
         }
 
         [Test]
@@ -106,10 +106,10 @@ namespace NGitLab.Tests.RepositoryClient
 
             var sha1 = context.Commits[0].Id;
             var commit = context.RepositoryClient.GetCommit(sha1);
-            Assert.AreEqual(sha1, commit.Id);
-            Assert.AreEqual(context.Commits[0].Message, commit.Message);
-            Assert.AreEqual(context.Commits[0].WebUrl, commit.WebUrl);
-            Assert.NotNull(commit.WebUrl);
+            Assert.That(commit.Id, Is.EqualTo(sha1));
+            Assert.That(commit.Message, Is.EqualTo(context.Commits[0].Message));
+            Assert.That(commit.WebUrl, Is.EqualTo(context.Commits[0].WebUrl));
+            Assert.That(commit.WebUrl, Is.Not.Null);
         }
 
         [Test]
@@ -126,8 +126,8 @@ namespace NGitLab.Tests.RepositoryClient
             };
 
             var commits = context.RepositoryClient.GetCommits(commitRequest).Reverse().ToArray();
-            Assert.AreEqual(allCommits[2].Id, commits[0].Id);
-            Assert.AreEqual(allCommits[3].Id, commits[1].Id);
+            Assert.That(commits[0].Id, Is.EqualTo(allCommits[2].Id));
+            Assert.That(commits[1].Id, Is.EqualTo(allCommits[3].Id));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.True(lastRequestQueryString.Contains($"since={expectedSinceValue}"));
+            Assert.That(lastRequestQueryString.Contains($"since={expectedSinceValue}"), Is.True);
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.False(lastRequestQueryString.Contains("since="));
+            Assert.That(lastRequestQueryString.Contains("since="), Is.False);
         }
 
         [Test]
@@ -200,7 +200,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.True(lastRequestQueryString.Contains($"until={expectedUntilValue}"));
+            Assert.That(lastRequestQueryString.Contains($"until={expectedUntilValue}"), Is.True);
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.False(lastRequestQueryString.Contains("until="));
+            Assert.That(lastRequestQueryString.Contains("until="), Is.False);
         }
 
         [Test]
@@ -232,7 +232,7 @@ namespace NGitLab.Tests.RepositoryClient
         {
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
 
-            CollectionAssert.IsNotEmpty(context.RepositoryClient.GetCommitDiff(context.RepositoryClient.Commits.First().Id).ToArray());
+            Assert.That(context.RepositoryClient.GetCommitDiff(context.RepositoryClient.Commits.First().Id).ToArray(), Is.Not.Empty);
         }
 
         [TestCase(4)]
@@ -247,9 +247,9 @@ namespace NGitLab.Tests.RepositoryClient
             var expectedFileCount = (int)Math.Ceiling(commitCount / 2.0);
             var expectedDirCount = 1;
 
-            Assert.AreEqual(expectedFileCount, treeObjects.Count(t => t.Type == ObjectType.blob));
-            Assert.AreEqual(expectedDirCount, treeObjects.Count(t => t.Type == ObjectType.tree));
-            Assert.IsTrue(treeObjects.All(t => string.Equals(t.Path, t.Name, StringComparison.Ordinal)));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.blob), Is.EqualTo(expectedFileCount));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.tree), Is.EqualTo(expectedDirCount));
+            Assert.That(treeObjects.All(t => string.Equals(t.Path, t.Name, StringComparison.Ordinal)), Is.True);
         }
 
         [TestCase(4)]
@@ -264,8 +264,8 @@ namespace NGitLab.Tests.RepositoryClient
             var expectedFileCount = commitCount;
             var expectedDirCount = 1;
 
-            Assert.AreEqual(expectedFileCount, treeObjects.Count(t => t.Type == ObjectType.blob));
-            Assert.AreEqual(expectedDirCount, treeObjects.Count(t => t.Type == ObjectType.tree));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.blob), Is.EqualTo(expectedFileCount));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.tree), Is.EqualTo(expectedDirCount));
         }
 
         [TestCase(4)]
@@ -284,8 +284,8 @@ namespace NGitLab.Tests.RepositoryClient
             var expectedFileCount = commitCount;
             var expectedDirCount = 1;
 
-            Assert.AreEqual(expectedFileCount, treeObjects.Count(t => t.Type == ObjectType.blob));
-            Assert.AreEqual(expectedDirCount, treeObjects.Count(t => t.Type == ObjectType.tree));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.blob), Is.EqualTo(expectedFileCount));
+            Assert.That(treeObjects.Count(t => t.Type == ObjectType.tree), Is.EqualTo(expectedDirCount));
         }
 
         [TestCase(4)]
@@ -301,7 +301,7 @@ namespace NGitLab.Tests.RepositoryClient
                 treeObjects.Add(item);
             }
 
-            Assert.True(treeObjects.All(t => t.Path.StartsWith(RepositoryClientTestsContext.SubfolderName, StringComparison.OrdinalIgnoreCase)));
+            Assert.That(treeObjects.All(t => t.Path.StartsWith(RepositoryClientTestsContext.SubfolderName, StringComparison.OrdinalIgnoreCase)), Is.True);
         }
 
         [Test]
@@ -311,7 +311,7 @@ namespace NGitLab.Tests.RepositoryClient
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
 
             var treeObjects = context.RepositoryClient.GetTree(string.Empty, context.Project.DefaultBranch, recursive: false);
-            Assert.IsNotEmpty(treeObjects);
+            Assert.That(treeObjects, Is.Not.Empty);
         }
 
         [Test]
@@ -321,7 +321,7 @@ namespace NGitLab.Tests.RepositoryClient
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
 
             var treeObjects = context.RepositoryClient.GetTree(new RepositoryGetTreeOptions { Path = string.Empty, PerPage = 100 });
-            Assert.IsNotEmpty(treeObjects);
+            Assert.That(treeObjects, Is.Not.Empty);
         }
 
         [Test]
@@ -331,7 +331,7 @@ namespace NGitLab.Tests.RepositoryClient
             using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 2);
 
             var treeObjects = context.RepositoryClient.GetTree("Fakepath");
-            Assert.IsEmpty(treeObjects);
+            Assert.That(treeObjects, Is.Empty);
         }
 
         [TestCase(CommitRefType.All)]
@@ -346,11 +346,11 @@ namespace NGitLab.Tests.RepositoryClient
 
             if (type == CommitRefType.Tag)
             {
-                CollectionAssert.IsEmpty(commitRefs);
+                Assert.That(commitRefs, Is.Empty);
             }
             else
             {
-                CollectionAssert.IsNotEmpty(commitRefs);
+                Assert.That(commitRefs, Is.Not.Empty);
             }
         }
     }

--- a/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
@@ -152,7 +152,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.That(lastRequestQueryString.Contains($"since={expectedSinceValue}"), Is.True);
+            Assert.That(lastRequestQueryString, Does.Contain($"since={expectedSinceValue}"));
         }
 
         [Test]
@@ -175,7 +175,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.That(lastRequestQueryString.Contains("since="), Is.False);
+            Assert.That(lastRequestQueryString, Does.Not.Contain("since="));
         }
 
         [Test]
@@ -200,7 +200,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.That(lastRequestQueryString.Contains($"until={expectedUntilValue}"), Is.True);
+            Assert.That(lastRequestQueryString, Does.Contain($"until={expectedUntilValue}"));
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace NGitLab.Tests.RepositoryClient
             // Assert
             var lastRequestQueryString = context.Context.LastRequest.RequestUri.Query;
 
-            Assert.That(lastRequestQueryString.Contains("until="), Is.False);
+            Assert.That(lastRequestQueryString, Does.Not.Contain("until="));
         }
 
         [Test]

--- a/NGitLab.Tests/RunnerTests.cs
+++ b/NGitLab.Tests/RunnerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
@@ -23,10 +22,10 @@ namespace NGitLab.Tests
             runnersClient.EnableRunner(project2.Id, new RunnerId(runner.Id));
 
             runnersClient.DisableRunner(project1.Id, new RunnerId(runner.Id));
-            Assert.IsFalse(IsEnabled());
+            Assert.That(IsEnabled(), Is.False);
 
             runnersClient.EnableRunner(project1.Id, new RunnerId(runner.Id));
-            Assert.IsTrue(IsEnabled());
+            Assert.That(IsEnabled(), Is.True);
 
             bool IsEnabled() => runnersClient[runner.Id].Projects.Any(x => x.Id == project1.Id);
         }
@@ -43,32 +42,11 @@ namespace NGitLab.Tests
             runnersClient.EnableRunner(project2.Id, new RunnerId(runner.Id));
 
             var result = runnersClient.OfProject(project.Id).ToList();
-            Assert.IsTrue(result.Any(r => r.Id == runner.Id));
+            Assert.That(result.Any(r => r.Id == runner.Id), Is.True);
 
             runnersClient.DisableRunner(project.Id, new RunnerId(runner.Id));
             result = runnersClient.OfProject(project.Id).ToList();
-            Assert.IsTrue(result.All(r => r.Id != runner.Id));
-        }
-
-        [Test]
-        [NGitLabRetry]
-        public async Task Test_some_runner_fields_are_not_null()
-        {
-            using var context = await GitLabTestContext.CreateAsync();
-            var project = context.CreateProject(initializeWithCommits: true);
-            var runnersClient = context.Client.Runners;
-            var runner = runnersClient.Register(new RunnerRegister { Token = project.RunnersToken });
-
-            using (await context.StartRunnerForOneJobAsync(project.Id))
-            {
-                var runnerDetails = await GitLabTestContext.RetryUntilAsync(() => runnersClient[runner.Id], runner => runner.IpAddress != null, TimeSpan.FromMinutes(2));
-
-                Assert.IsNotNull(runnerDetails.Id);
-                Assert.IsNotNull(runnerDetails.Active);
-                Assert.IsNotNull(runnerDetails.Locked);
-                Assert.IsNotNull(runnerDetails.RunUntagged);
-                Assert.IsNotNull(runnerDetails.IpAddress);
-            }
+            Assert.That(result.All(r => r.Id != runner.Id), Is.True);
         }
 
         [Test]
@@ -79,13 +57,13 @@ namespace NGitLab.Tests
             var project = context.CreateProject(initializeWithCommits: true);
             var runnersClient = context.Client.Runners;
             var runner = runnersClient.Register(new RunnerRegister { Token = project.RunnersToken, Locked = false });
-            Assert.IsFalse(runner.Locked, "Runner should not be locked.");
+            Assert.That(runner.Locked, Is.False, "Runner should not be locked.");
 
             runner = runnersClient.Update(runner.Id, new RunnerUpdate { Locked = true });
-            Assert.IsTrue(runner.Locked, "Runner should be locked.");
+            Assert.That(runner.Locked, Is.True, "Runner should be locked.");
 
             runner = runnersClient.Update(runner.Id, new RunnerUpdate { Locked = false });
-            Assert.IsFalse(runner.Locked, "Runner should not be locked.");
+            Assert.That(runner.Locked, Is.False, "Runner should not be locked.");
         }
 
         [Test]
@@ -96,10 +74,10 @@ namespace NGitLab.Tests
             var project = context.CreateProject(initializeWithCommits: true);
             var runnersClient = context.Client.Runners;
             var runner = runnersClient.Register(new RunnerRegister { Token = project.RunnersToken, RunUntagged = false, TagList = new[] { "tag" } });
-            Assert.False(runner.RunUntagged);
+            Assert.That(runner.RunUntagged, Is.False);
 
             runner = runnersClient.Update(runner.Id, new RunnerUpdate { RunUntagged = true });
-            Assert.AreEqual(true, runner.RunUntagged);
+            Assert.That(runner.RunUntagged, Is.True);
         }
     }
 }

--- a/NGitLab.Tests/Sha1Tests.cs
+++ b/NGitLab.Tests/Sha1Tests.cs
@@ -9,21 +9,21 @@ namespace NGitLab.Tests
         public void WhenSha1WithLowerCase_ThenParsedCorrectly()
         {
             const string value = "2695effb5807a22ff3d138d593fd856244e155e7";
-            Assert.AreEqual(value.ToUpperInvariant(), new Sha1(value).ToString().ToUpperInvariant());
+            Assert.That(new Sha1(value).ToString().ToUpperInvariant(), Is.EqualTo(value.ToUpperInvariant()));
         }
 
         [Test]
         public void WhenSha1WithLeadingZero_ThenParsedCorrectly()
         {
             const string value = "59529D73E3E6E2B7015F05D197E12C43B13BA033";
-            Assert.AreEqual(value.ToUpperInvariant(), new Sha1(value).ToString().ToUpperInvariant());
+            Assert.That(new Sha1(value).ToString().ToUpperInvariant(), Is.EqualTo(value.ToUpperInvariant()));
         }
 
         [Test]
         public void WhenSha1WithUpperCase_ThenParsedCorrectly()
         {
             const string value = "2695EFFB5807A22FF3D138D593FD856244E155E7";
-            Assert.AreEqual(value, new Sha1(value).ToString().ToUpperInvariant());
+            Assert.That(new Sha1(value).ToString().ToUpperInvariant(), Is.EqualTo(value));
         }
 
         [Test]

--- a/NGitLab.Tests/SnippetsTest.cs
+++ b/NGitLab.Tests/SnippetsTest.cs
@@ -39,11 +39,11 @@ namespace NGitLab.Tests
 
             var returnedUserSnippet = snippetClient.All.First(s => string.Equals(s.Title, snippetName, StringComparison.Ordinal));
 
-            Assert.IsNotNull(returnedUserSnippet.Files);
-            Assert.AreEqual(2, returnedUserSnippet.Files.Length);
+            Assert.That(returnedUserSnippet.Files, Is.Not.Null);
+            Assert.That(returnedUserSnippet.Files, Has.Length.EqualTo(2));
 
-            Assert.IsNotNull(returnedUserSnippet.Files[0]);
-            Assert.IsTrue(string.Equals(returnedUserSnippet.Files[0].Path, "Path1.txt", StringComparison.Ordinal));
+            Assert.That(returnedUserSnippet.Files[0], Is.Not.Null);
+            Assert.That(string.Equals(returnedUserSnippet.Files[0].Path, "Path1.txt", StringComparison.Ordinal), Is.True);
 
             var updatedSnippet = new SnippetUpdate
             {
@@ -61,8 +61,8 @@ namespace NGitLab.Tests
 
             var returnedProjectSnippetAfterUpdate = snippetClient.User.First(s => string.Equals(s.Title, snippetName, StringComparison.Ordinal));
 
-            Assert.AreEqual(1, returnedProjectSnippetAfterUpdate.Files.Length);
-            Assert.AreEqual("rename.md", returnedProjectSnippetAfterUpdate.Files[0].Path);
+            Assert.That(returnedProjectSnippetAfterUpdate.Files, Has.Length.EqualTo(1));
+            Assert.That(returnedProjectSnippetAfterUpdate.Files[0].Path, Is.EqualTo("rename.md"));
 
             snippetClient.Delete(returnedUserSnippet.Id);
         }
@@ -103,11 +103,11 @@ namespace NGitLab.Tests
 
             Assert.That(snippetClient.Get(newSnippet.ProjectId, returnedProjectSnippet.Id), Is.Not.Null);
 
-            Assert.IsNotNull(returnedProjectSnippet.Files);
-            Assert.AreEqual(2, returnedProjectSnippet.Files.Length);
+            Assert.That(returnedProjectSnippet.Files, Is.Not.Null);
+            Assert.That(returnedProjectSnippet.Files, Has.Length.EqualTo(2));
 
-            Assert.IsNotNull(returnedProjectSnippet.Files[0]);
-            Assert.IsTrue(string.Equals(returnedProjectSnippet.Files[0].Path, "Path1.txt", StringComparison.Ordinal));
+            Assert.That(returnedProjectSnippet.Files[0], Is.Not.Null);
+            Assert.That(string.Equals(returnedProjectSnippet.Files[0].Path, "Path1.txt", StringComparison.Ordinal), Is.True);
 
             var updatedSnippet = new SnippetProjectUpdate
             {
@@ -126,8 +126,8 @@ namespace NGitLab.Tests
 
             var returnedProjectSnippetAfterUpdate = snippetClient.User.First(s => string.Equals(s.Title, projectSnippetName, StringComparison.Ordinal));
 
-            Assert.AreEqual(1, returnedProjectSnippetAfterUpdate.Files.Length);
-            Assert.AreEqual("rename.md", returnedProjectSnippetAfterUpdate.Files[0].Path);
+            Assert.That(returnedProjectSnippetAfterUpdate.Files, Has.Length.EqualTo(1));
+            Assert.That(returnedProjectSnippetAfterUpdate.Files[0].Path, Is.EqualTo("rename.md"));
 
             snippetClient.Delete(newSnippet.ProjectId, returnedProjectSnippet.Id);
         }

--- a/NGitLab.Tests/TagTests.cs
+++ b/NGitLab.Tests/TagTests.cs
@@ -25,12 +25,12 @@ namespace NGitLab.Tests
                 Ref = project.DefaultBranch,
             });
 
-            Assert.IsNotNull(result);
-            Assert.IsNotNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "v0.5", StringComparison.Ordinal)));
-            Assert.IsNotNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Message, "Test message", StringComparison.Ordinal)));
+            Assert.That(result, Is.Not.Null);
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "v0.5", StringComparison.Ordinal)), Is.Not.Null);
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Message, "Test message", StringComparison.Ordinal)), Is.Not.Null);
 
             tagsClient.Delete("v0.5");
-            Assert.IsNull(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "v0.5", StringComparison.Ordinal)));
+            Assert.That(tagsClient.All.FirstOrDefault(x => string.Equals(x.Name, "v0.5", StringComparison.Ordinal)), Is.Null);
         }
 
         [NGitLabRetry]
@@ -49,18 +49,18 @@ namespace NGitLab.Tests
                 Message = "Test message",
                 Ref = project.DefaultBranch,
             });
-            Assert.IsNotNull(tagCreated);
+            Assert.That(tagCreated, Is.Not.Null);
 
             // Act/Assert
             if (expectExistence)
             {
                 var tagFetched = await tagClient.GetByNameAsync(tagNameSought);
-                Assert.IsNotNull(tagFetched);
+                Assert.That(tagFetched, Is.Not.Null);
             }
             else
             {
                 var ex = Assert.ThrowsAsync<GitLabException>(() => tagClient.GetByNameAsync(tagNameSought));
-                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+                Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
             }
         }
     }

--- a/NGitLab.Tests/TriggerTests.cs
+++ b/NGitLab.Tests/TriggerTests.cs
@@ -19,12 +19,12 @@ namespace NGitLab.Tests
             var createdTrigger = triggersClient.Create("Unit_Test_Description");
             var trigger = triggersClient[createdTrigger.Id];
 
-            Assert.AreEqual("Unit_Test_Description", trigger.Description);
+            Assert.That(trigger.Description, Is.EqualTo("Unit_Test_Description"));
 
             var triggers = triggersClient.All.Take(10).ToArray();
 
-            Assert.IsNotNull(triggers);
-            Assert.IsNotEmpty(triggers);
+            Assert.That(triggers, Is.Not.Null);
+            Assert.That(triggers, Is.Not.Empty);
         }
     }
 }

--- a/NGitLab.Tests/UsersTests.cs
+++ b/NGitLab.Tests/UsersTests.cs
@@ -19,7 +19,7 @@ namespace NGitLab.Tests
         {
             using var context = await GitLabTestContext.CreateAsync();
             var users = context.Client.Users.All.Take(100).ToArray(); // We don't want to enumerate all users
-            CollectionAssert.IsNotEmpty(users);
+            Assert.That(users, Is.Not.Empty);
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace NGitLab.Tests
             var current = context.Client.Users.Current;
 
             var user = context.Client.Users[current.Id];
-            Assert.IsNotNull(user);
+            Assert.That(user, Is.Not.Null);
             Assert.That(user.Username, Is.EqualTo(current.Username));
         }
 
@@ -111,17 +111,17 @@ namespace NGitLab.Tests
                 Title = "test key",
             });
 
-            Assert.IsNotNull(result);
-            StringAssert.StartsWith(generatedKey.PublicKey, result.Key);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Key, Does.StartWith(generatedKey.PublicKey));
 
             var newKey = keys.All.FirstOrDefault(k => k.Id == result.Id);
 
-            Assert.IsNotNull(newKey);
-            Assert.AreEqual(result.Key, newKey.Key);
+            Assert.That(newKey, Is.Not.Null);
+            Assert.That(newKey.Key, Is.EqualTo(result.Key));
 
             keys.Remove(result.Id);
 
-            Assert.IsNull(keys.All.FirstOrDefault(k => k.Id == result.Id));
+            Assert.That(keys.All.FirstOrDefault(k => k.Id == result.Id), Is.Null);
         }
 
         [Test]
@@ -141,8 +141,8 @@ namespace NGitLab.Tests
 
             var tokenResult = users.CreateToken(tokenRequest);
 
-            Assert.IsNotEmpty(tokenResult.Token);
-            Assert.AreEqual(tokenRequest.Name, tokenResult.Name);
+            Assert.That(tokenResult.Token, Is.Not.Empty);
+            Assert.That(tokenResult.Name, Is.EqualTo(tokenRequest.Name));
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace NGitLab.Tests
         {
             using var context = await GitLabTestContext.CreateAsync();
             var activities = context.AdminClient.Users.GetLastActivityDatesAsync().ToArray();
-            CollectionAssert.IsNotEmpty(activities.Where(a => string.Equals(a.Username, context.AdminClient.Users.Current.Username, StringComparison.Ordinal)));
+            Assert.That(activities.Where(a => string.Equals(a.Username, context.AdminClient.Users.Current.Username, StringComparison.Ordinal)), Is.Not.Empty);
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace NGitLab.Tests
             using var context = await GitLabTestContext.CreateAsync();
             var yesterday = DateTimeOffset.UtcNow.AddDays(-1);
             var activities = context.AdminClient.Users.GetLastActivityDatesAsync(from: yesterday).ToArray();
-            CollectionAssert.IsNotEmpty(activities);
+            Assert.That(activities, Is.Not.Empty);
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace NGitLab.Tests
             using var context = await GitLabTestContext.CreateAsync();
             var tomorrow = DateTimeOffset.UtcNow.AddDays(1);
             var activities = context.AdminClient.Users.GetLastActivityDatesAsync(from: tomorrow).ToArray();
-            CollectionAssert.IsEmpty(activities);
+            Assert.That(activities, Is.Empty);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace NGitLab.Tests
         {
             using var context = await GitLabTestContext.CreateAsync();
             var exception = Assert.Throws<GitLabException>(() => context.Client.Users.GetLastActivityDatesAsync().ToArray());
-            Assert.AreEqual(HttpStatusCode.Forbidden, exception.StatusCode);
+            Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
         }
 
         private static User CreateNewUser(GitLabTestContext context)


### PR DESCRIPTION
- Add package reference to `NUnit.Analyzers`
- Use analyzer fixers to convert asserts to constraint models
- Remove the no longer necessary `GlobalUsings.cs`
- Remove `NGitLab.Tests.RunnerTests.Test_some_runner_fields_are_not_null()`, as it's pointless: it checks whether non-nullable values are indeed not null