### PR TITLE
Set global.json's "rollForward" to "major" rather than "latestMajor"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "8.0.100",
-        "rollForward": "latestMajor"
+        "rollForward": "major"
     }
 }


### PR DESCRIPTION
With this new setting, the .NET SDK version used won't necessarily be the latest one installed on the machine, but the "closest" one that is >= specified version.

According to [the documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward):

```
Uses the latest patch level for the specified major, minor, and feature band.
If not found, rolls forward to the next higher feature band within the same major/minor version and uses the latest patch level for that feature band.
If not found, rolls forward to the next higher minor and feature band within the same major and uses the latest patch level for that feature band.
If not found, rolls forward to the next higher major, minor, and feature band and uses the latest patch level for that feature band.
If not found, fails.
```