### PR TITLE
Allow MR Comment Range type to be nullable

### DIFF
--- a/NGitLab/Models/Range.cs
+++ b/NGitLab/Models/Range.cs
@@ -8,5 +8,5 @@ public class Range
     public string LineCode { get; set; }
 
     [JsonPropertyName("type")]
-    public DynamicEnum<RangeType> Type { get; set; }
+    public DynamicEnum<RangeType>? Type { get; set; }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -3050,7 +3050,7 @@ NGitLab.Models.Range
 NGitLab.Models.Range.LineCode.get -> string
 NGitLab.Models.Range.LineCode.set -> void
 NGitLab.Models.Range.Range() -> void
-NGitLab.Models.Range.Type.get -> NGitLab.DynamicEnum<NGitLab.Models.RangeType>
+NGitLab.Models.Range.Type.get -> NGitLab.DynamicEnum<NGitLab.Models.RangeType>?
 NGitLab.Models.Range.Type.set -> void
 NGitLab.Models.RangeType
 NGitLab.Models.RangeType.New = 0 -> NGitLab.Models.RangeType


### PR DESCRIPTION
GitLab sometimes returns Null as the range type, which breaks deserialization of the model.

Setting the field to nullable fixes the issue, without breaking deserialization of the DynamicEnum when it is actually set 