### PR TITLE
Add async functions to `IMembersClient` and other changes

### DIFF
--- a/NGitLab.Mock.Tests/MembersMockTests.cs
+++ b/NGitLab.Mock.Tests/MembersMockTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
 using NGitLab.Mock.Config;
 using NUnit.Framework;
 
@@ -81,5 +84,98 @@ public class MembersMockTests
         var members = client.Members.OfProject("1", includeInheritedMembers: true);
 
         Assert.That(members.Count(), Is.EqualTo(3), "Membership found are invalid");
+    }
+
+    [Test]
+    public async Task Test_members_async_methods_simulate_gitlab_behavior()
+    {
+        // This test emulates GitLab's behavior. See `MembersClientTests.AsyncMethodsBehaveAsExpected()`
+
+        // Arrange
+        var user1Name = "user1";
+        var ownerName = "owner";
+
+        using var server = new GitLabConfig()
+            .WithUser(ownerName, isDefault: true)
+            .WithUser(user1Name)
+            .WithGroupOfFullPath("G1", configure: g =>
+                g.WithUserPermission(ownerName, Models.AccessLevel.Owner)
+                 .WithUserPermission(user1Name, Models.AccessLevel.Maintainer))
+            .WithGroupOfFullPath("G1/G2", configure: g =>
+                g.WithUserPermission(ownerName, Models.AccessLevel.Owner))
+            .WithProject("Project", 1, @namespace: "G1")
+            .BuildServer();
+
+        var client = server.CreateClient(ownerName);
+
+        var user1 = await client.Users.GetByUserNameAsync(user1Name);
+        var user1Id = user1.Id.ToString();
+
+        // Act
+        // Assert
+        const string projectId = "G1/Project";
+        const string groupId = "G1/G2";
+
+        // Does NOT search inherited permission by default...
+        AssertThrowsGitLabException(() => client.Members.GetMemberOfProjectAsync(projectId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.GetMemberOfGroupAsync(groupId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        client.Members.OfProjectAsync(projectId).Select(m => m.UserName).Should().BeEmpty();
+        client.Members.OfGroupAsync(groupId).Select(m => m.UserName).Should().BeEquivalentTo(new[] { ownerName });
+
+        // Does search inherited permission when asked...
+        (await client.Members.GetMemberOfProjectAsync(projectId, user1.Id, includeInheritedMembers: true)).UserName.Should().Be(user1Name);
+        (await client.Members.GetMemberOfGroupAsync(groupId, user1.Id, includeInheritedMembers: true)).UserName.Should().Be(user1Name);
+        client.Members.OfProjectAsync(projectId, includeInheritedMembers: true).Select(m => m.UserName).Should().BeEquivalentTo(new[] { ownerName, user1Name });
+        client.Members.OfGroupAsync(groupId, includeInheritedMembers: true).Select(m => m.UserName).Should().BeEquivalentTo(new[] { ownerName, user1Name });
+
+        // Cannot update non-existent membership...
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), System.Net.HttpStatusCode.NotFound);
+
+        // Cannot add membership with an access-level lower than inherited...
+        AssertThrowsGitLabException(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+        AssertThrowsGitLabException(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+
+        // Can add membership with greater than or equal access-level...
+        await AssertReturnsMembership(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Maintainer }), Models.AccessLevel.Maintainer);
+        await AssertReturnsMembership(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Maintainer }), Models.AccessLevel.Maintainer);
+
+        // Cannot add duplicate membership...
+        AssertThrowsGitLabException(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), System.Net.HttpStatusCode.Conflict);
+        AssertThrowsGitLabException(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), System.Net.HttpStatusCode.Conflict);
+
+        // Can raise access-level above inherited...
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), Models.AccessLevel.Owner);
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Owner }), Models.AccessLevel.Owner);
+
+        // Can decrease access-level to inherited...
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Maintainer }), Models.AccessLevel.Maintainer);
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Maintainer }), Models.AccessLevel.Maintainer);
+
+        // Cannot decrease access-level lower than inherited...
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = Models.AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+
+        // Can delete...
+        await client.Members.RemoveMemberFromProjectAsync(projectId, user1.Id);
+        await client.Members.RemoveMemberFromGroupAsync(groupId, user1.Id);
+
+        // Delete fails when not exist...
+        AssertThrowsGitLabException(() => client.Members.RemoveMemberFromProjectAsync(projectId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.RemoveMemberFromGroupAsync(groupId, user1.Id), System.Net.HttpStatusCode.NotFound);
+    }
+
+    private static async Task AssertReturnsMembership(Func<Task<Models.Membership>> code, Models.AccessLevel expectedAccessLevel)
+    {
+        var membership = await code.Invoke().ConfigureAwait(false);
+        Assert.That(membership, Is.Not.Null);
+        Assert.That(membership.AccessLevel, Is.EqualTo((int)expectedAccessLevel));
+    }
+
+    private static void AssertThrowsGitLabException(AsyncTestDelegate code, System.Net.HttpStatusCode expectedStatusCode)
+    {
+        var ex = Assert.CatchAsync(typeof(GitLabException), code) as GitLabException;
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex.StatusCode, Is.EqualTo(expectedStatusCode));
     }
 }

--- a/NGitLab.Mock/Clients/ClientBase.cs
+++ b/NGitLab.Mock/Clients/ClientBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using NGitLab.Models;
 
 namespace NGitLab.Mock.Clients;
 
@@ -31,6 +32,8 @@ internal abstract class ClientBase
         {
             int idInt => Server.AllGroups.FindById(idInt),
             string idStr => Server.AllGroups.FindGroup(idStr),
+            IIdOrPathAddressable gid when gid.Path != null => Server.AllGroups.FindByNamespacedPath(gid.Path),
+            IIdOrPathAddressable gid => Server.AllGroups.FindById(gid.Id),
             _ => throw new ArgumentException($"Id of type '{id.GetType()}' is not supported"),
         };
 
@@ -77,6 +80,8 @@ internal abstract class ClientBase
         {
             int idInt => Server.AllProjects.FindById(idInt),
             string idStr => Server.AllProjects.FindProject(idStr),
+            IIdOrPathAddressable pid when pid.Path != null => Server.AllProjects.FindByNamespacedPath(pid.Path),
+            IIdOrPathAddressable pid => Server.AllProjects.FindById(pid.Id),
             _ => throw new ArgumentException($"Id of type '{id.GetType()}' is not supported"),
         };
 

--- a/NGitLab.Mock/Clients/GroupClient.cs
+++ b/NGitLab.Mock/Clients/GroupClient.cs
@@ -34,8 +34,13 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
             var newGroup = new Group
             {
                 Name = group.Name,
+                Path = group.Path,
                 Description = group.Description,
                 Visibility = group.Visibility,
+                LfsEnabled = group.LfsEnabled,
+                RequestAccessEnabled = group.RequestAccessEnabled,
+                SharedRunnersLimit = TimeSpan.FromMinutes(group.SharedRunnersMinutesLimit ?? 0),
+
                 Permissions =
                 {
                     new Permission(Context.User, AccessLevel.Owner),

--- a/NGitLab.Mock/Clients/MembersClient.cs
+++ b/NGitLab.Mock/Clients/MembersClient.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Extensions;
+using NGitLab.Mock.Internals;
 using NGitLab.Models;
 
 namespace NGitLab.Mock.Clients;
@@ -12,100 +15,6 @@ internal sealed class MembersClient : ClientBase, IMembersClient
     public MembersClient(ClientContext context)
         : base(context)
     {
-    }
-
-    public Membership AddMemberToProject(string projectId, ProjectMemberCreate projectMemberCreate)
-    {
-        using (Context.BeginOperationScope())
-        {
-            var project = GetProject(projectId, ProjectPermission.Edit);
-            var user = Server.Users.GetById(projectMemberCreate.UserId);
-
-            CheckUserPermissionOfProject(projectMemberCreate.AccessLevel, user, project);
-
-            var permission = new Permission(user, projectMemberCreate.AccessLevel);
-            project.Permissions.Add(permission);
-
-            return project.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
-        }
-    }
-
-    public Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate projectMemberUpdate)
-    {
-        using (Context.BeginOperationScope())
-        {
-            var project = GetProject(projectId, ProjectPermission.Edit);
-            var user = Server.Users.GetById(projectMemberUpdate.UserId);
-
-            CheckUserPermissionOfProject(projectMemberUpdate.AccessLevel, user, project);
-            return project.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
-        }
-    }
-
-    public Membership AddMemberToGroup(string groupId, GroupMemberCreate groupMemberCreate)
-    {
-        using (Context.BeginOperationScope())
-        {
-            var group = GetGroup(groupId, GroupPermission.Edit);
-            var user = Server.Users.GetById(groupMemberCreate.UserId);
-
-            CheckUserPermissionOfGroup(groupMemberCreate.AccessLevel, user, group);
-
-            var permission = new Permission(user, groupMemberCreate.AccessLevel);
-            group.Permissions.Add(permission);
-
-            return group.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
-        }
-    }
-
-    public Membership UpdateMemberOfGroup(string groupId, GroupMemberUpdate groupMemberUpdate)
-    {
-        using (Context.BeginOperationScope())
-        {
-            var group = GetGroup(groupId, GroupPermission.Edit);
-            var user = Server.Users.GetById(groupMemberUpdate.UserId);
-
-            CheckUserPermissionOfGroup(groupMemberUpdate.AccessLevel, user, group);
-            return group.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
-        }
-    }
-
-    public Membership GetMemberOfGroup(string groupId, string userId)
-    {
-        return OfGroup(groupId, includeInheritedMembers: false)
-            .FirstOrDefault(u => string.Equals(u.Id.ToString(CultureInfo.InvariantCulture), userId, StringComparison.Ordinal));
-    }
-
-    public Membership GetMemberOfProject(string projectId, string userId)
-    {
-        return OfProject(projectId, includeInheritedMembers: false)
-            .FirstOrDefault(u => string.Equals(u.Id.ToString(CultureInfo.InvariantCulture), userId, StringComparison.Ordinal));
-    }
-
-    public Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers)
-    {
-        return OfProject(projectId, includeInheritedMembers)
-           .FirstOrDefault(u => string.Equals(u.Id.ToString(CultureInfo.InvariantCulture), userId, StringComparison.Ordinal));
-    }
-
-    public IEnumerable<Membership> OfGroup(string groupId)
-    {
-        return OfGroup(groupId, includeInheritedMembers: false);
-    }
-
-    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
-    {
-        using (Context.BeginOperationScope())
-        {
-            var group = GetGroup(groupId, GroupPermission.View);
-            var members = group.GetEffectivePermissions(includeInheritedMembers).Permissions;
-            return members.Select(member => member.ToMembershipClient());
-        }
-    }
-
-    public IEnumerable<Membership> OfNamespace(string groupId)
-    {
-        return OfGroup(groupId);
     }
 
     public IEnumerable<Membership> OfProject(string projectId)
@@ -123,43 +32,248 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         }
     }
 
-    private static void CheckUserPermissionOfProject(AccessLevel accessLevel, User user, Project project)
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false)
     {
-        var existingPermission = project.GetEffectivePermissions().GetEffectivePermission(user);
-        if (existingPermission != null)
+        return GitLabCollectionResponse.Create(OfProject(projectId.ValueAsString(), includeInheritedMembers));
+    }
+
+    public Membership AddMemberToProject(string projectId, ProjectMemberCreate projectMemberCreate)
+    {
+        using (Context.BeginOperationScope())
         {
-            if (existingPermission.AccessLevel > accessLevel)
+            var project = GetProject(projectId, ProjectPermission.Edit);
+            var user = Server.Users.GetById(projectMemberCreate.UserId);
+
+            if (project.Permissions.Any(p => p.User.Id == user.Id))
             {
-                throw new GitLabException("{\"access_level\":[\"should be greater than or equal to Owner inherited membership from group Runners\"]}.")
+                throw new GitLabException("Member already exists")
                 {
-                    StatusCode = HttpStatusCode.BadRequest,
+                    // actual GitLab error
+                    StatusCode = HttpStatusCode.Conflict,
+                    ErrorMessage = "Member already exists",
                 };
             }
 
-            if (existingPermission.AccessLevel == accessLevel)
-            {
-                throw new GitLabException { StatusCode = HttpStatusCode.Conflict };
-            }
+            ValidateNewProjectPermission(projectMemberCreate.AccessLevel, user, project);
+
+            project.Permissions.Add(new(user, projectMemberCreate.AccessLevel));
+
+            return project.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
         }
     }
 
-    private static void CheckUserPermissionOfGroup(AccessLevel accessLevel, User user, Group group)
+    public async Task<Membership> AddMemberToProjectAsync(ProjectId projectId, ProjectMemberCreate user, CancellationToken cancellationToken = default)
     {
-        var existingPermission = group.GetEffectivePermissions().GetEffectivePermission(user);
-        if (existingPermission != null)
+        await Task.Yield();
+        return AddMemberToProject(projectId.ValueAsString(), user);
+    }
+
+    public Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate projectMemberUpdate)
+    {
+        using (Context.BeginOperationScope())
         {
-            if (existingPermission.AccessLevel > accessLevel)
+            var project = GetProject(projectId, ProjectPermission.Edit);
+            var user = Server.Users.GetById(projectMemberUpdate.UserId);
+
+            var curPermission = project.Permissions.SingleOrDefault(p => p.User.Id == user.Id)
+                ?? throw new GitLabNotFoundException();
+
+            ValidateNewProjectPermission(projectMemberUpdate.AccessLevel, user, project);
+
+            project.Permissions.Remove(curPermission);
+            project.Permissions.Add(new(user, projectMemberUpdate.AccessLevel));
+
+            return project.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
+        }
+    }
+
+    public async Task<Membership> UpdateMemberOfProjectAsync(ProjectId projectId, ProjectMemberUpdate projectMemberUpdate, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return UpdateMemberOfProject(projectId.ValueAsString(), projectMemberUpdate);
+    }
+
+    public Membership GetMemberOfProject(string projectId, string userId)
+    {
+        return GetMemberOfProject(projectId, userId, includeInheritedMembers: false);
+    }
+
+    public Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers)
+    {
+        return OfProject(projectId, includeInheritedMembers)
+           .FirstOrDefault(u => string.Equals(u.Id.ToStringInvariant(), userId, StringComparison.Ordinal))
+           ?? throw new GitLabNotFoundException();
+    }
+
+    public async Task<Membership> GetMemberOfProjectAsync(ProjectId projectId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return GetMemberOfProject(projectId.ValueAsString(), userId.ToStringInvariant(), includeInheritedMembers);
+    }
+
+    public async Task RemoveMemberFromProjectAsync(ProjectId projectId, long userId, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(projectId, ProjectPermission.Edit);
+
+            var permission = project.Permissions.SingleOrDefault(p => p.User.Id == userId)
+                ?? throw new GitLabNotFoundException();
+
+            project.Permissions.Remove(permission);
+        }
+    }
+
+    [Obsolete("Use OfGroup")]
+    public IEnumerable<Membership> OfNamespace(string groupId)
+    {
+        return OfGroup(groupId);
+    }
+
+    public IEnumerable<Membership> OfGroup(string groupId)
+    {
+        return OfGroup(groupId, includeInheritedMembers: false);
+    }
+
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var group = GetGroup(groupId, GroupPermission.View);
+            var members = group.GetEffectivePermissions(includeInheritedMembers).Permissions;
+            return members.Select(member => member.ToMembershipClient());
+        }
+    }
+
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false)
+    {
+        return GitLabCollectionResponse.Create(OfGroup(groupId.ValueAsString(), includeInheritedMembers));
+    }
+
+    public Membership AddMemberToGroup(string groupId, GroupMemberCreate groupMemberCreate)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var group = GetGroup(groupId, GroupPermission.Edit);
+            var user = Server.Users.GetById(groupMemberCreate.UserId);
+
+            if (group.Permissions.Any(p => p.User.Id == user.Id))
             {
-                throw new GitLabException("{\"access_level\":[\"should be greater than or equal to Owner inherited membership from group Runners\"]}.")
+                throw new GitLabException("Member already exists")
                 {
-                    StatusCode = HttpStatusCode.BadRequest,
+                    // actual GitLab error
+                    StatusCode = HttpStatusCode.Conflict,
+                    ErrorMessage = "Member already exists",
                 };
             }
 
-            if (existingPermission.AccessLevel == accessLevel)
+            ValidateNewGroupPermission(groupMemberCreate.AccessLevel, user, group);
+
+            group.Permissions.Add(new(user, groupMemberCreate.AccessLevel));
+
+            return group.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
+        }
+    }
+
+    public async Task<Membership> AddMemberToGroupAsync(GroupId groupId, GroupMemberCreate user, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return AddMemberToGroup(groupId.ValueAsString(), user);
+    }
+
+    public Membership UpdateMemberOfGroup(string groupId, GroupMemberUpdate groupMemberUpdate)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var group = GetGroup(groupId, GroupPermission.Edit);
+            var user = Server.Users.GetById(groupMemberUpdate.UserId);
+
+            var curPermission = group.Permissions.SingleOrDefault(p => p.User.Id == user.Id)
+                ?? throw new GitLabNotFoundException();
+
+            ValidateNewGroupPermission(groupMemberUpdate.AccessLevel, user, group);
+
+            group.Permissions.Remove(curPermission);
+            group.Permissions.Add(new(user, groupMemberUpdate.AccessLevel));
+
+            return group.GetEffectivePermissions().GetEffectivePermission(user).ToMembershipClient();
+        }
+    }
+
+    public async Task<Membership> UpdateMemberOfGroupAsync(GroupId groupId, GroupMemberUpdate groupMemberUpdate, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return UpdateMemberOfGroup(groupId.ValueAsString(), groupMemberUpdate);
+    }
+
+    public Membership GetMemberOfGroup(string groupId, string userId)
+    {
+        return GetMemberOfGroup(groupId, userId, false);
+    }
+
+    public Membership GetMemberOfGroup(string groupId, string userId, bool includeInheritedMembers)
+    {
+        return OfGroup(groupId, includeInheritedMembers: includeInheritedMembers)
+            .FirstOrDefault(u => string.Equals(u.Id.ToStringInvariant(), userId, StringComparison.Ordinal))
+            ?? throw new GitLabNotFoundException();
+    }
+
+    public async Task<Membership> GetMemberOfGroupAsync(GroupId groupId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return GetMemberOfGroup(groupId.ValueAsString(), userId.ToStringInvariant(), includeInheritedMembers);
+    }
+
+    public async Task RemoveMemberFromGroupAsync(GroupId groupId, long userId, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        using (Context.BeginOperationScope())
+        {
+            var group = GetGroup(groupId, GroupPermission.Edit);
+
+            var permission = group.Permissions.SingleOrDefault(p => p.User.Id == userId)
+                ?? throw new GitLabNotFoundException();
+
+            group.Permissions.Remove(permission);
+        }
+    }
+
+    /// <summary>
+    /// Checks if the given permission can be applied to the project and throws an exception if it is invalid.
+    /// </summary>
+    /// <exception cref="GitLabException">The new access level is less than an inherited membership role.</exception>
+    private static void ValidateNewProjectPermission(AccessLevel newAccessLevel, User user, Project project)
+    {
+        // Get the existing permission from the parent, if it exists...
+        var permission = project.Group?.GetEffectivePermissions().GetEffectivePermission(user);
+        if (permission?.AccessLevel > newAccessLevel)
+        {
+            throw new GitLabException("access_level should be greater than or equal to inherited membership.")
             {
-                throw new GitLabException { StatusCode = HttpStatusCode.Conflict };
-            }
+                // actual GitLab error
+                StatusCode = HttpStatusCode.BadRequest,
+                ErrorMessage = $$"""{"access_level":["should be greater than or equal to {{permission.AccessLevel}} inherited membership from project {{project.PathWithNamespace}}"]}.""",
+            };
+        }
+    }
+
+    /// <summary>
+    /// Checks if the given permission can be applied to the group and throws an exception if it is invalid.
+    /// </summary>
+    /// <exception cref="GitLabException">The new access level is less than an inherited membership role.</exception>
+    private static void ValidateNewGroupPermission(AccessLevel newAccessLevel, User user, Group group)
+    {
+        // Get the existing permission from the parent, if it exists...
+        var permission = group.Parent?.GetEffectivePermissions().GetEffectivePermission(user);
+        if (permission?.AccessLevel > newAccessLevel)
+        {
+            throw new GitLabException("access_level should be greater than or equal to inherited membership.")
+            {
+                // actual GitLab error
+                StatusCode = HttpStatusCode.BadRequest,
+                ErrorMessage = $$"""{"access_level":["should be greater than or equal to {{permission.AccessLevel}} inherited membership from group {{group.PathWithNameSpace}}"]}.""",
+            };
         }
     }
 }

--- a/NGitLab.Mock/Config/GitLabGroup.cs
+++ b/NGitLab.Mock/Config/GitLabGroup.cs
@@ -20,6 +20,11 @@ public class GitLabGroup : GitLabObject<GitLabConfig>
     public string Name { get; set; }
 
     /// <summary>
+    /// Path/slug. Defaults to <see cref="Slug.Create(Name)"/>.
+    /// </summary>
+    public string Path { get; set; }
+
+    /// <summary>
     /// Parent namespace
     /// </summary>
     public string Namespace { get; set; }

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -220,6 +220,35 @@ public static class GitLabHelpers
     }
 
     /// <summary>
+    /// Add a group with the given full path, i.e., "{namespace}/{path}".
+    /// The namespace is optional, and leading or trailing slashes are ignored.
+    /// </summary>
+    /// <param name="config">Config.</param>
+    /// <param name="fullPath">The fully qualified path of the group.</param>
+    /// <param name="name">Optional name. Defaults to the path.</param>
+    /// <param name="id">Optional explicit ID (config increment)</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="visibility">Optional visibility.</param>
+    /// <param name="addDefaultUserAsMaintainer">Optionally define default user as maintainer.</param>
+    /// <param name="configure">Optional configuration method</param>
+    public static GitLabConfig WithGroupOfFullPath(this GitLabConfig config, string fullPath, string? name = null, int id = default, string? description = null, VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, Action<GitLabGroup>? configure = null)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath))
+            throw new ArgumentNullException(nameof(fullPath));
+
+        var span = fullPath.AsSpan().Trim('/');
+        var slash = span.LastIndexOf('/');
+        var path = slash == -1 ? span.ToString() : span.Slice(slash + 1).ToString();
+        var @namespace = slash == -1 ? null : span.Slice(0, slash).ToString();
+
+        return WithGroup(config, name ?? path, id, @namespace, description, visibility, addDefaultUserAsMaintainer, configure: group =>
+        {
+            group.Path = path;
+            configure?.Invoke(group);
+        });
+    }
+
+    /// <summary>
     /// Add a project description in config
     /// </summary>
     /// <param name="config">Config.</param>
@@ -1141,6 +1170,7 @@ public static class GitLabHelpers
         var grp = new Group(group.Name ?? throw new ArgumentException(@"group.Name == null", nameof(group)))
         {
             Id = group.Id,
+            Path = group.Path,
             Description = group.Description,
             Visibility = group.Visibility ?? group.Parent.DefaultVisibility,
         };

--- a/NGitLab.Mock/GroupCollection.cs
+++ b/NGitLab.Mock/GroupCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace NGitLab.Mock;
 
@@ -17,6 +18,37 @@ public sealed class GroupCollection : Collection<Group>
         if (group.Id == default)
         {
             group.Id = Server.GetNewGroupId();
+        }
+        else if (this.Any(g => StringComparer.OrdinalIgnoreCase.Equals(g.Id, group.Id)))
+        {
+            // Cannot do this in GitLab
+            throw new NotSupportedException("Duplicate group id");
+        }
+
+        if (group.Name == null && group.Path == null)
+        {
+            throw new GitLabException("Missing name and path")
+            {
+                // actual GitLab error
+                StatusCode = System.Net.HttpStatusCode.BadRequest,
+                ErrorMessage = """name is missing, path is missing""",
+            };
+        }
+
+        // Auto-generate the Path or Name...
+        group.Path ??= Slug.Create(group.Name);
+        group.Name ??= group.Path;
+
+        // Check for conflicts.
+        // Mimics GitLab behavior...
+        if (this.Any(g => g.Parent == group.Parent && StringComparer.OrdinalIgnoreCase.Equals(g.Path, group.Path)))
+        {
+            throw new GitLabException("Duplicate group path")
+            {
+                // actual GitLab error
+                StatusCode = System.Net.HttpStatusCode.BadRequest,
+                ErrorMessage = """Failed to save group {:path=>["has already been taken"]}""",
+            };
         }
 
         base.Add(group);

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -135,6 +135,8 @@ NGitLab.Mock.Config.GitLabConfig.Serialize() -> string
 NGitLab.Mock.Config.GitLabConfig.Url.get -> string
 NGitLab.Mock.Config.GitLabConfig.Url.set -> void
 NGitLab.Mock.Config.GitLabGroup.Milestones.get -> NGitLab.Mock.Config.GitLabMilestonesCollection
+NGitLab.Mock.Config.GitLabGroup.Path.get -> string
+NGitLab.Mock.Config.GitLabGroup.Path.set -> void
 NGitLab.Mock.Config.GitLabGroup.Visibility.get -> NGitLab.Models.VisibilityLevel?
 NGitLab.Mock.Config.GitLabIssue.Comments.get -> NGitLab.Mock.Config.GitLabCommentsCollection
 NGitLab.Mock.Config.GitLabIssue.CreatedAt.get -> System.DateTime?
@@ -1234,6 +1236,7 @@ static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.Gi
 static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message = null, string user = null, string sourceBranch = null, string targetBranch = null, string fromBranch = null, System.Collections.Generic.IEnumerable<string> tags = null, string alias = null, System.Action<NGitLab.Mock.Config.GitLabCommit> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message, string user, System.Action<NGitLab.Mock.Config.GitLabCommit> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithGroup(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithGroupOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, int id = 0, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithGroupPermission(this NGitLab.Mock.Config.GitLabGroup grp, string groupName, NGitLab.Models.AccessLevel level) -> NGitLab.Mock.Config.GitLabGroup
 static NGitLab.Mock.Config.GitLabHelpers.WithGroupPermission(this NGitLab.Mock.Config.GitLabProject project, string groupName, NGitLab.Models.AccessLevel level) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithIssue(this NGitLab.Mock.Config.GitLabProject project, string title = null, int id = 0, string description = null, string author = null, string assignee = null, string milestone = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Collections.Generic.IEnumerable<string> labels = null, System.Action<NGitLab.Mock.Config.GitLabIssue> configure = null) -> NGitLab.Mock.Config.GitLabProject

--- a/NGitLab.Tests/MembersClientTests.cs
+++ b/NGitLab.Tests/MembersClientTests.cs
@@ -151,4 +151,96 @@ public class MembersClientTests
         var groupUser = context.Client.Members.GetMemberOfGroup(groupId, user.Id.ToString(CultureInfo.InvariantCulture));
         Assert.That((AccessLevel)groupUser.AccessLevel, Is.EqualTo(AccessLevel.Developer));
     }
+
+    [Test]
+    public async Task AsyncMethodsBehaveAsExpected()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var client = context.Client;
+        var ownerName = client.Users.Current.Username;
+
+        // Create a user, a top-level group, a group project, and a subgroup...
+        context.CreateNewUser(out var user1);
+        var group1 = context.CreateGroup();
+        var group2 = context.CreateSubgroup(group1.Id);
+        var project = context.CreateProject(group1.Id);
+
+        var user1Name = user1.Username;
+        var user1Id = user1.Id.ToString();
+
+        // Add the user to the top-level group as a Maintainer...
+        await client.Members.AddMemberToGroupAsync(group1, new()
+        {
+            AccessLevel = AccessLevel.Maintainer,
+            UserId = user1Id,
+        });
+
+        // Act
+        // Assert
+        var projectId = project.PathWithNamespace!;
+        var groupId = group2.FullPath!;
+
+        // Does NOT search inherited permission by default...
+        AssertThrowsGitLabException(() => client.Members.GetMemberOfProjectAsync(projectId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.GetMemberOfGroupAsync(groupId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        Assert.That(client.Members.OfProjectAsync(projectId).Select(m => m.UserName), Is.Empty);
+        Assert.That(client.Members.OfGroupAsync(groupId).Select(m => m.UserName), Is.EquivalentTo(new[] { ownerName }));
+
+        // Does search inherited permission when asked...
+        await client.Members.GetMemberOfProjectAsync(projectId, user1.Id, includeInheritedMembers: true);
+        await client.Members.GetMemberOfGroupAsync(groupId, user1.Id, includeInheritedMembers: true);
+        Assert.That(client.Members.OfProjectAsync(projectId, includeInheritedMembers: true).Select(m => m.UserName), Is.EquivalentTo(new[] { ownerName, user1Name }));
+        Assert.That(client.Members.OfGroupAsync(groupId, includeInheritedMembers: true).Select(m => m.UserName), Is.EquivalentTo(new[] { ownerName, user1Name }));
+
+        // Cannot update non-existent membership...
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), System.Net.HttpStatusCode.NotFound);
+
+        // Cannot add membership with an access-level lower than inherited...
+        AssertThrowsGitLabException(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+        AssertThrowsGitLabException(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+
+        // Can add membership with greater than or equal access-level...
+        await AssertReturnsMembership(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Maintainer }), AccessLevel.Maintainer);
+        await AssertReturnsMembership(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Maintainer }), AccessLevel.Maintainer);
+
+        // Cannot add duplicate membership...
+        AssertThrowsGitLabException(() => client.Members.AddMemberToProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), System.Net.HttpStatusCode.Conflict);
+        AssertThrowsGitLabException(() => client.Members.AddMemberToGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), System.Net.HttpStatusCode.Conflict);
+
+        // Can raise access-level above inherited...
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), AccessLevel.Owner);
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Owner }), AccessLevel.Owner);
+
+        // Can decrease access-level to inherited...
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Maintainer }), AccessLevel.Maintainer);
+        await AssertReturnsMembership(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Maintainer }), AccessLevel.Maintainer);
+
+        // Cannot decrease access-level lower than inherited...
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfProjectAsync(projectId, new() { UserId = user1Id, AccessLevel = AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+        AssertThrowsGitLabException(() => client.Members.UpdateMemberOfGroupAsync(groupId, new() { UserId = user1Id, AccessLevel = AccessLevel.Reporter }), System.Net.HttpStatusCode.BadRequest);
+
+        // Can delete...
+        await client.Members.RemoveMemberFromProjectAsync(projectId, user1.Id);
+        await client.Members.RemoveMemberFromGroupAsync(groupId, user1.Id);
+
+        // Delete fails when not exist...
+        AssertThrowsGitLabException(() => client.Members.RemoveMemberFromProjectAsync(projectId, user1.Id), System.Net.HttpStatusCode.NotFound);
+        AssertThrowsGitLabException(() => client.Members.RemoveMemberFromGroupAsync(groupId, user1.Id), System.Net.HttpStatusCode.NotFound);
+    }
+
+    private static async Task AssertReturnsMembership(Func<Task<Membership>> code, AccessLevel expectedAccessLevel)
+    {
+        var membership = await code.Invoke().ConfigureAwait(false);
+        Assert.That(membership, Is.Not.Null);
+        Assert.That(membership.AccessLevel, Is.EqualTo((int)expectedAccessLevel));
+    }
+
+    private static void AssertThrowsGitLabException(AsyncTestDelegate code, System.Net.HttpStatusCode expectedStatusCode)
+    {
+        var ex = Assert.CatchAsync(typeof(GitLabException), code) as GitLabException;
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex.StatusCode, Is.EqualTo(expectedStatusCode));
+    }
 }

--- a/NGitLab/IMembersClient.cs
+++ b/NGitLab/IMembersClient.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Models;
 
 namespace NGitLab;
@@ -13,6 +15,24 @@ public interface IMembersClient
 
     IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers);
 
+    GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false);
+
+    Membership GetMemberOfProject(string projectId, string userId);
+
+    Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers);
+
+    Task<Membership> GetMemberOfProjectAsync(ProjectId projectId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default);
+
+    Membership AddMemberToProject(string projectId, ProjectMemberCreate user);
+
+    Task<Membership> AddMemberToProjectAsync(ProjectId projectId, ProjectMemberCreate user, CancellationToken cancellationToken = default);
+
+    Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate user);
+
+    Task<Membership> UpdateMemberOfProjectAsync(ProjectId projectId, ProjectMemberUpdate user, CancellationToken cancellationToken = default);
+
+    Task RemoveMemberFromProjectAsync(ProjectId projectId, long userId, CancellationToken cancellationToken = default);
+
     [Obsolete("Use OfGroup")]
     IEnumerable<Membership> OfNamespace(string groupId);
 
@@ -20,17 +40,21 @@ public interface IMembersClient
 
     IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers);
 
+    GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false);
+
     Membership GetMemberOfGroup(string groupId, string userId);
 
-    Membership GetMemberOfProject(string projectId, string userId);
+    Membership GetMemberOfGroup(string groupId, string userId, bool includeInheritedMembers);
 
-    Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers);
-
-    Membership AddMemberToProject(string projectId, ProjectMemberCreate user);
-
-    Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate user);
+    Task<Membership> GetMemberOfGroupAsync(GroupId groupId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default);
 
     Membership AddMemberToGroup(string groupId, GroupMemberCreate user);
 
+    Task<Membership> AddMemberToGroupAsync(GroupId groupId, GroupMemberCreate user, CancellationToken cancellationToken = default);
+
     Membership UpdateMemberOfGroup(string groupId, GroupMemberUpdate user);
+
+    Task<Membership> UpdateMemberOfGroupAsync(GroupId groupId, GroupMemberUpdate user, CancellationToken cancellationToken = default);
+
+    Task RemoveMemberFromGroupAsync(GroupId groupId, long userId, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/IUserClient.cs
+++ b/NGitLab/IUserClient.cs
@@ -16,6 +16,8 @@ public interface IUserClient
 
     Task<User> GetByIdAsync(int id, CancellationToken cancellationToken = default);
 
+    Task<User> GetByUserNameAsync(string username, CancellationToken cancellationToken = default);
+
     User Create(UserUpsert user);
 
     Task<User> CreateAsync(UserUpsert user, CancellationToken cancellationToken = default);

--- a/NGitLab/Impl/MembersClient.cs
+++ b/NGitLab/Impl/MembersClient.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Extensions;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -25,6 +28,17 @@ public class MembersClient : IMembersClient
         return _api.Get().GetAll<Membership>(url);
     }
 
+    private GitLabCollectionResponse<Membership> GetAllAsync(string url, bool includeInheritedMembers)
+    {
+        url += "/members";
+        if (includeInheritedMembers)
+        {
+            url += "/all";
+        }
+
+        return _api.Get().GetAllAsync<Membership>(url);
+    }
+
     public IEnumerable<Membership> OfProject(string projectId)
     {
         return OfProject(projectId, includeInheritedMembers: false);
@@ -32,7 +46,54 @@ public class MembersClient : IMembersClient
 
     public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers)
     {
-        return GetAll(Project.Url + "/" + WebUtility.UrlEncode(projectId), includeInheritedMembers);
+        return GetAll($"{Project.Url}/{WebUtility.UrlEncode(projectId)}", includeInheritedMembers);
+    }
+
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false)
+    {
+        return GetAllAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}", includeInheritedMembers);
+    }
+
+    public Membership GetMemberOfProject(string projectId, string userId)
+    {
+        return GetMemberOfProject(projectId, userId, includeInheritedMembers: false);
+    }
+
+    public Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers)
+    {
+        var url = $"{Project.Url}/{WebUtility.UrlEncode(projectId)}/members/{(includeInheritedMembers ? "all/" : string.Empty)}{WebUtility.UrlEncode(userId)}";
+        return _api.Get().To<Membership>(url);
+    }
+
+    public Task<Membership> GetMemberOfProjectAsync(ProjectId projectId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default)
+    {
+        var url = $"{Project.Url}/{projectId.ValueAsUriParameter()}/members/{(includeInheritedMembers ? "all/" : string.Empty)}{userId.ToStringInvariant()}";
+        return _api.Get().ToAsync<Membership>(url, cancellationToken);
+    }
+
+    public Membership AddMemberToProject(string projectId, ProjectMemberCreate user)
+    {
+        return _api.Post().With(user).To<Membership>($"{Project.Url}/{WebUtility.UrlEncode(projectId)}/members");
+    }
+
+    public Task<Membership> AddMemberToProjectAsync(ProjectId projectId, ProjectMemberCreate user, CancellationToken cancellationToken = default)
+    {
+        return _api.Post().With(user).ToAsync<Membership>($"{Project.Url}/{projectId.ValueAsUriParameter()}/members", cancellationToken);
+    }
+
+    public Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate user)
+    {
+        return _api.Put().With(user).To<Membership>($"{Project.Url}/{WebUtility.UrlEncode(projectId)}/members/{WebUtility.UrlEncode(user.UserId)}");
+    }
+
+    public Task<Membership> UpdateMemberOfProjectAsync(ProjectId projectId, ProjectMemberUpdate user, CancellationToken cancellationToken = default)
+    {
+        return _api.Put().With(user).ToAsync<Membership>($"{Project.Url}/{projectId.ValueAsUriParameter()}/members/{WebUtility.UrlEncode(user.UserId)}", cancellationToken);
+    }
+
+    public Task RemoveMemberFromProjectAsync(ProjectId projectId, long userId, CancellationToken cancellationToken = default)
+    {
+        return _api.Delete().ExecuteAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}/members/{userId.ToStringInvariant()}", cancellationToken);
     }
 
     [Obsolete("Use OfGroup")]
@@ -48,43 +109,53 @@ public class MembersClient : IMembersClient
 
     public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
     {
-        return GetAll(GroupsClient.Url + "/" + WebUtility.UrlEncode(groupId), includeInheritedMembers);
+        return GetAll($"{Group.Url}/{WebUtility.UrlEncode(groupId)}", includeInheritedMembers);
+    }
+
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false)
+    {
+        return GetAllAsync($"{Group.Url}/{groupId.ValueAsUriParameter()}", includeInheritedMembers);
     }
 
     public Membership GetMemberOfGroup(string groupId, string userId)
     {
-        return _api.Get().To<Membership>(GroupsClient.Url + "/" + WebUtility.UrlEncode(groupId) + "/members/" + WebUtility.UrlEncode(userId));
+        return GetMemberOfGroup(groupId, userId, includeInheritedMembers: false);
     }
 
-    public Membership GetMemberOfProject(string projectId, string userId)
+    public Membership GetMemberOfGroup(string groupId, string userId, bool includeInheritedMembers)
     {
-        return GetMemberOfProject(projectId, userId, includeInheritedMembers: false);
+        var tailAPIUrl = $"{Group.Url}/{WebUtility.UrlEncode(groupId)}/members/{(includeInheritedMembers ? "all/" : string.Empty)}{WebUtility.UrlEncode(userId)}";
+        return _api.Get().To<Membership>(tailAPIUrl);
     }
 
-    public Membership GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers)
+    public Task<Membership> GetMemberOfGroupAsync(GroupId groupId, long userId, bool includeInheritedMembers = false, CancellationToken cancellationToken = default)
     {
-        var url = $"{Project.Url}/{WebUtility.UrlEncode(projectId)}/members/{(includeInheritedMembers ? "all/" : string.Empty)}{WebUtility.UrlEncode(userId)}";
-
-        return _api.Get().To<Membership>(url);
-    }
-
-    public Membership AddMemberToProject(string projectId, ProjectMemberCreate user)
-    {
-        return _api.Post().With(user).To<Membership>(Project.Url + "/" + WebUtility.UrlEncode(projectId) + "/members");
-    }
-
-    public Membership UpdateMemberOfProject(string projectId, ProjectMemberUpdate user)
-    {
-        return _api.Put().With(user).To<Membership>(Project.Url + "/" + WebUtility.UrlEncode(projectId) + "/members/" + WebUtility.UrlEncode(user.UserId));
+        var tailAPIUrl = $"{Group.Url}/{groupId.ValueAsUriParameter()}/members/{(includeInheritedMembers ? "all/" : string.Empty)}{userId.ToStringInvariant()}";
+        return _api.Get().ToAsync<Membership>(tailAPIUrl, cancellationToken);
     }
 
     public Membership AddMemberToGroup(string groupId, GroupMemberCreate user)
     {
-        return _api.Post().With(user).To<Membership>(Group.Url + "/" + WebUtility.UrlEncode(groupId) + "/members");
+        return _api.Post().With(user).To<Membership>($"{Group.Url}/{WebUtility.UrlEncode(groupId)}/members");
+    }
+
+    public Task<Membership> AddMemberToGroupAsync(GroupId groupId, GroupMemberCreate user, CancellationToken cancellationToken = default)
+    {
+        return _api.Post().With(user).ToAsync<Membership>($"{Group.Url}/{groupId.ValueAsUriParameter()}/members", cancellationToken);
     }
 
     public Membership UpdateMemberOfGroup(string groupId, GroupMemberUpdate user)
     {
-        return _api.Put().With(user).To<Membership>(Group.Url + "/" + WebUtility.UrlEncode(groupId) + "/members/" + WebUtility.UrlEncode(user.UserId));
+        return _api.Put().With(user).To<Membership>($"{Group.Url}/{WebUtility.UrlEncode(groupId)}/members/{WebUtility.UrlEncode(user.UserId)}");
+    }
+
+    public Task<Membership> UpdateMemberOfGroupAsync(GroupId groupId, GroupMemberUpdate user, CancellationToken cancellationToken = default)
+    {
+        return _api.Put().With(user).ToAsync<Membership>($"{Group.Url}/{groupId.ValueAsUriParameter()}/members/{WebUtility.UrlEncode(user.UserId)}", cancellationToken);
+    }
+
+    public Task RemoveMemberFromGroupAsync(GroupId groupId, long userId, CancellationToken cancellationToken = default)
+    {
+        return _api.Delete().ExecuteAsync($"{Group.Url}/{groupId.ValueAsUriParameter()}/members/{userId.ToStringInvariant()}", cancellationToken);
     }
 }

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -27,6 +27,21 @@ public class UserClient : IUserClient
         return _api.Get().ToAsync<User>(User.Url + "/" + id.ToStringInvariant(), cancellationToken);
     }
 
+    public async Task<User> GetByUserNameAsync(string username, CancellationToken cancellationToken = default)
+    {
+        // This query returns 0 or 1 user.
+        await foreach (var u in _api.Get().GetAllAsync<User>(User.Url + "?username=" + username).WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            return u;
+        }
+
+        throw new GitLabException("User not found.")
+        {
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+            ErrorMessage = "User not found.",
+        };
+    }
+
     public IEnumerable<User> Get(string username) => _api.Get().GetAll<User>(User.Url + "?username=" + username);
 
     public IEnumerable<User> Get(UserQuery query)

--- a/NGitLab/Models/GroupMemberCreate.cs
+++ b/NGitLab/Models/GroupMemberCreate.cs
@@ -4,12 +4,18 @@ namespace NGitLab.Models;
 
 public class GroupMemberCreate
 {
+    /// <summary>
+    /// The Id of the user. Must be an integer value.
+    /// </summary>
     [JsonPropertyName("user_id")]
     public string UserId;
 
     [JsonPropertyName("access_level")]
     public AccessLevel AccessLevel;
 
+    /// <summary>
+    /// The optional expiration date. Must be null or a value like "yyyy-MM-dd".
+    /// </summary>
     [JsonPropertyName("expires_at")]
     public string ExpiresAt;
 }

--- a/NGitLab/Models/GroupMemberUpdate.cs
+++ b/NGitLab/Models/GroupMemberUpdate.cs
@@ -4,12 +4,18 @@ namespace NGitLab.Models;
 
 public class GroupMemberUpdate
 {
+    /// <summary>
+    /// The Id of the user. Must be an integer value.
+    /// </summary>
     [JsonPropertyName("user_id")]
     public string UserId;
 
     [JsonPropertyName("access_level")]
     public AccessLevel AccessLevel;
 
+    /// <summary>
+    /// The optional expiration date. Must be null or a value like "yyyy-MM-dd".
+    /// </summary>
     [JsonPropertyName("expires_at")]
     public string ExpiresAt;
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -379,17 +379,28 @@ NGitLab.ILintClient.ValidateCIYamlContentAsync(string projectId, string yamlCont
 NGitLab.ILintClient.ValidateProjectCIConfigurationAsync(string projectId, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
 NGitLab.IMembersClient
 NGitLab.IMembersClient.AddMemberToGroup(string groupId, NGitLab.Models.GroupMemberCreate user) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.AddMemberToGroupAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupMemberCreate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.AddMemberToProject(string projectId, NGitLab.Models.ProjectMemberCreate user) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.AddMemberToProjectAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectMemberCreate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.GetMemberOfGroup(string groupId, string userId) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.GetMemberOfGroup(string groupId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.GetMemberOfGroupAsync(NGitLab.Models.GroupId groupId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId) -> NGitLab.Models.Membership
 NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.IMembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IMembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IMembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.UpdateMemberOfGroupAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupMemberUpdate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.UpdateMemberOfProject(string projectId, NGitLab.Models.ProjectMemberUpdate user) -> NGitLab.Models.Membership
+NGitLab.IMembersClient.UpdateMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectMemberUpdate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMergeRequestApprovalClient
 NGitLab.IMergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
@@ -658,18 +669,29 @@ NGitLab.Impl.LintClient.ValidateCIYamlContentAsync(string projectId, string yaml
 NGitLab.Impl.LintClient.ValidateProjectCIConfigurationAsync(string projectId, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
 NGitLab.Impl.MembersClient
 NGitLab.Impl.MembersClient.AddMemberToGroup(string groupId, NGitLab.Models.GroupMemberCreate user) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.AddMemberToGroupAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupMemberCreate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.AddMemberToProject(string projectId, NGitLab.Models.ProjectMemberCreate user) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.AddMemberToProjectAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectMemberCreate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.GetMemberOfGroup(string groupId, string userId) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.GetMemberOfGroup(string groupId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.GetMemberOfGroupAsync(NGitLab.Models.GroupId groupId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.GetMemberOfProject(string projectId, string userId) -> NGitLab.Models.Membership
 NGitLab.Impl.MembersClient.GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.MembersClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.MembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.MembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.MembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.UpdateMemberOfGroupAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupMemberUpdate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.UpdateMemberOfProject(string projectId, NGitLab.Models.ProjectMemberUpdate user) -> NGitLab.Models.Membership
+NGitLab.Impl.MembersClient.UpdateMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectMemberUpdate user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MergeRequestApprovalClient
 NGitLab.Impl.MergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
@@ -931,6 +953,7 @@ NGitLab.Impl.UserClient.Delete(int userId) -> void
 NGitLab.Impl.UserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
+NGitLab.Impl.UserClient.GetByUserNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
 NGitLab.Impl.UserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.Impl.UserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
@@ -1141,6 +1164,7 @@ NGitLab.IUserClient.Delete(int id) -> void
 NGitLab.IUserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
+NGitLab.IUserClient.GetByUserNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
 NGitLab.IUserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.IUserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>


### PR DESCRIPTION
- Improve Create Group and Create User mock to better emulate GitLab.
- Add support for explicit Group Path in mock helpers.
- Add `RemoveMemberFrom*Async` and Implement async versions of the other Group and Project methods.
- Add `IUserClient.GetByUserNameAsync`
- Add unit and integrations tests to verify behavior of both the GitHub and Mock `IMembersClient`.