### PR TITLE
Add async CRUD methods to `IProjectClient`

### DIFF
--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -179,6 +180,69 @@ public class ProjectsMockTests
     }
 
     [Test]
+    public async Task CreateAsync_WhenMockCreatedWithSupportedOptions_TheyAreAvailableInModel()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .WithGroupOfFullPath("my-group", name: "MyGroup", addDefaultUserAsMaintainer: true)
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+
+        var expected = new ProjectCreate()
+        {
+            Name = "MyProject",
+            Path = "my-project",
+            NamespaceId = "my-group",
+            Description = "Description",
+            DefaultBranch = "foo",
+            InitializeWithReadme = true,
+            Topics = new() { "t1", "t2" },
+            BuildTimeout = (int)TimeSpan.FromMinutes(15).TotalSeconds,
+        };
+
+        // Act
+        var actual = await projectClient.CreateAsync(expected);
+
+        // Assert
+        actual.Name.Should().Be(expected.Name);
+        actual.Path.Should().Be(expected.Path);
+        actual.Description.Should().Be(expected.Description);
+        actual.Namespace.FullPath.Should().Be(expected.NamespaceId);
+        actual.NameWithNamespace.Should().Be($"MyGroup / {expected.Name}");
+        actual.PathWithNamespace.Should().Be($"my-group/{expected.Path}");
+        actual.DefaultBranch.Should().Be(expected.DefaultBranch);
+        actual.Topics.Should().BeEquivalentTo(expected.Topics);
+        actual.BuildTimeout.Should().Be(expected.BuildTimeout);
+    }
+
+    [Test]
+    public async Task CreateAsync_WhenInitializeWithReadmeIsFalse_ItIgnoresDefaultBranch()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+
+        var expected = new ProjectCreate()
+        {
+            Name = "MyProject",
+            DefaultBranch = "foo",
+            InitializeWithReadme = false,
+        };
+
+        // Act
+        var actual = await projectClient.CreateAsync(expected);
+
+        // Assert
+        actual.Name.Should().Be(expected.Name);
+        actual.DefaultBranch.Should().NotBe(expected.DefaultBranch);
+    }
+
+    [Test]
     public void CreateAsync_WhenProjectPathAlreadyExists_ItThrows()
     {
         // Arrange
@@ -190,7 +254,7 @@ public class ProjectsMockTests
         var projectClient = server.CreateClient().Projects;
 
         // Act
-        var ex = Assert.ThrowsAsync<GitLabException>(() =>
+        var ex = Assert.CatchAsync<GitLabException>(() =>
             projectClient.CreateAsync(new()
             {
                 Path = "DUPLICATE", // GitLab path is case-INsensitive
@@ -246,5 +310,60 @@ public class ProjectsMockTests
 
         // Assert
         Assert.That(newProject.Name, Is.EqualTo("NOT_DUPLICATE"));
+    }
+
+    [Test]
+    public void UpdateAsync_WhenProjectNotFound_ItThrows()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+
+        // Act
+        var ex = Assert.CatchAsync<GitLabException>(() =>
+            projectClient.UpdateAsync(int.MaxValue, new()
+            {
+                Visibility = VisibilityLevel.Private,
+            }));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task DeleteAsync_WhenProjectExists_ItIsDeleted()
+    {
+        var projectFullPath = $"Test/{nameof(DeleteAsync_WhenProjectExists_ItIsDeleted)}";
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .WithProjectOfFullPath(projectFullPath)
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+
+        // Act
+        await projectClient.DeleteAsync(projectFullPath);
+
+        // Assert
+        Assert.CatchAsync<GitLabException>(() => projectClient.GetAsync(projectFullPath));
+    }
+
+    [Test]
+    public void DeleteAsync_WhenProjectNotFound_ItThrows()
+    {
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+
+        // Act
+        var ex = Assert.CatchAsync<GitLabException>(() => projectClient.DeleteAsync(int.MaxValue));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
     }
 }

--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -13,6 +13,25 @@ namespace NGitLab.Mock.Tests;
 public class ProjectsMockTests
 {
     [Test]
+    public void WithProjectHelper_WhenPathNotSpecified_ItAutogeneratesPathFromName()
+    {
+        // Arrange
+        var config = new GitLabConfig()
+            .WithUser("Foo", isDefault: true);
+
+        // Act
+        using var server = config
+            .WithProject("TEST", configure: p => p.@Namespace = "Foo")
+            .BuildServer();
+
+        // Assert
+        var client = server.CreateClient();
+        var project = client.Projects["Foo/Test"];
+
+        Assert.That(project.Path, Is.EqualTo("test"));
+    }
+
+    [Test]
     public void Test_projects_created_can_be_found()
     {
         using var server = new GitLabConfig()

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -1250,10 +1250,10 @@ public static class GitLabHelpers
 
     private static void CreateProject(GitLabServer server, GitLabProject project)
     {
-        var prj = new Project(project.Name ?? project.Path ?? Guid.NewGuid().ToString("D"))
+        var projectName = project.Name ?? project.Path ?? Guid.NewGuid().ToString("D");
+        var prj = new Project(projectName, project.Path)
         {
             Id = project.Id,
-            Path = project.Path,
             Description = project.Description,
             DefaultBranch = project.DefaultBranch ?? server.DefaultBranchName,
             Visibility = project.Visibility ?? project.Parent.DefaultVisibility,

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -320,6 +320,53 @@ public static class GitLabHelpers
     }
 
     /// <summary>
+    /// Add a project with the given full path, i.e., "{namespace}/{path}".
+    /// If the namespace is not specified, the project will be created in a new top-level group.
+    /// Leading or trailing slashes are ignored.
+    /// </summary>
+    /// <param name="config">Config.</param>
+    /// <param name="fullPath">The fully qualified path of the project.</param>
+    /// <param name="name">Optional name. Defaults to the path.</param>
+    /// <param name="id">Optional explicit ID (config increment)</param>
+    /// <param name="description">Optional description.</param>
+    /// <param name="defaultBranch">Optional repository default branch.</param>
+    /// <param name="visibility">Optional visibility.</param>
+    /// <param name="initialCommit">Indicates if an initial commit is added.</param>
+    /// <param name="addDefaultUserAsMaintainer">Define default user as maintainer.</param>
+    /// <param name="clonePath">Path where to clone repository after server resolving</param>
+    /// <param name="cloneParameters">Parameters passed to clone command</param>
+    /// <param name="configure">Configuration method</param>
+    public static GitLabConfig WithProjectOfFullPath(this GitLabConfig config, string? fullPath, string? name = null, int id = default, string? description = null,
+                                                     string? defaultBranch = null, VisibilityLevel visibility = VisibilityLevel.Internal, bool initialCommit = false,
+                                                     bool addDefaultUserAsMaintainer = false, string? clonePath = null, string? cloneParameters = null, Action<GitLabProject>? configure = null)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath))
+            throw new ArgumentNullException(nameof(fullPath));
+
+        var span = fullPath.AsSpan().Trim('/');
+        var slash = span.LastIndexOf('/');
+        var path = slash == -1 ? span.ToString() : span.Slice(slash + 1).ToString();
+        var @namespace = slash == -1 ? null : span.Slice(0, slash).ToString();
+
+        return config.WithProject(
+            name: name ?? path,
+            id: id,
+            @namespace: @namespace,
+            description: description,
+            defaultBranch: defaultBranch,
+            visibility: visibility,
+            initialCommit: initialCommit,
+            addDefaultUserAsMaintainer: addDefaultUserAsMaintainer,
+            clonePath: clonePath,
+            cloneParameters: cloneParameters,
+            configure: project =>
+        {
+            project.Path = path;
+            configure?.Invoke(project);
+        });
+    }
+
+    /// <summary>
     /// Add a group description in group
     /// </summary>
     /// <param name="group">Group.</param>
@@ -1203,9 +1250,10 @@ public static class GitLabHelpers
 
     private static void CreateProject(GitLabServer server, GitLabProject project)
     {
-        var prj = new Project(project.Name ?? Guid.NewGuid().ToString("D"))
+        var prj = new Project(project.Name ?? project.Path ?? Guid.NewGuid().ToString("D"))
         {
             Id = project.Id,
+            Path = project.Path,
             Description = project.Description,
             DefaultBranch = project.DefaultBranch ?? server.DefaultBranchName,
             Visibility = project.Visibility ?? project.Parent.DefaultVisibility,

--- a/NGitLab.Mock/Config/GitLabProject.cs
+++ b/NGitLab.Mock/Config/GitLabProject.cs
@@ -24,6 +24,11 @@ public class GitLabProject : GitLabObject<GitLabConfig>
     /// </summary>
     public string Name { get; set; }
 
+    /// <summary>
+    /// Path/slug. Defaults to <see cref="Slug.Create(Name)"/>.
+    /// </summary>
+    public string Path { get; set; }
+
     public string Namespace { get; set; }
 
     public string DefaultBranch { get; set; }

--- a/NGitLab.Mock/Config/GitLabProject.cs
+++ b/NGitLab.Mock/Config/GitLabProject.cs
@@ -25,7 +25,7 @@ public class GitLabProject : GitLabObject<GitLabConfig>
     public string Name { get; set; }
 
     /// <summary>
-    /// Path/slug. Defaults to <see cref="Slug.Create(Name)"/>.
+    /// Path/slug.
     /// </summary>
     public string Path { get; set; }
 

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -56,7 +56,7 @@ public sealed class Project : GitLabObject
         {
             if (string.IsNullOrEmpty(_defaultBranch))
             {
-                return Parent?.Server?.DefaultBranchName ?? throw new InvalidOperationException("Project is not added to a Server");
+                _defaultBranch = Parent?.Server?.DefaultBranchName ?? throw new InvalidOperationException("Project is not added to a Server");
             }
 
             return _defaultBranch;

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -56,7 +56,7 @@ public sealed class Project : GitLabObject
         {
             if (string.IsNullOrEmpty(_defaultBranch))
             {
-                _defaultBranch = Parent?.Server?.DefaultBranchName ?? throw new InvalidOperationException("Project is not added to a Server");
+                return Parent?.Server?.DefaultBranchName ?? throw new InvalidOperationException("Project is not added to a Server");
             }
 
             return _defaultBranch;
@@ -134,7 +134,7 @@ public sealed class Project : GitLabObject
 
     public string PathWithNamespace => Group == null ? Path : (Group.PathWithNameSpace + "/" + Path);
 
-    public string FullName => Group == null ? Name : (Group.FullName + "/" + Name);
+    public string FullName => Group == null ? Name : (Group.FullName + " / " + Name);
 
     public ProjectHookCollection Hooks { get; }
 
@@ -457,6 +457,7 @@ public sealed class Project : GitLabObject
             EmptyRepo = Repository.IsEmpty,
             Path = Path,
             PathWithNamespace = PathWithNamespace,
+            NameWithNamespace = FullName,
             ForkedFromProject = ForkedFrom?.ToClientProject(currentUser),
             ForkingAccessLevel = ForkingAccessLevel,
             ImportStatus = ImportStatus,
@@ -466,7 +467,7 @@ public sealed class Project : GitLabObject
             VisibilityLevel = Visibility,
             Namespace = new Namespace { FullPath = Group.PathWithNameSpace, Id = Group.Id, Kind = kind, Name = Group.Name, Path = Group.Path },
             WebUrl = WebUrl,
-            BuildTimeout = (int)BuildTimeout.TotalMinutes,
+            BuildTimeout = (int)BuildTimeout.TotalSeconds,
             RepositoryAccessLevel = RepositoryAccessLevel,
             RunnersToken = RunnersToken,
             LfsEnabled = LfsEnabled,

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -8,13 +8,19 @@ namespace NGitLab.Mock;
 public sealed class Project : GitLabObject
 {
     public Project()
-        : this(Guid.NewGuid().ToString("N"))
+        : this(Guid.NewGuid().ToString("N"), path: null)
     {
     }
 
     public Project(string name)
+        : this(name, path: null)
+    {
+    }
+
+    public Project(string name, string path)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
+        Path = path ?? Slug.Create(Name);
 
         Permissions = new PermissionCollection(this);
         LintCIs = new LintCICollection(this);
@@ -124,7 +130,7 @@ public sealed class Project : GitLabObject
 
     public Group Group => (Group)Parent;
 
-    public string Path => Slug.Create(Name);
+    public string Path { get; internal set; }
 
     public string PathWithNamespace => Group == null ? Path : (Group.PathWithNameSpace + "/" + Path);
 

--- a/NGitLab.Mock/ProjectCollection.cs
+++ b/NGitLab.Mock/ProjectCollection.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Net;
 
 namespace NGitLab.Mock;
 
@@ -30,6 +32,38 @@ public sealed class ProjectCollection : Collection<Project>
         if (project.Id == default)
         {
             project.Id = Server.GetNewProjectId();
+        }
+        else if (this.Any(p => p.Id == project.Id))
+        {
+            // Cannot do this in GitLab
+            throw new NotSupportedException("Duplicate project id");
+        }
+
+        if (project.Name == null && project.Path == null)
+        {
+            throw new GitLabException("Missing name and path")
+            {
+                // actual GitLab error
+                StatusCode = HttpStatusCode.BadRequest,
+                ErrorMessage = """name is missing, path is missing""",
+            };
+        }
+
+        // Auto-generate the Path or Name...
+        project.Path ??= Slug.Create(project.Name);
+        project.Name ??= project.Path;
+
+        // Name is case sensitive
+        if (this.Any(p =>
+            p.Path.Equals(project.Path, StringComparison.OrdinalIgnoreCase) ||
+            p.Name.Equals(project.Name, StringComparison.Ordinal)))
+        {
+            throw new GitLabException("Name or Path already exists")
+            {
+                // actual GitLab error
+                StatusCode = HttpStatusCode.BadRequest,
+                ErrorMessage = "[\"has already been taken\"]",
+            };
         }
 
         project.RunnersToken ??= Server.GetNewRegistrationToken();

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -199,6 +199,8 @@ NGitLab.Mock.Config.GitLabProject.CloneParameters.set -> void
 NGitLab.Mock.Config.GitLabProject.ForkingAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Config.GitLabProject.ForkingAccessLevel.set -> void
 NGitLab.Mock.Config.GitLabProject.Milestones.get -> NGitLab.Mock.Config.GitLabMilestonesCollection
+NGitLab.Mock.Config.GitLabProject.Path.get -> string
+NGitLab.Mock.Config.GitLabProject.Path.set -> void
 NGitLab.Mock.Config.GitLabProject.Pipelines.get -> NGitLab.Mock.Config.GitLabPipelinesCollection
 NGitLab.Mock.Config.GitLabProject.Releases.get -> NGitLab.Mock.Config.GitLabReleaseInfoCollection
 NGitLab.Mock.Config.GitLabProject.Visibility.get -> NGitLab.Models.VisibilityLevel?
@@ -865,6 +867,7 @@ NGitLab.Mock.Project.Permissions.get -> NGitLab.Mock.PermissionCollection
 NGitLab.Mock.Project.Pipelines.get -> NGitLab.Mock.PipelineCollection
 NGitLab.Mock.Project.Project() -> void
 NGitLab.Mock.Project.Project(string name) -> void
+NGitLab.Mock.Project.Project(string name, string path) -> void
 NGitLab.Mock.Project.ProtectedBranches.get -> NGitLab.Mock.ProtectedBranchCollection
 NGitLab.Mock.Project.RegisteredRunners.get -> NGitLab.Mock.RunnerCollection
 NGitLab.Mock.Project.Releases.get -> NGitLab.Mock.ReleaseCollection
@@ -1251,6 +1254,7 @@ static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.
 static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabProject project, string title, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithPipeline(this NGitLab.Mock.Config.GitLabProject project, string ref, System.Action<NGitLab.Mock.Config.GitLabPipeline> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithProjectOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, int id = 0, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithRelease(this NGitLab.Mock.Config.GitLabProject project, string author, string tagName, System.DateTime? createdAt = null, System.DateTime? releasedAt = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithSubModule(this NGitLab.Mock.Config.GitLabCommit commit, string projectName) -> NGitLab.Mock.Config.GitLabCommit
 static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabIssue

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NGitLab.Extensions;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
 using NUnit.Framework;
@@ -34,6 +36,55 @@ public class ProjectsTests
 
         var projectResult = await projectClient.GetByNamespacedPathAsync(project.PathWithNamespace, new SingleProjectQuery(), CancellationToken.None);
         Assert.That(projectResult.Id, Is.EqualTo(project.Id));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetProjectAsync_WorksWithId_ReturnsProject()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var projectResult = await projectClient.GetAsync(project.Id, new() { Statistics = true });
+
+        // Assert
+        Assert.That(projectResult.Id, Is.EqualTo(project.Id));
+        Assert.That(projectResult.Statistics, Is.Not.Null);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetProjectAsync_WithPathAndWithoutQuery_ReturnsProject()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var projectResult = await projectClient.GetAsync(project.PathWithNamespace, query: null);
+
+        // Assert
+        Assert.That(projectResult.Id, Is.EqualTo(project.Id));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetProjectAsync_WhenProjectDoesNotExist_ShouldThrowNotFound()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        // Assert
+        var ex = Assert.ThrowsAsync<GitLabException>(() => projectClient.GetAsync("baz1234"));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
     }
 
     [Test]
@@ -200,7 +251,7 @@ public class ProjectsTests
         };
 
         context.Client.GetRepository(project.Id).Files.Create(file);
-        var languages = projectClient.GetLanguages(project.Id.ToString(CultureInfo.InvariantCulture));
+        var languages = projectClient.GetLanguages(project.Id.ToStringInvariant());
         Assert.That(languages, Has.Count.EqualTo(1));
         Assert.That(languages.First().Key, Is.EqualTo("javascript").IgnoreCase);
         Assert.That(languages.First().Value, Is.EqualTo(100));
@@ -240,7 +291,7 @@ public class ProjectsTests
             Description = "desc",
             IssuesEnabled = true,
             MergeRequestsEnabled = true,
-            Name = "CreateDelete_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture),
+            Name = "CreateDelete_Test_" + context.GetRandomNumber().ToStringInvariant(),
             NamespaceId = null,
             SnippetsEnabled = true,
             VisibilityLevel = VisibilityLevel.Internal,
@@ -267,14 +318,14 @@ public class ProjectsTests
         // Update
         expectedTopics = new List<string> { "Tag-3" };
         var updateOptions = new ProjectUpdate { Visibility = VisibilityLevel.Private, Topics = expectedTopics };
-        var updatedProject = projectClient.Update(createdProject.Id.ToString(CultureInfo.InvariantCulture), updateOptions);
+        var updatedProject = projectClient.Update(createdProject.Id.ToStringInvariant(), updateOptions);
         Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Private));
         Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
         Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
 
         updateOptions.Visibility = VisibilityLevel.Public;
         updateOptions.Topics = null;    // If Topics are null, the project's existing topics will remain
-        updatedProject = projectClient.Update(createdProject.Id.ToString(CultureInfo.InvariantCulture), updateOptions);
+        updatedProject = projectClient.Update(createdProject.Id.ToStringInvariant(), updateOptions);
         Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Public));
         Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
         Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
@@ -283,6 +334,183 @@ public class ProjectsTests
         Assert.That(updatedProject2.VisibilityLevel, Is.EqualTo(VisibilityLevel.Internal));
 
         projectClient.Delete(createdProject.Id);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task CreateAsync_CreatesNewProject()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var projectClient = context.Client.Projects;
+
+        var project = new ProjectCreate
+        {
+            Description = "desc",
+            IssuesEnabled = true,
+            MergeRequestsEnabled = true,
+            Name = "CreateAsync_" + context.GetRandomNumber().ToStringInvariant(),
+            NamespaceId = null,
+            VisibilityLevel = VisibilityLevel.Internal,
+            Topics = new() { "Tag-1", "Tag-2" },
+        };
+
+        // Act
+        var createdProject = await projectClient.CreateAsync(project);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(createdProject.Description, Is.EqualTo(project.Description));
+            Assert.That(createdProject.IssuesEnabled, Is.EqualTo(project.IssuesEnabled));
+            Assert.That(createdProject.MergeRequestsEnabled, Is.EqualTo(project.MergeRequestsEnabled));
+            Assert.That(createdProject.Name, Is.EqualTo(project.Name));
+            Assert.That(createdProject.VisibilityLevel, Is.EqualTo(project.VisibilityLevel));
+            Assert.That(createdProject.Topics, Is.EquivalentTo(project.Topics));
+            Assert.That(createdProject.RepositoryAccessLevel, Is.EqualTo(RepositoryAccessLevel.Enabled));
+        });
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task CreateAsync_WhenProjectAlreadyExists_ItThrows()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var existingProject = context.CreateProject();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var ex = Assert.ThrowsAsync<GitLabException>(() =>
+            projectClient.CreateAsync(new()
+            {
+                Path = existingProject.Path,
+            }));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(ex.ErrorMessage, Contains.Substring("[\"has already been taken\"]"));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task SearchAsync_WhenSearchForExistingProject_ItFindsIt()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var actualProjects = projectClient.GetAsync(new()
+        {
+            Search = project.Name,
+            Scope = ProjectQueryScope.All,
+        });
+
+        // Assert
+        Assert.That(actualProjects.Count(), Is.EqualTo(1));
+        Assert.That(actualProjects.Single().Id, Is.EqualTo(project.Id));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task SearchAsync_WhenNotFound_ReturnsEmptySet()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var actualProjects = projectClient.GetAsync(new()
+        {
+            Search = Guid.NewGuid().ToString(),
+            Scope = ProjectQueryScope.All,
+        });
+
+        // Assert
+        Assert.That(actualProjects, Is.Empty);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task UpdateAsync_WhenUpdateVisibilityAndTopics_ItWorks()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject(p =>
+        {
+            p.VisibilityLevel = VisibilityLevel.Public;
+            p.Topics = new() { "Tag-1", "Tag-2" };
+        });
+
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var expectedTopics = new List<string>() { "Tag-3" };
+        var updatedProject = await projectClient.UpdateAsync(project.PathWithNamespace, new()
+        {
+            Visibility = VisibilityLevel.Private,
+            Topics = expectedTopics,
+        });
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Private));
+            Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
+        });
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task UpdateAsync_WhenProjectNotFound_ItThrows()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var ex = Assert.ThrowsAsync<GitLabException>(() =>
+            projectClient.UpdateAsync(int.MaxValue, new()
+            {
+                Visibility = VisibilityLevel.Private,
+            }));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task DeleteAsync_WhenProjectExists_ItIsDeleted()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var group = context.CreateGroup();
+        var project = context.CreateProject(group.Id);
+        var projectClient = context.Client.Projects;
+
+        // Act
+        await projectClient.DeleteAsync(project.Id);
+
+        // Assert
+        Assert.ThrowsAsync<GitLabException>(() => projectClient.GetAsync(project.Id));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task DeleteAsync_WhenProjectNotFound_ItThrows()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var group = context.CreateGroup();
+        var project = context.CreateProject(group.Id);
+        var projectClient = context.Client.Projects;
+
+        // Act
+        var ex = Assert.ThrowsAsync<GitLabException>(() => projectClient.DeleteAsync(int.MaxValue));
+
+        // Assert
+        Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
     }
 
     // No owner level (50) for project! See https://docs.gitlab.com/ee/api/members.html
@@ -322,7 +550,7 @@ public class ProjectsTests
             p.Description = "desc";
             p.IssuesEnabled = true;
             p.MergeRequestsEnabled = true;
-            p.Name = "ForkProject_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture);
+            p.Name = "ForkProject_Test_" + context.GetRandomNumber().ToStringInvariant();
             p.NamespaceId = null;
             p.SnippetsEnabled = true;
             p.VisibilityLevel = VisibilityLevel.Internal;
@@ -338,7 +566,7 @@ public class ProjectsTests
             RawContent = "this project should only live during the unit tests, you can delete if you find some",
         });
 
-        var forkedProject = projectClient.Fork(createdProject.Id.ToString(CultureInfo.InvariantCulture), new ForkProject
+        var forkedProject = projectClient.Fork(createdProject.Id.ToStringInvariant(), new ForkProject
         {
             Path = createdProject.Path + "-fork",
             Name = createdProject.Name + "Fork",
@@ -347,7 +575,7 @@ public class ProjectsTests
         // Wait for the fork to be ready
         await GitLabTestContext.RetryUntilAsync(() => projectClient[forkedProject.Id], p => string.Equals(p.ImportStatus, "finished", StringComparison.Ordinal), TimeSpan.FromMinutes(2));
 
-        var forks = projectClient.GetForks(createdProject.Id.ToString(CultureInfo.InvariantCulture), new ForkedProjectQuery());
+        var forks = projectClient.GetForks(createdProject.Id.ToStringInvariant(), new ForkedProjectQuery());
         Assert.That(forks.Single().Id, Is.EqualTo(forkedProject.Id));
 
         // Create a merge request with AllowCollaboration (only testable on a fork, also the source branch must not be protected)
@@ -398,7 +626,7 @@ public class ProjectsTests
 
         var createdProject = context.CreateProject(prj =>
         {
-            prj.Name = "Project_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture);
+            prj.Name = "Project_Test_" + context.GetRandomNumber().ToStringInvariant();
             prj.VisibilityLevel = VisibilityLevel.Internal;
         });
         Assert.That(createdProject.EmptyRepo, Is.True);
@@ -463,7 +691,7 @@ public class ProjectsTests
         var project = new ProjectCreate
         {
             Description = "desc",
-            Name = "CreateProjectWithSquashOption_Test_" + context.GetRandomNumber().ToString(CultureInfo.InvariantCulture),
+            Name = "CreateProjectWithSquashOption_Test_" + context.GetRandomNumber().ToStringInvariant(),
             VisibilityLevel = VisibilityLevel.Internal,
             SquashOption = inputSquashOption,
         };

--- a/NGitLab/IProjectClient.cs
+++ b/NGitLab/IProjectClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -8,25 +9,26 @@ namespace NGitLab;
 public interface IProjectClient
 {
     /// <summary>
-    /// Get a list of projects for which the authenticated user is a member.
+    /// Gets a list of projects for which the authenticated user is a member.
     /// </summary>
     IEnumerable<Project> Accessible { get; }
 
     /// <summary>
-    /// Get a list of projects owned by the authenticated user.
+    /// Gets a list of projects owned by the authenticated user.
     /// </summary>
     IEnumerable<Project> Owned { get; }
 
     /// <summary>
-    /// Get a list of projects which the authenticated user can see.
+    /// Gets a list of projects which the authenticated user can see.
     /// </summary>
     IEnumerable<Project> Visible { get; }
 
     /// <summary>
-    /// Get a list of all GitLab projects (admin only).
+    /// Gets a list of all GitLab projects (admin only).
     /// </summary>
     IEnumerable<Project> Get(ProjectQuery query);
 
+    /// <inheritdoc cref="Get(ProjectQuery)"/>
     GitLabCollectionResponse<Project> GetAsync(ProjectQuery query);
 
     Project this[int id] { get; }
@@ -39,9 +41,15 @@ public interface IProjectClient
 
     Project Create(ProjectCreate project);
 
+    Task<Project> CreateAsync(ProjectCreate project, CancellationToken cancellationToken = default);
+
     Project Update(string id, ProjectUpdate projectUpdate);
 
+    Task<Project> UpdateAsync(ProjectId projectId, ProjectUpdate projectUpdate, CancellationToken cancellationToken = default);
+
     void Delete(int id);
+
+    Task DeleteAsync(ProjectId projectId, CancellationToken cancellationToken = default);
 
     void Archive(int id);
 
@@ -57,6 +65,8 @@ public interface IProjectClient
     Task<Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default);
 
     Task<Project> GetByNamespacedPathAsync(string path, SingleProjectQuery query = null, CancellationToken cancellationToken = default);
+
+    Task<Project> GetAsync(ProjectId projectId, SingleProjectQuery query = null, CancellationToken cancellationToken = default);
 
     Project Fork(string id, ForkProject forkProject);
 

--- a/NGitLab/Models/Project.cs
+++ b/NGitLab/Models/Project.cs
@@ -183,6 +183,9 @@ public class Project
     [JsonPropertyName("visibility")]
     public VisibilityLevel VisibilityLevel;
 
+    /// <summary>
+    /// The maximum amount of time, in seconds, that a job can run.
+    /// </summary>
     [JsonPropertyName("build_timeout")]
     public int? BuildTimeout;
 

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -14,8 +14,14 @@ public class ProjectCreate
     [JsonPropertyName("namespace_id")]
     public string NamespaceId;
 
+    /// <summary>
+    /// The default branch name. Requires <see cref="InitializeWithReadme"/> to be true.
+    /// </summary>
     [JsonPropertyName("default_branch")]
     public string DefaultBranch;
+
+    [JsonPropertyName("initialize_with_readme")]
+    public bool InitializeWithReadme;
 
     [JsonPropertyName("description")]
     public string Description;
@@ -74,6 +80,9 @@ public class ProjectCreate
     [JsonPropertyName("topics")]
     public List<string> Topics { get; set; }
 
+    /// <summary>
+    /// The maximum amount of time, in seconds, that a job can run.
+    /// </summary>
     [JsonPropertyName("build_timeout")]
     public int? BuildTimeout;
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2879,6 +2879,7 @@ NGitLab.Models.ProjectCreate.BuildTimeout -> int?
 NGitLab.Models.ProjectCreate.DefaultBranch -> string
 NGitLab.Models.ProjectCreate.Description -> string
 NGitLab.Models.ProjectCreate.ImportUrl -> string
+NGitLab.Models.ProjectCreate.InitializeWithReadme -> bool
 NGitLab.Models.ProjectCreate.IssuesAccessLevel -> string
 NGitLab.Models.ProjectCreate.IssuesEnabled -> bool
 NGitLab.Models.ProjectCreate.MergePipelinesEnabled -> bool

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -813,10 +813,13 @@ NGitLab.Impl.ProjectClient
 NGitLab.Impl.ProjectClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.Archive(int id) -> void
 NGitLab.Impl.ProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitLab.Models.Project
+NGitLab.Impl.ProjectClient.CreateAsync(NGitLab.Models.ProjectCreate project, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.Delete(int id) -> void
+NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.ProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.ForkAsync(string id, NGitLab.Models.ForkProject forkProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.Impl.ProjectClient.GetAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
@@ -830,6 +833,7 @@ NGitLab.Impl.ProjectClient.this[int id].get -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.this[string fullName].get -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.Unarchive(int id) -> void
 NGitLab.Impl.ProjectClient.Update(string id, NGitLab.Models.ProjectUpdate projectUpdate) -> NGitLab.Models.Project
+NGitLab.Impl.ProjectClient.UpdateAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectUpdate projectUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.UploadFile(string id, NGitLab.Models.FormDataContent data) -> NGitLab.Models.UploadedProjectFile
 NGitLab.Impl.ProjectClient.Visible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectHooksClient
@@ -1011,10 +1015,13 @@ NGitLab.IProjectClient
 NGitLab.IProjectClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IProjectClient.Archive(int id) -> void
 NGitLab.IProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitLab.Models.Project
+NGitLab.IProjectClient.CreateAsync(NGitLab.Models.ProjectCreate project, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.Delete(int id) -> void
+NGitLab.IProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.IProjectClient.ForkAsync(string id, NGitLab.Models.ForkProject forkProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.IProjectClient.GetAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
 NGitLab.IProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
@@ -1027,6 +1034,7 @@ NGitLab.IProjectClient.this[int id].get -> NGitLab.Models.Project
 NGitLab.IProjectClient.this[string fullName].get -> NGitLab.Models.Project
 NGitLab.IProjectClient.Unarchive(int id) -> void
 NGitLab.IProjectClient.Update(string id, NGitLab.Models.ProjectUpdate projectUpdate) -> NGitLab.Models.Project
+NGitLab.IProjectClient.UpdateAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectUpdate projectUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.UploadFile(string id, NGitLab.Models.FormDataContent data) -> NGitLab.Models.UploadedProjectFile
 NGitLab.IProjectClient.Visible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IProjectHooksClient


### PR DESCRIPTION
- Adds async CRUD methods to `IProjectClient`.
- Improves the Mock ProjectClient to better emulate actual GitLab behavior:
  - Project Create must specify Name or Path.
  - Auto-generate missing Path from Name, and vice-versa.
  - Cannot create project with duplicate Name (case-sensitive).
  - Cannot create project with duplicate Path (case-INsensitive).
  - `Project.BuildTimeout` is in seconds, not minutes.
  - GitLab [ignores](https://docs.gitlab.com/ee/api/projects.html#create-project) `ProjectCreate.DefaultBranch` unless `ProjectCreate.InitializeWithReadme` is true.
  - `Project.ToClientProject()` did not populate `NameWithNamspace`.
  - `Project.FullName` contains spaces around the slash separator.
- Added tests to verify GitLab and Mock behaviors.