### PR TITLE
Add IUserClient.CreateTokenAsync() and Group.CreatedAt prop

### DIFF
--- a/NGitLab.Mock.Tests/GroupsMockTests.cs
+++ b/NGitLab.Mock.Tests/GroupsMockTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NGitLab.Mock.Config;
@@ -405,5 +405,26 @@ public class GroupsMockTests
 
         // Assert
         Assert.That(groupHooksClient.All.ToArray(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Test_group_created_at_date()
+    {
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .BuildServer();
+
+        var client = server.CreateClient("user1");
+
+        var t1 = DateTime.UtcNow;
+        var group = await client.Groups.CreateAsync(new Models.GroupCreate
+        {
+            Name = "Foo",
+            Path = "foo",
+        });
+        var t2 = DateTime.UtcNow;
+
+        Assert.That(group.CreatedAt, Is.GreaterThanOrEqualTo(t1));
+        Assert.That(group.CreatedAt, Is.LessThanOrEqualTo(t2));
     }
 }

--- a/NGitLab.Mock/Clients/UserClient.cs
+++ b/NGitLab.Mock/Clients/UserClient.cs
@@ -77,6 +77,12 @@ internal sealed class UserClient : ClientBase, IUserClient
         throw new NotSupportedException();
     }
 
+    public async Task<UserToken> CreateTokenAsync(UserTokenCreate tokenRequest, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return CreateToken(tokenRequest);
+    }
+
     public void Delete(int id)
     {
         using (Context.BeginOperationScope())

--- a/NGitLab.Mock/Group.cs
+++ b/NGitLab.Mock/Group.cs
@@ -118,6 +118,8 @@ public sealed class Group : GitLabObject
         }
     }
 
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
     public IEnumerable<Project> AllProjects => Projects.Concat(DescendantGroups.SelectMany(group => group.Projects));
 
     public EffectivePermissions GetEffectivePermissions() => GetEffectivePermissions(includeInheritedPermissions: true);
@@ -259,6 +261,7 @@ public sealed class Group : GitLabObject
             LfsEnabled = LfsEnabled,
             ExtraSharedRunnersMinutesLimit = (int)ExtraSharedRunnersLimit.TotalMinutes,
             SharedRunnersMinutesLimit = (int)SharedRunnersLimit.TotalMinutes,
+            CreatedAt = CreatedAt,
         };
     }
 

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -437,6 +437,8 @@ NGitLab.Mock.Group.CanUserDeleteGroup(NGitLab.Mock.User user) -> bool
 NGitLab.Mock.Group.CanUserEditGroup(NGitLab.Mock.User user) -> bool
 NGitLab.Mock.Group.CanUserViewGroup(NGitLab.Mock.User user) -> bool
 NGitLab.Mock.Group.CreateBotUser(NGitLab.Models.AccessLevel accessLevel) -> NGitLab.Mock.User
+NGitLab.Mock.Group.CreatedAt.get -> System.DateTime
+NGitLab.Mock.Group.CreatedAt.set -> void
 NGitLab.Mock.Group.DescendantGroups.get -> System.Collections.Generic.IEnumerable<NGitLab.Mock.Group>
 NGitLab.Mock.Group.Description.get -> string
 NGitLab.Mock.Group.Description.set -> void

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -52,6 +52,23 @@ public class GroupsTests
 
     [Test]
     [NGitLabRetry]
+    public async Task Test_group_created_on_date_is_now()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+
+        var t1 = DateTime.UtcNow;
+        var group = context.CreateGroup();
+        var t2 = DateTime.UtcNow;
+
+        Assert.That(group.CreatedAt, Is.GreaterThanOrEqualTo(t1));
+        Assert.That(group.CreatedAt, Is.LessThanOrEqualTo(t2));
+
+        var group2 = await context.Client.Groups.GetByIdAsync(group.Id);
+        Assert.That(group2.CreatedAt, Is.EqualTo(group.CreatedAt));
+    }
+
+    [Test]
+    [NGitLabRetry]
     public async Task Test_create_delete_group()
     {
         using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/IUserClient.cs
+++ b/NGitLab/IUserClient.cs
@@ -26,10 +26,16 @@ public interface IUserClient
 
     /// <summary>
     /// Request a token for user impersonation.
-    /// Admin account/token is required for impersonation
+    /// Requires an Admin account/token.
+    /// <para/>
+    /// See https://docs.gitlab.com/ee/api/users.html#create-an-impersonation-token
     /// </summary>
     /// <param name="tokenRequest">info required to create the token</param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The new impersonation token.</returns>
+    public Task<UserToken> CreateTokenAsync(UserTokenCreate tokenRequest, CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="CreateTokenAsync(UserTokenCreate, CancellationToken)"/>>
     UserToken CreateToken(UserTokenCreate tokenRequest);
 
     void Delete(int id);

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -73,7 +73,11 @@ public class UserClient : IUserClient
 
     public Task<User> CreateAsync(UserUpsert user, CancellationToken cancellationToken = default) => _api.Post().With(user).ToAsync<User>(User.Url, cancellationToken);
 
-    public UserToken CreateToken(UserTokenCreate tokenRequest) => _api.Post().With(tokenRequest).To<UserToken>(User.Url + "/" + tokenRequest.UserId.ToStringInvariant() + "/impersonation_tokens");
+    public UserToken CreateToken(UserTokenCreate tokenRequest) =>
+        _api.Post().With(tokenRequest).To<UserToken>($"{User.Url}/{tokenRequest.UserId.ToStringInvariant()}/impersonation_tokens");
+
+    public Task<UserToken> CreateTokenAsync(UserTokenCreate tokenRequest, CancellationToken cancellationToken = default) =>
+        _api.Post().With(tokenRequest).ToAsync<UserToken>($"{User.Url}/{tokenRequest.UserId.ToStringInvariant()}/impersonation_tokens", cancellationToken);
 
     public User Update(int id, UserUpsert user) => _api.Put().With(user).To<User>(User.Url + "/" + id.ToStringInvariant());
 

--- a/NGitLab/Models/Group.cs
+++ b/NGitLab/Models/Group.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
@@ -50,4 +51,7 @@ public class Group
 
     [JsonPropertyName("marked_for_deletion_on")]
     public string MarkedForDeletionOn;
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt;
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -965,6 +965,7 @@ NGitLab.Impl.UserClient.All.get -> System.Collections.Generic.IEnumerable<NGitLa
 NGitLab.Impl.UserClient.Create(NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.Impl.UserClient.CreateAsync(NGitLab.Models.UserUpsert user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.CreateToken(NGitLab.Models.UserTokenCreate tokenRequest) -> NGitLab.Models.UserToken
+NGitLab.Impl.UserClient.CreateTokenAsync(NGitLab.Models.UserTokenCreate tokenRequest, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.UserToken>
 NGitLab.Impl.UserClient.Current.get -> NGitLab.Models.Session
 NGitLab.Impl.UserClient.CurrentUserSShKeys.get -> NGitLab.ISshKeyClient
 NGitLab.Impl.UserClient.Deactivate(int userId) -> void
@@ -1180,6 +1181,7 @@ NGitLab.IUserClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Mo
 NGitLab.IUserClient.Create(NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.IUserClient.CreateAsync(NGitLab.Models.UserUpsert user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.CreateToken(NGitLab.Models.UserTokenCreate tokenRequest) -> NGitLab.Models.UserToken
+NGitLab.IUserClient.CreateTokenAsync(NGitLab.Models.UserTokenCreate tokenRequest, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.UserToken>
 NGitLab.IUserClient.Current.get -> NGitLab.Models.Session
 NGitLab.IUserClient.CurrentUserSShKeys.get -> NGitLab.ISshKeyClient
 NGitLab.IUserClient.Deactivate(int id) -> void

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1857,6 +1857,7 @@ NGitLab.Models.GraphQLQuery.Query.set -> void
 NGitLab.Models.GraphQLQuery.Variables.get -> System.Collections.Generic.IDictionary<string, object>
 NGitLab.Models.Group
 NGitLab.Models.Group.AvatarUrl -> string
+NGitLab.Models.Group.CreatedAt -> System.DateTime
 NGitLab.Models.Group.Description -> string
 NGitLab.Models.Group.ExtraSharedRunnersMinutesLimit -> int?
 NGitLab.Models.Group.FullName -> string


### PR DESCRIPTION
- Adds an async version of `IUserClient.CreateToken()`.
- Includes the `CreatedAt` property (`"created_at"`) to the `NGitLab.Models.Group` object. See [here](https://docs.gitlab.com/ee/api/groups.html#details-of-a-group) for a GitLab example.