### PR TITLE
Fix project and group resolution in mocks

### DIFF
--- a/NGitLab.Mock.Tests/GitLabClientMockTest.cs
+++ b/NGitLab.Mock.Tests/GitLabClientMockTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using NGitLab.Mock.Config;
+using NGitLab.Models;
+using NUnit.Framework;
+
+namespace NGitLab.Mock.Tests;
+
+
+public class GitLabClientMockTest
+{
+    public static IEnumerable TestCases
+    {
+        get
+        {
+            static TestCaseData TestCase(string name, Func<IGitLabClient, ProjectId, object> getClient) => new TestCaseData(getClient).SetArgDisplayNames(name);
+
+            // Enumerate all methods on IGitLabClient that accept a single ProjectId parameter
+
+            var methods = typeof(IGitLabClient).GetMethods()
+                .Where(method => method.IsPublic)
+                .Where(method => method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(ProjectId));
+
+            foreach (var method in methods)
+            {
+                yield return TestCase(method.Name, (client, id) => method.Invoke(client, new object[] { id }));
+            }
+
+        }
+    }
+
+    [TestCaseSource(nameof(TestCases))]
+    public void Test_can_get_project_client(Func<IGitLabClient, ProjectId, object> getClient)
+    {
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .WithGroup("test-group")
+            .WithProject("test-project", id: 1, @namespace: "test-group")
+            .BuildServer();
+
+        var client = server.CreateClient();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(getClient(client, 1), Is.Not.Null);
+            Assert.That(getClient(client, "test-group/test-project"), Is.Not.Null);
+        });
+    }
+}

--- a/NGitLab.Mock.Tests/GitLabClientMockTest.cs
+++ b/NGitLab.Mock.Tests/GitLabClientMockTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using NGitLab.Mock.Config;
 using NGitLab.Models;
 using NUnit.Framework;
@@ -10,27 +12,44 @@ namespace NGitLab.Mock.Tests;
 
 public class GitLabClientMockTest
 {
-    public static IEnumerable TestCases
+    public static IEnumerable ProjectClientTestCases
     {
         get
         {
             static TestCaseData TestCase(string name, Func<IGitLabClient, ProjectId, object> getClient) => new TestCaseData(getClient).SetArgDisplayNames(name);
 
-            // Enumerate all methods on IGitLabClient that accept a single ProjectId parameter
-
-            var methods = typeof(IGitLabClient).GetMethods()
-                .Where(method => method.IsPublic)
-                .Where(method => method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(ProjectId));
-
-            foreach (var method in methods)
+            // Create a test case for each method in IGitLabClient that has a single parameter of type ProjectId
+            foreach (var method in GetMethods<ProjectId>())
             {
+                yield return TestCase(method.Name, (client, id) => method.Invoke(client, new object[] { id }));
+            }
+        }
+    }
+
+    public static IEnumerable GroupClientTestCases
+    {
+        get
+        {
+            static TestCaseData TestCase(string name, Func<IGitLabClient, GroupId, object> getClient) => new TestCaseData(getClient).SetArgDisplayNames(name);
+
+            // Create a test case for each method in IGitLabClient that has a single parameter of type GroupId
+            foreach (var method in GetMethods<GroupId>())
+            {
+                // GetGroupMergeRequest() is not implemented in the mock MergeRequestClient and will throw a NotImplementedException
+                // To avoid a test failure, exclude this mehtod from the test cases (this is the only such case)
+                // This can be removed if a mock for group merge requests is implemented
+                if (string.Equals(method.Name, nameof(IGitLabClient.GetGroupMergeRequest), StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 yield return TestCase(method.Name, (client, id) => method.Invoke(client, new object[] { id }));
             }
 
         }
     }
 
-    [TestCaseSource(nameof(TestCases))]
+    [TestCaseSource(nameof(ProjectClientTestCases))]
     public void Test_can_get_project_client(Func<IGitLabClient, ProjectId, object> getClient)
     {
         using var server = new GitLabConfig()
@@ -46,5 +65,62 @@ public class GitLabClientMockTest
             Assert.That(getClient(client, 1), Is.Not.Null);
             Assert.That(getClient(client, "test-group/test-project"), Is.Not.Null);
         });
+    }
+
+    [TestCaseSource(nameof(GroupClientTestCases))]
+    public void Test_can_get_group_client(Func<IGitLabClient, GroupId, object> getClient)
+    {
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .WithGroup("test-group", group =>
+            {
+                group.Namespace = "parent-group";
+                group.Id = 1;
+            })
+            .BuildServer();
+
+        var client = server.CreateClient();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(getClient(client, 1), Is.Not.Null);
+            Assert.That(getClient(client, "parent-group/test-group"), Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void Test_getting_MergeRequestClient_for_group_is_not_implemented()
+    {
+        // GetGroupMergeRequest() is not implemented in the mock MergeRequestClient and will throw a NotImplementedException
+        // For that reason, this method is excluded from the test cases retruend by GroupClientTestCases
+        //
+        // This test checkes that this assumption still holds true and the method is rightly is skipped in GroupClientTestCases
+        // When a mock for GetGroupMergeRequest(), this test will fail.
+        // In this case, this test special logic for GetGroupMergeRequest() in GroupClientTestCases can be removed
+
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .WithGroup("test-group", group =>
+            {
+                group.Namespace = "parent-group";
+                group.Id = 1;
+            })
+            .BuildServer();
+
+        var client = server.CreateClient();
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<NotImplementedException>(() => client.GetGroupMergeRequest(1));
+            Assert.Throws<NotImplementedException>(() => client.GetGroupMergeRequest("parent-group/test-group"));
+        });
+    }
+
+    private static IEnumerable<MethodInfo> GetMethods<TParameter>()
+    {
+        return typeof(IGitLabClient)
+            .GetMethods()
+            .Where(method => method.IsPublic)
+            .Where(method => method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(TParameter));
     }
 }

--- a/NGitLab.Mock.Tests/GitLabClientMockTest.cs
+++ b/NGitLab.Mock.Tests/GitLabClientMockTest.cs
@@ -36,7 +36,7 @@ public class GitLabClientMockTest
             foreach (var method in GetMethods<GroupId>())
             {
                 // GetGroupMergeRequest() is not implemented in the mock MergeRequestClient and will throw a NotImplementedException
-                // To avoid a test failure, exclude this mehtod from the test cases (this is the only such case)
+                // To avoid a test failure, exclude this method from the test cases (this is the only such case)
                 // This can be removed if a mock for group merge requests is implemented
                 if (string.Equals(method.Name, nameof(IGitLabClient.GetGroupMergeRequest), StringComparison.Ordinal))
                 {

--- a/NGitLab.Mock/Clients/ClusterClient.cs
+++ b/NGitLab.Mock/Clients/ClusterClient.cs
@@ -11,7 +11,7 @@ internal sealed class ClusterClient : ClientBase, IClusterClient
     public ClusterClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public IEnumerable<ClusterInfo> All => throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/CommitClient.cs
+++ b/NGitLab.Mock/Clients/CommitClient.cs
@@ -12,7 +12,7 @@ internal sealed class CommitClient : ClientBase, ICommitClient
     public CommitClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Commit Create(CommitCreate commit)

--- a/NGitLab.Mock/Clients/CommitStatusClient.cs
+++ b/NGitLab.Mock/Clients/CommitStatusClient.cs
@@ -12,7 +12,7 @@ internal sealed class CommitStatusClient : ClientBase, ICommitStatusClient
     public CommitStatusClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public CommitStatusCreate AddOrUpdate(CommitStatusCreate status)

--- a/NGitLab.Mock/Clients/EnvironmentClient.cs
+++ b/NGitLab.Mock/Clients/EnvironmentClient.cs
@@ -14,7 +14,7 @@ internal sealed class EnvironmentClient : ClientBase, IEnvironmentClient
     public EnvironmentClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public IEnumerable<EnvironmentInfo> All => throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/EventClient.cs
+++ b/NGitLab.Mock/Clients/EventClient.cs
@@ -18,7 +18,7 @@ internal sealed class EventClient : ClientBase, IEventClient
         : base(context)
     {
         _userId = userId;
-        _projectId = projectId.HasValue ? Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id : null;
+        _projectId = projectId.HasValue ? Server.AllProjects.FindProject(projectId.ValueAsString()).Id : null;
     }
 
     IEnumerable<Models.Event> IEventClient.Get(EventQuery query)

--- a/NGitLab.Mock/Clients/GitLabClient.cs
+++ b/NGitLab.Mock/Clients/GitLabClient.cs
@@ -142,10 +142,7 @@ internal sealed class GitLabClient : ClientBase, IGitLabClient
 
     public IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId) => new ProtectedBranchClient(Context, projectId);
 
-    public IProtectedTagClient GetProtectedTagClient(ProjectId projectId)
-    {
-        throw new System.NotImplementedException();
-    }
+    public IProtectedTagClient GetProtectedTagClient(ProjectId projectId) => new ProtectedTagClient(Context, projectId);
 
     public ISearchClient GetGroupSearchClient(int groupId) => GetGroupSearchClient((long)groupId);
 

--- a/NGitLab.Mock/Clients/GroupBadgeClient.cs
+++ b/NGitLab.Mock/Clients/GroupBadgeClient.cs
@@ -11,7 +11,7 @@ internal sealed class GroupBadgeClient : ClientBase, IGroupBadgeClient
     public GroupBadgeClient(ClientContext context, GroupId groupId)
         : base(context)
     {
-        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsUriParameter()).Id;
+        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsString()).Id;
     }
 
     public Models.Badge this[int id]

--- a/NGitLab.Mock/Clients/GroupHooksClient.cs
+++ b/NGitLab.Mock/Clients/GroupHooksClient.cs
@@ -11,7 +11,7 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
     public GroupHooksClient(ClientContext context, GroupId groupId)
         : base(context)
     {
-        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsUriParameter()).Id;
+        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsString()).Id;
     }
 
     public IEnumerable<Models.GroupHook> All

--- a/NGitLab.Mock/Clients/GroupSearchClient.cs
+++ b/NGitLab.Mock/Clients/GroupSearchClient.cs
@@ -12,7 +12,7 @@ internal sealed class GroupSearchClient : ClientBase, ISearchClient
         : base(context)
     {
         _context = context;
-        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsUriParameter()).Id;
+        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsString()).Id;
     }
 
     public GitLabCollectionResponse<SearchBlob> GetBlobsAsync(SearchQuery query)

--- a/NGitLab.Mock/Clients/GroupVariableClient.cs
+++ b/NGitLab.Mock/Clients/GroupVariableClient.cs
@@ -11,7 +11,7 @@ internal sealed class GroupVariableClient : ClientBase, IGroupVariableClient
     public GroupVariableClient(ClientContext context, GroupId groupId)
         : base(context)
     {
-        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsUriParameter()).Id;
+        _groupId = Server.AllGroups.FindGroup(groupId.ValueAsString()).Id;
     }
 
     public Variable this[string key] => throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/JobClient.cs
+++ b/NGitLab.Mock/Clients/JobClient.cs
@@ -16,7 +16,7 @@ internal sealed class JobClient : ClientBase, IJobClient
     public JobClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Models.Job Get(int jobId)

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -22,7 +22,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
     public MergeRequestClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public MergeRequestClient(ClientContext context, GroupId groupId)

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -28,6 +28,9 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
     public MergeRequestClient(ClientContext context, GroupId groupId)
         : base(context)
     {
+        // Support for group-level Merge Requests is not implemented in the mocks yet.
+        // For this reason, the GetGroupMergeRequest() method is excluded from the test cases in GitLabClientMockTest (see GroupClientTestCases).
+        // The exclusion in the test should be removed when support for support for merge requests in groups is implemented.
         throw new NotImplementedException();
     }
 

--- a/NGitLab.Mock/Clients/MilestoneClient.cs
+++ b/NGitLab.Mock/Clients/MilestoneClient.cs
@@ -18,7 +18,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         _resourceId = scope switch
         {
             MilestoneScope.Groups => Server.AllGroups.FindGroup(id.ValueAsUriParameter()).Id,
-            MilestoneScope.Projects => Server.AllProjects.FindProject(id.ValueAsUriParameter()).Id,
+            MilestoneScope.Projects => Server.AllProjects.FindProject(id.ValueAsString()).Id,
             _ => throw new NotSupportedException($"{scope} milestone is not supported yet."),
         };
         Scope = scope;

--- a/NGitLab.Mock/Clients/MilestoneClient.cs
+++ b/NGitLab.Mock/Clients/MilestoneClient.cs
@@ -17,7 +17,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
     {
         _resourceId = scope switch
         {
-            MilestoneScope.Groups => Server.AllGroups.FindGroup(id.ValueAsUriParameter()).Id,
+            MilestoneScope.Groups => Server.AllGroups.FindGroup(id.ValueAsString()).Id,
             MilestoneScope.Projects => Server.AllProjects.FindProject(id.ValueAsString()).Id,
             _ => throw new NotSupportedException($"{scope} milestone is not supported yet."),
         };

--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -18,7 +18,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         : base(context)
     {
         _jobClient = jobClient;
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Models.Pipeline this[int id]

--- a/NGitLab.Mock/Clients/ProjectBadgeClient.cs
+++ b/NGitLab.Mock/Clients/ProjectBadgeClient.cs
@@ -12,7 +12,7 @@ internal sealed class ProjectBadgeClient : ClientBase, IProjectBadgeClient
     public ProjectBadgeClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Models.Badge this[int id]

--- a/NGitLab.Mock/Clients/ProjectIssueNoteClient.cs
+++ b/NGitLab.Mock/Clients/ProjectIssueNoteClient.cs
@@ -11,7 +11,7 @@ internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClie
     public ProjectIssueNoteClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Models.ProjectIssueNote Create(ProjectIssueNoteCreate create)

--- a/NGitLab.Mock/Clients/ProjectLevelApprovalRulesClient.cs
+++ b/NGitLab.Mock/Clients/ProjectLevelApprovalRulesClient.cs
@@ -11,7 +11,7 @@ internal sealed class ProjectLevelApprovalRulesClient : ClientBase, IProjectLeve
     public ProjectLevelApprovalRulesClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public List<ApprovalRule> GetProjectLevelApprovalRules()

--- a/NGitLab.Mock/Clients/ProjectSearchClient.cs
+++ b/NGitLab.Mock/Clients/ProjectSearchClient.cs
@@ -12,7 +12,7 @@ internal sealed class ProjectSearchClient : ClientBase, ISearchClient
         : base(context)
     {
         _context = context;
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public GitLabCollectionResponse<SearchBlob> GetBlobsAsync(SearchQuery query)

--- a/NGitLab.Mock/Clients/ProjectVariableClient.cs
+++ b/NGitLab.Mock/Clients/ProjectVariableClient.cs
@@ -11,7 +11,7 @@ internal sealed class ProjectVariableClient : ClientBase, IProjectVariableClient
     public ProjectVariableClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Variable this[string key] => throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/ProtectedBranchClient.cs
+++ b/NGitLab.Mock/Clients/ProtectedBranchClient.cs
@@ -11,7 +11,7 @@ internal sealed class ProtectedBranchClient : ClientBase, IProtectedBranchClient
     public ProtectedBranchClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Models.ProtectedBranch GetProtectedBranch(string branchName)

--- a/NGitLab.Mock/Clients/ProtectedTagClient.cs
+++ b/NGitLab.Mock/Clients/ProtectedTagClient.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Models;
+
+namespace NGitLab.Mock.Clients;
+
+internal sealed class ProtectedTagClient : ClientBase, IProtectedTagClient
+{
+    private readonly int _projectId;
+
+    public ProtectedTagClient(ClientContext context, ProjectId projectId)
+        : base(context)
+    {
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
+    }
+
+    public ProtectedTag GetProtectedTag(string name)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<ProtectedTag> GetProtectedTagAsync(string name, CancellationToken cancellationToken = default)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public IEnumerable<ProtectedTag> GetProtectedTags()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public GitLabCollectionResponse<ProtectedTag> GetProtectedTagsAsync()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public ProtectedTag ProtectTag(TagProtect protect)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task<ProtectedTag> ProtectTagAsync(TagProtect protect, CancellationToken cancellationToken = default)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void UnprotectTag(string name)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task UnprotectTagAsync(string name, CancellationToken cancellationToken = default)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/NGitLab.Mock/Clients/ReleaseClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseClient.cs
@@ -16,7 +16,7 @@ internal sealed class ReleaseClient : ClientBase, IReleaseClient
     public ReleaseClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public IEnumerable<Models.ReleaseInfo> All

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -14,7 +14,7 @@ internal sealed class RepositoryClient : ClientBase, IRepositoryClient
     public RepositoryClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public ITagClient Tags => new TagClient(Context, _projectId);

--- a/NGitLab.Mock/Clients/TriggerClient.cs
+++ b/NGitLab.Mock/Clients/TriggerClient.cs
@@ -11,7 +11,7 @@ internal sealed class TriggerClient : ClientBase, ITriggerClient
     public TriggerClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public Trigger this[int id] => throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/WikiClient.cs
+++ b/NGitLab.Mock/Clients/WikiClient.cs
@@ -11,7 +11,7 @@ internal sealed class WikiClient : ClientBase, IWikiClient
     public WikiClient(ClientContext context, ProjectId projectId)
         : base(context)
     {
-        _projectId = Server.AllProjects.FindProject(projectId.ValueAsUriParameter()).Id;
+        _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
     public WikiPage this[string slug] => throw new NotImplementedException();


### PR DESCRIPTION
I noticed that getting a group or project client from the mock GitLabClient by passing in a group or project path string was throwing a NullReferenceException.

This was due to the fact that each mock client that was using `FindProject()` or `FindGroup()` was passing in `id.ValueAsUriParameter()` which escapes and URL characters.
When the group or project path contained a "/", no matching entry was found.

This MR resolves this by using `ValueAsString()` instead of `ValueAsUriParameter()`.
I have also added tests that ensure a mock client can be retrieved for a group or project either by path or by the numeric id.