### PR TITLE
Resolve GitLab version in GitLabDockerContainer

### DIFF
--- a/NGitLab.Tests/Docker/GitLabDockerContainer.cs
+++ b/NGitLab.Tests/Docker/GitLabDockerContainer.cs
@@ -25,8 +25,20 @@ public class GitLabDockerContainer
     public const string ContainerName = "NGitLabClientTests";
     public const string ImageName = "gitlab/gitlab-ee";
 
-    // https://hub.docker.com/r/gitlab/gitlab-ee/tags/
-    public const string GitLabDockerVersion = "15.11.9-ee.0"; // Keep in sync with .github/workflows/ci.yml
+    /// <summary>
+    /// GitLab docker image version to spawn.
+    /// Used only on local environment (CI should already have a running GitLab instance from its services)
+    /// </summary>
+    /// <remarks>
+    /// <para>Keep in sync with .github/workflows/ci.yml</para>
+    /// <para>List of available versions: https://hub.docker.com/r/gitlab/gitlab-ee/tags/</para>
+    /// </remarks>
+    private const string LocalGitLabDockerVersion = "15.11.9-ee.0";
+
+    /// <summary>
+    /// Resolved GitLab version taken from the help page once logged in
+    /// </summary>
+    private static string ResolvedGitLabVersion = null;
 
     private static string s_creationErrorMessage;
     private static readonly SemaphoreSlim s_setupLock = new(initialCount: 1, maxCount: 1);
@@ -91,12 +103,49 @@ public class GitLabDockerContainer
 
     private async Task SetupAsync()
     {
-        await SpawnDockerContainerAsync().ConfigureAwait(false);
-        await LoadCredentialsAsync().ConfigureAwait(false);
-        if (Credentials == null)
+        if (GitLabTestContext.IsContinuousIntegration())
         {
-            await GenerateCredentialsAsync().ConfigureAwait(false);
-            PersistCredentialsAsync();
+            await VerifyCiGitLabInstance().ConfigureAwait(false);
+        }
+        else
+        {
+            await SpawnDockerContainerAsync().ConfigureAwait(false);
+        }
+
+        EnsureChromiumIsInstalled();
+
+        // Use Playwright to launch Chromium
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            // Headless = false,   // Uncomment to have browser window visible
+            // SlowMo = 1000,      // Slows down Playwright operations by the specified amount of ms.
+        });
+        await using var browserContext = await browser.NewContextAsync();
+
+        await LoginAsync(browserContext);
+        await ResolveGitLabVersionAsync(browserContext).ConfigureAwait(false);
+
+        await LoadCredentialsAsync().ConfigureAwait(false);
+
+        if (Credentials != null)
+        {
+            Console.WriteLine("Using credentials from persisted credential file");
+            return;
+        }
+
+        await GenerateCredentialsAsync(browserContext).ConfigureAwait(false);
+        PersistCredentialsAsync();
+
+        static void EnsureChromiumIsInstalled()
+        {
+            TestContext.Progress.WriteLine("Making sure Chromium is installed");
+
+            var exitCode = Microsoft.Playwright.Program.Main(new[] { "install", "--force", "chromium", "--with-deps" });
+            if (exitCode != 0)
+                throw new InvalidOperationException($"Cannot install browser (exit code: {exitCode})");
+
+            TestContext.Progress.WriteLine("Chromium installed");
         }
     }
 
@@ -119,39 +168,8 @@ public class GitLabDockerContainer
 
     private async Task SpawnDockerContainerAsync()
     {
-        // Check if the container is accessible?
-        var isContinuousIntegration = GitLabTestContext.IsContinuousIntegration();
+        Console.WriteLine($"Executing tests locally. Spawning GitLab docker image version '{LocalGitLabDockerVersion}'");
         using var httpClient = new HttpClient();
-        try
-        {
-            Console.WriteLine("Testing " + GitLabUrl);
-            var result = await httpClient.GetStringAsync(GitLabUrl).ConfigureAwait(false);
-            if (isContinuousIntegration) // When not on CI, we want to check the container is on the expected version
-                return;
-        }
-        catch
-        {
-            if (isContinuousIntegration)
-            {
-                var now = Stopwatch.StartNew();
-                while (now.Elapsed < TimeSpan.FromMinutes(10))
-                {
-                    try
-                    {
-                        var result = await httpClient.GetStringAsync(GitLabUrl).ConfigureAwait(false);
-                        return;
-                    }
-                    catch
-                    {
-                    }
-
-                    await Task.Delay(1000);
-                }
-
-                s_creationErrorMessage = "GitLab is not well configured in CI";
-                Assert.Fail(s_creationErrorMessage);
-            }
-        }
 
         // Spawn the container
         // https://docs.gitlab.com/omnibus/settings/configuration.html
@@ -166,7 +184,7 @@ public class GitLabDockerContainer
         {
             TestContext.Progress.WriteLine("Verifying if the GitLab Docker container is using the right image");
             var inspect = await client.Containers.InspectContainerAsync(container.ID).ConfigureAwait(false);
-            var inspectImage = await client.Images.InspectImageAsync(ImageName + ":" + GitLabDockerVersion).ConfigureAwait(false);
+            var inspectImage = await client.Images.InspectImageAsync(ImageName + ":" + LocalGitLabDockerVersion).ConfigureAwait(false);
             if (inspect.Image != inspectImage.ID)
             {
                 TestContext.Progress.WriteLine("Ending GitLab Docker container, as it's using the wrong image");
@@ -179,7 +197,7 @@ public class GitLabDockerContainer
         {
             // Download GitLab images
             TestContext.Progress.WriteLine("Making sure the right GitLab Docker image is available locally");
-            await client.Images.CreateImageAsync(new ImagesCreateParameters { FromImage = ImageName, Tag = GitLabDockerVersion }, new AuthConfig(), new Progress<JSONMessage>()).ConfigureAwait(false);
+            await client.Images.CreateImageAsync(new ImagesCreateParameters { FromImage = ImageName, Tag = LocalGitLabDockerVersion }, new AuthConfig(), new Progress<JSONMessage>()).ConfigureAwait(false);
 
             // Create the container
             TestContext.Progress.WriteLine("Creating the GitLab Docker container");
@@ -194,7 +212,7 @@ public class GitLabDockerContainer
             var response = await client.Containers.CreateContainerAsync(new CreateContainerParameters
             {
                 Hostname = "localhost",
-                Image = ImageName + ":" + GitLabDockerVersion,
+                Image = ImageName + ":" + LocalGitLabDockerVersion,
                 Name = ContainerName,
                 Tty = false,
                 HostConfig = hostConfig,
@@ -264,8 +282,10 @@ public class GitLabDockerContainer
         TestContext.Progress.WriteLine("GitLab Docker container is ready");
     }
 
-    private async Task GenerateCredentialsAsync()
+    private async Task GenerateCredentialsAsync(IBrowserContext context)
     {
+        Console.WriteLine("Requesting credentials from GitLab instance");
+
         var credentials = new GitLabCredential();
         await GenerateAdminToken(credentials).ConfigureAwait(false);
         if (credentials.AdminUserToken != null)
@@ -277,41 +297,12 @@ public class GitLabDockerContainer
 
         async Task GenerateAdminToken(GitLabCredential credentials)
         {
-            EnsureChromiumIsInstalled();
-
-            // Use Playwright to launch Chromium
-            using var playwright = await Playwright.CreateAsync();
-            await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-            {
-                // Headless = false,   // Uncomment to have browser window visible
-                // SlowMo = 1000,      // Slows down Playwright operations by the specified amount of ms.
-            });
-
-            await using var browserContext = await browser.NewContextAsync();
-
-            var page = await browserContext.NewPageAsync();
+            var page = await context.NewPageAsync();
             await page.GotoAsync(GitLabUrl.AbsoluteUri);
 
             TestContext.Progress.WriteLine("Generating Credentials");
 
             var url = await GetCurrentUrl(page);
-
-            // Login
-            if (url == "/users/sign_in")
-            {
-                await page.Locator("form#new_user input[name='user[login]']").FillAsync(AdminUserName);
-                await page.Locator("form#new_user input[name='user[password]']").FillAsync(AdminPassword);
-
-                var checkbox = page.Locator("form#new_user input[type=checkbox][name='user[remember_me]']");
-                await checkbox.CheckAsync(new LocatorCheckOptions { Force = true });
-
-                await page.RunAndWaitForResponseAsync(async () =>
-                {
-                    await page.EvalOnSelectorAsync("form#new_user", "form => form.submit()");
-                }, response => response.Status == 200);
-
-                url = await GetCurrentUrl(page);
-            }
 
             // Create a token
             if (url == "/")
@@ -339,7 +330,7 @@ public class GitLabDockerContainer
             // Get admin login cookie
             // result.Cookie: experimentation_subject_id=XXX; _gitlab_session=XXXX; known_sign_in=XXXX
             TestContext.Progress.WriteLine("Extracting GitLab session cookie");
-            var cookies = await browserContext.CookiesAsync(new[] { GitLabUrl.AbsoluteUri });
+            var cookies = await context.CookiesAsync(new[] { GitLabUrl.AbsoluteUri });
             foreach (var cookie in cookies)
             {
                 if (cookie.Name == "_gitlab_session")
@@ -349,19 +340,6 @@ public class GitLabDockerContainer
                 }
             }
         }
-
-        static void EnsureChromiumIsInstalled()
-        {
-            TestContext.Progress.WriteLine("Making sure Chromium is installed");
-
-            var exitCode = Microsoft.Playwright.Program.Main(new[] { "install", "--force", "chromium", "--with-deps" });
-            if (exitCode != 0)
-                throw new InvalidOperationException($"Cannot install browser (exit code: {exitCode})");
-
-            TestContext.Progress.WriteLine("Chromium installed");
-        }
-
-        static Task<string> GetCurrentUrl(IPage page) => page.EvaluateAsync<string>("window.location.pathname");
 
         void GenerateUserToken()
         {
@@ -451,4 +429,77 @@ public class GitLabDockerContainer
     {
         return Path.Combine(Path.GetTempPath(), "ngitlab", "credentials.json");
     }
+
+    private async Task VerifyCiGitLabInstance()
+    {
+        Console.WriteLine($"Executing tests on CI. Checking GitLab instance...");
+
+        using var httpClient = new HttpClient();
+        Console.WriteLine("Testing " + GitLabUrl);
+
+        var now = Stopwatch.StartNew();
+        while (now.Elapsed < TimeSpan.FromMinutes(10))
+        {
+            try
+            {
+                var result = await httpClient.GetStringAsync(GitLabUrl).ConfigureAwait(false);
+                return;
+            }
+            catch
+            {
+            }
+
+            await Task.Delay(1000);
+        }
+
+        s_creationErrorMessage = "GitLab is not well configured in CI";
+        Assert.Fail(s_creationErrorMessage);
+    }
+
+    private async Task ResolveGitLabVersionAsync(IBrowserContext context)
+    {
+        Console.WriteLine("Resolving GitLab version from help page...");
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(new Uri(GitLabUrl, "help").AbsoluteUri);
+        var titleLink = await page.QuerySelectorAsync("h1 a");
+
+        if (titleLink is null)
+            throw new InvalidOperationException($"Cannot find title on the help page to get GitLab version");
+
+        var version = await titleLink.TextContentAsync();
+
+        if (string.IsNullOrEmpty(version))
+            throw new InvalidOperationException($"Found title on the help page, but the version is empty");
+
+        ResolvedGitLabVersion = version;
+        Console.WriteLine($"GitLab resolved version is '{ResolvedGitLabVersion}'");
+    }
+
+    private async Task LoginAsync(IBrowserContext context)
+    {
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(GitLabUrl.AbsoluteUri);
+        var url = await GetCurrentUrl(page);
+
+        if (url == "/users/sign_in")
+        {
+            Console.WriteLine("Loggin in on GitLab instance...");
+            await page.Locator("form#new_user input[name='user[login]']").FillAsync(AdminUserName);
+            await page.Locator("form#new_user input[name='user[password]']").FillAsync(AdminPassword);
+
+            var checkbox = page.Locator("form#new_user input[type=checkbox][name='user[remember_me]']");
+            await checkbox.CheckAsync(new LocatorCheckOptions { Force = true });
+
+            await page.RunAndWaitForResponseAsync(async () =>
+            {
+                await page.EvalOnSelectorAsync("form#new_user", "form => form.submit()");
+            }, response => response.Status == 200);
+        }
+        else
+        {
+            Console.WriteLine("Already logged in on GitLab instance...");
+        }
+    }
+
+    private static Task<string> GetCurrentUrl(IPage page) => page.EvaluateAsync<string>("window.location.pathname");
 }

--- a/NGitLab.Tests/Docker/GitLabDockerContainer.cs
+++ b/NGitLab.Tests/Docker/GitLabDockerContainer.cs
@@ -106,7 +106,7 @@ public class GitLabDockerContainer
     {
         if (GitLabTestContext.IsContinuousIntegration())
         {
-            await VerifyCiGitLabInstance().ConfigureAwait(false);
+            await WaitForCiGitLabInstance().ConfigureAwait(false);
         }
         else
         {
@@ -283,7 +283,7 @@ public class GitLabDockerContainer
         TestContext.Progress.WriteLine("GitLab Docker container is ready");
     }
 
-    private async Task GenerateCredentialsAsync(IBrowserContext context)
+    private async Task GenerateCredentialsAsync(IBrowserContext browserContext)
     {
         Console.WriteLine("Requesting credentials from GitLab instance");
 
@@ -306,7 +306,7 @@ public class GitLabDockerContainer
 
             TestContext.Progress.WriteLine("Creating root token");
 
-            var page = await context.NewPageAsync();
+            var page = await browserContext.NewPageAsync();
             await page.GotoAsync(GitLabUrl + "/-/profile/personal_access_tokens");
 
             var formLocator = page.Locator("main#content-body form");
@@ -344,7 +344,7 @@ public class GitLabDockerContainer
             // Get admin login cookie
             // result.Cookie: experimentation_subject_id=XXX; _gitlab_session=XXXX; known_sign_in=XXXX
             TestContext.Progress.WriteLine("Extracting GitLab session cookie");
-            var cookies = await context.CookiesAsync(new[] { GitLabUrl.AbsoluteUri });
+            var cookies = await browserContext.CookiesAsync(new[] { GitLabUrl.AbsoluteUri });
             foreach (var cookie in cookies)
             {
                 if (cookie.Name == "_gitlab_session")
@@ -444,7 +444,7 @@ public class GitLabDockerContainer
         return Path.Combine(Path.GetTempPath(), "ngitlab", "credentials.json");
     }
 
-    private async Task VerifyCiGitLabInstance()
+    private async Task WaitForCiGitLabInstance()
     {
         Console.WriteLine($"Executing tests on CI. Checking GitLab instance...");
 
@@ -470,10 +470,10 @@ public class GitLabDockerContainer
         Assert.Fail(s_creationErrorMessage);
     }
 
-    private async Task ResolveGitLabVersionAsync(IBrowserContext context)
+    private async Task ResolveGitLabVersionAsync(IBrowserContext browserContext)
     {
         Console.WriteLine("Resolving GitLab version from help page...");
-        var page = await context.NewPageAsync();
+        var page = await browserContext.NewPageAsync();
         await page.GotoAsync(new Uri(GitLabUrl, "help").AbsoluteUri);
         var titleLink = await page.QuerySelectorAsync("h1 a");
 
@@ -495,9 +495,9 @@ public class GitLabDockerContainer
         Console.WriteLine($"GitLab resolved version is '{ResolvedGitLabVersion}'");
     }
 
-    private async Task LoginAsync(IBrowserContext context)
+    private async Task LoginAsync(IBrowserContext browserContext)
     {
-        var page = await context.NewPageAsync();
+        var page = await browserContext.NewPageAsync();
         await page.GotoAsync(GitLabUrl.AbsoluteUri);
         var url = await GetCurrentUrl(page);
 


### PR DESCRIPTION
- Add comments to clarify `GitLabDockerVersion` property
- Retrieve GitLab version once logged in on the instance
- Store its value in `ResolvedGitLabVersion` that could be used afterwards
- Supports both v15/v16 login process as well as on token retrieval

![image](https://github.com/ubisoft/NGitLab/assets/78750681/4f952250-4d9b-4570-b436-d20a22e2a0f8)
