### PR TITLE
Support major GitLab versions greater than 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
         gitlab:
           - 'gitlab/gitlab-ee:15.11.9-ee.0'
           - 'gitlab/gitlab-ee:15.11.13-ee.0'
-          - 'gitlab/gitlab-ee:16.10.6-ee.0'
-          - 'gitlab/gitlab-ee:16.11.3-ee.0'
+          - 'gitlab/gitlab-ee:16.10.7-ee.0'
+          - 'gitlab/gitlab-ee:16.11.4-ee.0'
+          - 'gitlab/gitlab-ee:17.0.2-ee.0'
         configuration: [Release]
       fail-fast: false
     services:

--- a/NGitLab.Tests/Docker/GitLabDockerContainer.cs
+++ b/NGitLab.Tests/Docker/GitLabDockerContainer.cs
@@ -302,7 +302,7 @@ public class GitLabDockerContainer
 
             var gitLabVersionAsNuGetVersion = NuGetVersion.Parse(ResolvedGitLabVersion);
             var isMajorVersion15 = VersionRange.Parse("[15.0,16.0)").Satisfies(gitLabVersionAsNuGetVersion);
-            var isMajorVersion16 = VersionRange.Parse("[16.0,17.0)").Satisfies(gitLabVersionAsNuGetVersion);
+            var isMajorVersionAtLeast16 = VersionRange.Parse("[16.0,)").Satisfies(gitLabVersionAsNuGetVersion);
 
             TestContext.Progress.WriteLine("Creating root token");
 
@@ -319,7 +319,7 @@ public class GitLabDockerContainer
                 formLocator = page.Locator("main#content-body form");
                 await formLocator.GetByLabel("Token name").FillAsync(tokenName);
             }
-            else if (isMajorVersion16)
+            else if (isMajorVersionAtLeast16)
             {
                 await page.Locator("main[id='content-body'] button[data-testid='add-new-token-button']").ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
                 formLocator = page.Locator("main[id='content-body'] form[id='js-new-access-token-form']");


### PR DESCRIPTION
> [Toa741](https://github.com/Toa741) [3 weeks ago](https://github.com/ubisoft/NGitLab/pull/682#discussion_r1621243418)
Could you make the range to be version 16 and upper (not limiting between 16 and 17), cause it would make a potential version 18 to throw (and ideally they don't change their html markup again on future major versions ^^).

> Should maybe be [16.0,) ?

@Toa741 I apologize, you were right. It seems I tested when there were still other problems ...