### PR TITLE
Ignore Scope property for json serialisation

### DIFF
--- a/NGitLab/Models/Variable.cs
+++ b/NGitLab/Models/Variable.cs
@@ -31,6 +31,7 @@ public class Variable
     [JsonPropertyName("raw")]
     public bool Raw { get; set; }
 
+    [JsonIgnore]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public string Scope
     {


### PR DESCRIPTION
@Toa741 When we kept the [Scope](https://github.com/ubisoft/NGitLab/pull/697#discussion_r1646181418) property, we forgot to annotate JsonIgnore