### PR TITLE
Fix Runners active state in Mocks

### DIFF
--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -217,7 +217,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
             var project = Server.AllProjects.SingleOrDefault(p => string.Equals(p.RunnersToken, request.Token, StringComparison.Ordinal));
             if (project != null)
             {
-                var runner = project.AddRunner(null, request.Description, request.IsActive() ?? false, request.Locked ?? true, false, request.RunUntagged ?? false);
+                var runner = project.AddRunner(null, request.Description, request.IsActive() ?? true, request.Locked ?? true, false, request.RunUntagged ?? false);
                 return runner.ToClientRunner(Context.User);
             }
 

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -94,7 +94,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
             var runner = this[runnerId] ?? throw new GitLabNotFoundException();
             var runnerOnServer = GetServerRunner(runnerId);
 
-            runnerOnServer.Active = runnerUpdate.Active ?? runnerOnServer.Active;
+            runnerOnServer.Active = runnerUpdate.IsActive() ?? runnerOnServer.IsActive();
             runnerOnServer.Paused = runnerUpdate.Paused ?? runnerOnServer.Paused;
             runnerOnServer.TagList = runnerUpdate.TagList ?? runnerOnServer.TagList;
             runnerOnServer.Description = !string.IsNullOrEmpty(runnerUpdate.Description) ? runnerUpdate.Description : runnerOnServer.Description;
@@ -217,9 +217,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
             var project = Server.AllProjects.SingleOrDefault(p => string.Equals(p.RunnersToken, request.Token, StringComparison.Ordinal));
             if (project != null)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var runner = project.AddRunner(null, request.Description, request.Active ?? false, request.Locked ?? true, false, request.RunUntagged ?? false);
-#pragma warning restore CS0618 // Type or member is obsolete
+                var runner = project.AddRunner(null, request.Description, request.IsActive() ?? false, request.Locked ?? true, false, request.RunUntagged ?? false);
                 return runner.ToClientRunner(Context.User);
             }
 

--- a/NGitLab.Mock/RunnersExtensions.cs
+++ b/NGitLab.Mock/RunnersExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using NGitLab.Models;
 
 namespace NGitLab.Mock;
+
 internal static class RunnersExtensions
 {
     public static bool? IsActive(this RunnerRegister runner)

--- a/NGitLab.Mock/RunnersExtensions.cs
+++ b/NGitLab.Mock/RunnersExtensions.cs
@@ -1,0 +1,26 @@
+﻿using NGitLab.Models;
+
+namespace NGitLab.Mock;
+internal static class RunnersExtensions
+{
+    public static bool? IsActive(this RunnerRegister runner)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return runner.Active ?? !runner.Paused;
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    public static bool? IsActive(this RunnerUpdate runner)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return runner.Active ?? !runner.Paused;
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    public static bool IsActive(this Runner runner)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return runner.Active || !runner.Paused;
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}


### PR DESCRIPTION
- Handle both IsActive (obsolete) & Paused in the Runner classes for the Mock
- When using only Paused, the Register() method was calling AddRuner() with isActive to false