### PR TITLE
Support new job status 'canceling'

### DIFF
--- a/NGitLab/Models/BuildStatus.cs
+++ b/NGitLab/Models/BuildStatus.cs
@@ -28,4 +28,5 @@ public enum JobStatus
     [EnumMember(Value = "waiting_for_resource")]
     WaitingForResource,
     Scheduled,
+    Canceling,
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1221,6 +1221,7 @@ NGitLab.IWikiClient.this[string slug].get -> NGitLab.Models.WikiPage
 NGitLab.IWikiClient.Update(string slug, NGitLab.Models.WikiPageUpdate wikiPage) -> NGitLab.Models.WikiPage
 NGitLab.JobStatus
 NGitLab.JobStatus.Canceled = 6 -> NGitLab.JobStatus
+NGitLab.JobStatus.Canceling = 13 -> NGitLab.JobStatus
 NGitLab.JobStatus.Created = 5 -> NGitLab.JobStatus
 NGitLab.JobStatus.Failed = 3 -> NGitLab.JobStatus
 NGitLab.JobStatus.Manual = 8 -> NGitLab.JobStatus


### PR DESCRIPTION
A GitLab job can now be in the state "canceling".
See https://gitlab.com/gitlab-org/gitlab/-/merge_requests/140522.

Without this change, reading jobs in this state produces the error "Requested value 'canceling' was not found.".

Fixes: #722 