### PR TITLE
Add support for the "Update pipeline metadata" API

### DIFF
--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -305,4 +305,9 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
             return Task.FromResult(this[pipelineId]);
         }
     }
+
+    public Task<Models.Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -313,7 +313,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
             var project = GetProject(_projectId, ProjectPermission.Edit);
             var pipeline = project.Pipelines.GetById(pipelineId);
 
-            // Currently, "name" is the only field that can be update dvia the "Update pipeline metadata" API
+            // Currently, "name" is the only field that can be updated via the "Update pipeline metadata" API
             // See https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata
             // If no name is set, GitLab returns a "Bad Request" error
             // This behavior is mimicked here

--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -308,6 +308,25 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
 
     public Task<Models.Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(_projectId, ProjectPermission.Edit);
+            var pipeline = project.Pipelines.GetById(pipelineId);
+
+            // Currently, "name" is the only field that can be update dvia the "Update pipeline metadata" API
+            // See https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata
+            // If no name is set, GitLab returns a "Bad Request" error
+            // This behavior is mimicked here
+            if (update.Name is not null)
+            {
+                pipeline.Name = update.Name;
+            }
+            else
+            {
+                throw new GitLabBadRequestException("name is missing");
+            }
+
+            return Task.FromResult(pipeline.ToPipelineClient());
+        }
     }
 }

--- a/NGitLab.Mock/Pipeline.cs
+++ b/NGitLab.Mock/Pipeline.cs
@@ -56,6 +56,8 @@ public sealed class Pipeline : GitLabObject
 
     public TestReportSummary TestReportsSummary { get; set; }
 
+    public string Name { get; set; }
+
     [Obsolete("Use other overloads")]
     public Job AddNewJob(Project project)
     {
@@ -150,6 +152,7 @@ public sealed class Pipeline : GitLabObject
             Coverage = Coverage,
             ProjectId = ProjectId,
             WebUrl = Project?.WebUrl + "/-/pipelines/" + Id.ToString(CultureInfo.InvariantCulture),
+            Name = Name
         };
     }
 }

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -803,6 +803,8 @@ NGitLab.Mock.Pipeline.FinishedAt.get -> System.DateTimeOffset?
 NGitLab.Mock.Pipeline.FinishedAt.set -> void
 NGitLab.Mock.Pipeline.Id.get -> int
 NGitLab.Mock.Pipeline.Id.set -> void
+NGitLab.Mock.Pipeline.Name.get -> string
+NGitLab.Mock.Pipeline.Name.set -> void
 NGitLab.Mock.Pipeline.Pipeline(string ref) -> void
 NGitLab.Mock.Pipeline.Project.get -> NGitLab.Mock.Project
 NGitLab.Mock.Pipeline.ProjectId.get -> int

--- a/NGitLab/IPipelineClient.cs
+++ b/NGitLab/IPipelineClient.cs
@@ -117,4 +117,13 @@ public interface IPipelineClient
     GitLabCollectionResponse<Bridge> GetBridgesAsync(PipelineBridgeQuery query);
 
     Task<Pipeline> RetryAsync(int pipelineId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the metadata for the specified pipeline
+    /// </summary>
+    /// <param name="pipelineId">ID of the pipeline</param>
+    /// <param name="update">The metadata to update</param>
+    /// <param name="cancellationToken">The cancellation otken for the operation</param>
+    /// <seealso href="https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata" />
+    Task<Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -27,6 +27,8 @@ public partial class HttpRequestor
 
         public FormDataContent FormData { get; }
 
+        public UrlEncodedContent UrlEncodedData { get; }
+
         private MethodType Method { get; }
 
         public WebHeaderCollection Headers { get; } = new WebHeaderCollection();
@@ -63,6 +65,10 @@ public partial class HttpRequestor
             if (data is FormDataContent formData)
             {
                 FormData = formData;
+            }
+            else if (Data is UrlEncodedContent urlEncodedData)
+            {
+                UrlEncodedData = urlEncodedData;
             }
             else if (data != null)
             {
@@ -169,6 +175,10 @@ public partial class HttpRequestor
                 {
                     AddFileData(request, options);
                 }
+                else if (UrlEncodedData != null)
+                {
+                    AddUrlEncodedData(request, options);
+                }
                 else if (JsonData != null)
                 {
                     AddJsonData(request, options);
@@ -205,6 +215,14 @@ public partial class HttpRequestor
             };
 
             uploadContent.CopyToAsync(options.GetRequestStream(request)).Wait();
+        }
+
+        public void AddUrlEncodedData(HttpWebRequest request, RequestOptions options)
+        {
+            request.ContentType = "application/x-www-form-urlencoded";
+
+            using var content = new FormUrlEncodedContent(UrlEncodedData.Values);
+            content.CopyToAsync(options.GetRequestStream(request)).Wait();
         }
 
         /// <summary>

--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -222,4 +222,16 @@ public class PipelineClient : IPipelineClient
         var url = $"{_pipelinesPath}/{pipelineId.ToStringInvariant()}/retry";
         return _api.Post().ToAsync<Pipeline>(url, cancellationToken);
     }
+
+    public Task<Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
+    {
+        var updatedMetadataValues = new Dictionary<string, string>();
+
+        if (update.Name is not null)
+        {
+            updatedMetadataValues.Add("name", update.Name);
+        }
+
+        return _api.Put().With(new UrlEncodedContent(updatedMetadataValues)).ToAsync<Pipeline>($"{_pipelinesPath}/{pipelineId.ToStringInvariant()}/metadata", cancellationToken);
+    }
 }

--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -225,7 +225,7 @@ public class PipelineClient : IPipelineClient
 
     public Task<Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
     {
-        var updatedMetadataValues = new Dictionary<string, string>();
+        var updatedMetadataValues = new Dictionary<string, string>(StringComparer.Ordinal);
 
         if (update.Name is not null)
         {

--- a/NGitLab/Models/Pipeline.cs
+++ b/NGitLab/Models/Pipeline.cs
@@ -10,6 +10,9 @@ public class Pipeline
     [JsonPropertyName("id")]
     public int Id;
 
+    [JsonPropertyName("name")]
+    public string Name;
+
     [JsonPropertyName("status")]
     public JobStatus Status;
 

--- a/NGitLab/Models/Pipeline.cs
+++ b/NGitLab/Models/Pipeline.cs
@@ -11,7 +11,7 @@ public class Pipeline
     public int Id;
 
     [JsonPropertyName("name")]
-    public string Name;
+    public string Name { get; set; }
 
     [JsonPropertyName("status")]
     public JobStatus Status;

--- a/NGitLab/Models/PipelineBasic.cs
+++ b/NGitLab/Models/PipelineBasic.cs
@@ -35,5 +35,5 @@ public class PipelineBasic
     public string WebUrl;
 
     [JsonPropertyName("name")]
-    public string Name;
+    public string Name { get; set; }
 }

--- a/NGitLab/Models/PipelineBasic.cs
+++ b/NGitLab/Models/PipelineBasic.cs
@@ -33,4 +33,7 @@ public class PipelineBasic
 
     [JsonPropertyName("web_url")]
     public string WebUrl;
+
+    [JsonPropertyName("name")]
+    public string Name;
 }

--- a/NGitLab/Models/PipelineMetadataUpdate.cs
+++ b/NGitLab/Models/PipelineMetadataUpdate.cs
@@ -1,0 +1,6 @@
+﻿namespace NGitLab.Models;
+
+public class PipelineMetadataUpdate
+{
+    public string Name { get; set; }
+}

--- a/NGitLab/Models/UrlEncodedContent.cs
+++ b/NGitLab/Models/UrlEncodedContent.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace NGitLab.Models;
+
+public sealed class UrlEncodedContent
+{
+    public IReadOnlyDictionary<string, string> Values { get; }
+
+    public UrlEncodedContent(IReadOnlyDictionary<string, string> values)
+    {
+        Values = values ?? throw new System.ArgumentNullException(nameof(values));
+    }
+}

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2784,7 +2784,8 @@ NGitLab.Models.Pipeline.DetailedStatus.set -> void
 NGitLab.Models.Pipeline.Duration -> long?
 NGitLab.Models.Pipeline.FinishedAt -> System.DateTime
 NGitLab.Models.Pipeline.Id -> int
-NGitLab.Models.Pipeline.Name -> string
+NGitLab.Models.Pipeline.Name.get -> string
+NGitLab.Models.Pipeline.Name.set -> void
 NGitLab.Models.Pipeline.Pipeline() -> void
 NGitLab.Models.Pipeline.ProjectId.get -> int
 NGitLab.Models.Pipeline.ProjectId.set -> void
@@ -2801,7 +2802,8 @@ NGitLab.Models.Pipeline.YamlError -> string
 NGitLab.Models.PipelineBasic
 NGitLab.Models.PipelineBasic.CreatedAt -> System.DateTime
 NGitLab.Models.PipelineBasic.Id -> int
-NGitLab.Models.PipelineBasic.Name -> string
+NGitLab.Models.PipelineBasic.Name.get -> string
+NGitLab.Models.PipelineBasic.Name.set -> void
 NGitLab.Models.PipelineBasic.PipelineBasic() -> void
 NGitLab.Models.PipelineBasic.ProjectId -> int
 NGitLab.Models.PipelineBasic.Ref -> string

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2784,6 +2784,7 @@ NGitLab.Models.Pipeline.DetailedStatus.set -> void
 NGitLab.Models.Pipeline.Duration -> long?
 NGitLab.Models.Pipeline.FinishedAt -> System.DateTime
 NGitLab.Models.Pipeline.Id -> int
+NGitLab.Models.Pipeline.Name -> string
 NGitLab.Models.Pipeline.Pipeline() -> void
 NGitLab.Models.Pipeline.ProjectId.get -> int
 NGitLab.Models.Pipeline.ProjectId.set -> void
@@ -2800,6 +2801,7 @@ NGitLab.Models.Pipeline.YamlError -> string
 NGitLab.Models.PipelineBasic
 NGitLab.Models.PipelineBasic.CreatedAt -> System.DateTime
 NGitLab.Models.PipelineBasic.Id -> int
+NGitLab.Models.PipelineBasic.Name -> string
 NGitLab.Models.PipelineBasic.PipelineBasic() -> void
 NGitLab.Models.PipelineBasic.ProjectId -> int
 NGitLab.Models.PipelineBasic.Ref -> string

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -834,6 +834,7 @@ NGitLab.Impl.PipelineClient.RetryAsync(int pipelineId, System.Threading.Cancella
 NGitLab.Impl.PipelineClient.Search(NGitLab.Models.PipelineQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.PipelineClient.SearchAsync(NGitLab.Models.PipelineQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.PipelineClient.this[int id].get -> NGitLab.Models.Pipeline
+NGitLab.Impl.PipelineClient.UpdateMetadataAsync(int pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.Impl.ProjectClient
 NGitLab.Impl.ProjectClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.Archive(int id) -> void
@@ -1033,6 +1034,7 @@ NGitLab.IPipelineClient.RetryAsync(int pipelineId, System.Threading.Cancellation
 NGitLab.IPipelineClient.Search(NGitLab.Models.PipelineQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IPipelineClient.SearchAsync(NGitLab.Models.PipelineQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
 NGitLab.IPipelineClient.this[int id].get -> NGitLab.Models.Pipeline
+NGitLab.IPipelineClient.UpdateMetadataAsync(int pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.IProjectBadgeClient
 NGitLab.IProjectBadgeClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Badge>
 NGitLab.IProjectBadgeClient.Create(NGitLab.Models.BadgeCreate badge) -> NGitLab.Models.Badge
@@ -2845,6 +2847,10 @@ NGitLab.Models.PipelineJobQuery.PipelineId.set -> void
 NGitLab.Models.PipelineJobQuery.PipelineJobQuery() -> void
 NGitLab.Models.PipelineJobQuery.Scope.get -> string[]
 NGitLab.Models.PipelineJobQuery.Scope.set -> void
+NGitLab.Models.PipelineMetadataUpdate
+NGitLab.Models.PipelineMetadataUpdate.Name.get -> string
+NGitLab.Models.PipelineMetadataUpdate.Name.set -> void
+NGitLab.Models.PipelineMetadataUpdate.PipelineMetadataUpdate() -> void
 NGitLab.Models.PipelineOrderBy
 NGitLab.Models.PipelineOrderBy.id = 0 -> NGitLab.Models.PipelineOrderBy
 NGitLab.Models.PipelineOrderBy.ref = 2 -> NGitLab.Models.PipelineOrderBy
@@ -3861,6 +3867,9 @@ NGitLab.Models.UploadedProjectFile.Markdown.set -> void
 NGitLab.Models.UploadedProjectFile.UploadedProjectFile() -> void
 NGitLab.Models.UploadedProjectFile.Url.get -> string
 NGitLab.Models.UploadedProjectFile.Url.set -> void
+NGitLab.Models.UrlEncodedContent
+NGitLab.Models.UrlEncodedContent.UrlEncodedContent(System.Collections.Generic.IReadOnlyDictionary<string, string> values) -> void
+NGitLab.Models.UrlEncodedContent.Values.get -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 NGitLab.Models.User
 NGitLab.Models.User.AvatarURL -> string
 NGitLab.Models.User.Bio -> string


### PR DESCRIPTION
Adds method `UpdateMetadataAsync()` to `IPipelineClient` that calls the ["Update pipeline metadata" API](https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata).

The REST API currently only supports setting the pipeline name but it looks like it is designed in a way that might allow setting other values in the future, so the metadata to update is passed to `UpdateMetadataAsync()` as an object rather than individual values.
This should allow adding additional data without changing the signature of the method.



