### PR TITLE
RepositoryClient and CommitCreate updates

### DIFF
--- a/NGitLab.Mock/CommitActionChmodHandler.cs
+++ b/NGitLab.Mock/CommitActionChmodHandler.cs
@@ -1,0 +1,40 @@
+﻿#if NET7_0_OR_GREATER
+using System;
+#endif
+
+using System.IO;
+using LibGit2Sharp;
+using NGitLab.Models;
+
+namespace NGitLab.Mock;
+
+internal sealed class CommitActionChmodHandler : ICommitActionHandler
+{
+    public void Handle(CreateCommitAction action, string repoPath, LibGit2Sharp.Repository repository)
+    {
+        if (!Directory.Exists(repoPath))
+            throw new DirectoryNotFoundException();
+
+        var filePath = Path.Combine(repoPath, action.FilePath);
+
+        if (!System.IO.File.Exists(filePath))
+            throw new FileNotFoundException("File does not exist.");
+
+#if NET7_0_OR_GREATER
+        if (!OperatingSystem.IsWindows())
+        {
+            var fileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                           UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                           UnixFileMode.OtherRead | UnixFileMode.OtherWrite |
+                           (action.IsExecutable
+                               ? UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute
+                               : UnixFileMode.None);
+            System.IO.File.SetUnixFileMode(filePath, fileMode);
+        }
+#endif
+
+        var blob = repository.ObjectDatabase.CreateBlob(filePath);
+        repository.Index.Add(blob, action.FilePath, action.IsExecutable ? Mode.ExecutableFile : Mode.NonExecutableFile);
+        repository.Index.Write();
+    }
+}

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -744,6 +744,7 @@ public sealed class Repository : GitLabObject, IDisposable
             CommitAction.Delete => new CommitActionDeleteHandler(),
             CommitAction.Update => new CommitActionUpdateHandler(),
             CommitAction.Move => new CommitActionMoveHandler(),
+            CommitAction.chmod => new CommitActionChmodHandler(),
             _ => throw new NotSupportedException(),
         };
     }

--- a/NGitLab.Tests/CommitsTests.cs
+++ b/NGitLab.Tests/CommitsTests.cs
@@ -117,4 +117,32 @@ public class CommitsTests
         var latestCommit = commitClient.GetCommit(project.DefaultBranch);
         Assert.That(latestCommit.Id, Is.EqualTo(cherryPickedCommit.Id));
     }
+
+    [Test]
+    public async Task Test_commit_can_be_created_from_sha()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject(initializeWithCommits: true);
+        var commitClient = context.Client.GetCommits(project.Id);
+
+        var commit = commitClient.GetCommit("main");
+        Assert.That(commit, Is.Not.Null);
+
+        var newCommit = commitClient.Create(new CommitCreate
+        {
+            Branch = "test-start-sha",
+            CommitMessage = "New commit",
+            StartSha = commit.Id.ToString().ToLowerInvariant(),
+            Actions = new List<CreateCommitAction>
+            {
+                new CreateCommitAction
+                {
+                    Action = "create",
+                    FilePath = "file.txt",
+                    Content = "content",
+                },
+            },
+        });
+        Assert.That(newCommit, Is.Not.Null);
+    }
 }

--- a/NGitLab.Tests/CommitsTests.cs
+++ b/NGitLab.Tests/CommitsTests.cs
@@ -145,4 +145,41 @@ public class CommitsTests
         });
         Assert.That(newCommit, Is.Not.Null);
     }
+
+    [Test]
+    public async Task Test_commit_can_set_executable_flag()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject(initializeWithCommits: true);
+        var commitClient = context.Client.GetCommits(project.Id);
+
+        var commit = commitClient.GetCommit("main");
+        Assert.That(commit, Is.Not.Null);
+
+        var newCommit = commitClient.Create(new CommitCreate
+        {
+            Branch = "test-set-executable-flag",
+            CommitMessage = "New commit",
+            StartBranch = project.DefaultBranch,
+            Actions = new List<CreateCommitAction>
+            {
+                new CreateCommitAction
+                {
+                    Action = "create",
+                    FilePath = "script.sh",
+                    Content = "echo 'Hello, world!'",
+                },
+                new CreateCommitAction
+                {
+                    Action = "chmod",
+                    FilePath = "script.sh",
+                    IsExecutable = true,
+                },
+            },
+        });
+        Assert.That(newCommit, Is.Not.Null);
+
+        var diff = context.Client.GetRepository(project.Id).GetCommitDiff(newCommit.Id).Single();
+        Assert.That(diff.BMode, Is.EqualTo("100755"));
+    }
 }

--- a/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
+++ b/NGitLab.Tests/RepositoryClient/RepositoryClientTests.cs
@@ -329,6 +329,28 @@ public class RepositoryClientTests
         Assert.That(archiveItems.Where(item => item.Value is TarEntryType.RegularFile).ToList(), Has.Count.EqualTo(commitCount));
     }
 
+    [Test]
+    [NGitLabRetry]
+    public async Task GetRawBlob()
+    {
+        // Arrange
+        using var context = await RepositoryClientTestsContext.CreateAsync(commitCount: 4);
+
+        var blob = context.RepositoryClient.Tree.First(t => t.Type == ObjectType.blob);
+
+        string content = null;
+
+        // Act
+        context.RepositoryClient.GetRawBlob(blob.Id.ToString(), stream =>
+        {
+            using var reader = new StreamReader(stream);
+            content = reader.ReadToEnd();
+        });
+
+        // Assert
+        Assert.That(content, Is.Not.Null);
+    }
+
     private sealed class RepositoryClientTestsContext : IDisposable
     {
         public const string SubfolderName = "subfolder";

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -52,7 +52,7 @@ public class RepositoryClient : IRepositoryClient
 
     public void GetRawBlob(string sha, Action<Stream> parser)
     {
-        _api.Get().Stream(_repoPath + "/raw_blobs/" + sha, parser);
+        _api.Get().Stream(_repoPath + "/blobs/" + sha + "/raw", parser);
     }
 
     public void GetArchive(Action<Stream> parser)

--- a/NGitLab/Models/CommitCreate.cs
+++ b/NGitLab/Models/CommitCreate.cs
@@ -54,4 +54,7 @@ public class CreateCommitAction
 
     [JsonPropertyName("encoding")]
     public string Encoding { get; set; }
+
+    [JsonPropertyName("execute_filemode")]
+    public bool IsExecutable { get; set; }
 }

--- a/NGitLab/Models/CommitCreate.cs
+++ b/NGitLab/Models/CommitCreate.cs
@@ -22,6 +22,9 @@ public class CommitCreate
     [JsonPropertyName("start_branch")]
     public string StartBranch;
 
+    [JsonPropertyName("start_sha")]
+    public string StartSha;
+
     [JsonPropertyName("author_email")]
     public string AuthorEmail;
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1565,6 +1565,8 @@ NGitLab.Models.CreateCommitAction.Encoding.get -> string
 NGitLab.Models.CreateCommitAction.Encoding.set -> void
 NGitLab.Models.CreateCommitAction.FilePath.get -> string
 NGitLab.Models.CreateCommitAction.FilePath.set -> void
+NGitLab.Models.CreateCommitAction.IsExecutable.get -> bool
+NGitLab.Models.CreateCommitAction.IsExecutable.set -> void
 NGitLab.Models.CreateCommitAction.PreviousPath.get -> string
 NGitLab.Models.CreateCommitAction.PreviousPath.set -> void
 NGitLab.Models.Deployment

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1480,6 +1480,7 @@ NGitLab.Models.CommitCreate.CommitMessage -> string
 NGitLab.Models.CommitCreate.Force -> bool?
 NGitLab.Models.CommitCreate.ProjectId -> int
 NGitLab.Models.CommitCreate.StartBranch -> string
+NGitLab.Models.CommitCreate.StartSha -> string
 NGitLab.Models.CommitInfo
 NGitLab.Models.CommitInfo.AuthoredDate -> System.DateTime
 NGitLab.Models.CommitInfo.AuthorEmail -> string


### PR DESCRIPTION
* fixing raw blob api [endpoint](https://docs.gitlab.com/ee/api/repositories.html#raw-blob-content)
* adding support for creating a commit based upon a commit sha
* adding support for setting the executable flag on a file in a new commit