### PR TITLE
Add Page property to control pagination. Add asynchronous support for GetCommits, GetCommit, and GetCommitDiff

### DIFF
--- a/NGitLab.Mock/Clients/CommitClient.cs
+++ b/NGitLab.Mock/Clients/CommitClient.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
 using NGitLab.Mock.Internals;
 using NGitLab.Models;
 
@@ -35,6 +37,12 @@ internal sealed class CommitClient : ClientBase, ICommitClient
 
             return commit?.ToCommitClient(project);
         }
+    }
+
+    public async Task<Commit> GetCommitAsync(string @ref, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return GetCommit(@ref);
     }
 
     public Commit CherryPick(CommitCherryPick cherryPick)

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Mock.Internals;
 using NGitLab.Models;
 
@@ -103,12 +106,36 @@ internal sealed class RepositoryClient : ClientBase, IRepositoryClient
         }
     }
 
+    public async IAsyncEnumerable<Commit> GetCommitsAsync(GetCommitsRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(_projectId, ProjectPermission.View);
+            foreach (var commit in project.Repository.GetCommits(request))
+            {
+                yield return ConvertToNGitLabCommit(commit, project);
+            }
+        }
+    }
+
     public Commit GetCommit(Sha1 sha)
     {
         throw new NotImplementedException();
     }
 
+    public Task<Commit> GetCommitAsync(Sha1 sha, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
     public IEnumerable<Diff> GetCommitDiff(Sha1 sha)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IAsyncEnumerable<Diff> GetCommitDiffAsync(Sha1 sha, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab/GetCommitsRequest.cs
+++ b/NGitLab/GetCommitsRequest.cs
@@ -16,6 +16,8 @@ public class GetCommitsRequest
 
     public uint PerPage { get; set; } = DefaultPerPage;
 
+    public uint? Page { get; set; }
+
     public DateTime? Since { get; set; }
 
     public DateTime? Until { get; set; }

--- a/NGitLab/ICommitClient.cs
+++ b/NGitLab/ICommitClient.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
 using NGitLab.Models;
 
 namespace NGitLab;
@@ -21,6 +23,11 @@ public interface ICommitClient
     /// Get a specific commit identified by the commit hash or name of a branch or tag.
     /// </summary>
     Commit GetCommit(string @ref);
+
+    /// <summary>
+    /// Get a specific commit identified by the commit hash or name of a branch or tag.
+    /// </summary>
+    Task<Commit> GetCommitAsync(string @ref, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cherry-picks a commit to a given branch.

--- a/NGitLab/IRepositoryClient.cs
+++ b/NGitLab/IRepositoryClient.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Models;
 
 namespace NGitLab;
@@ -37,9 +39,15 @@ public interface IRepositoryClient
     /// </summary>
     IEnumerable<Commit> GetCommits(GetCommitsRequest request);
 
+    IAsyncEnumerable<Commit> GetCommitsAsync(GetCommitsRequest request, CancellationToken cancellationToken = default);
+
     Commit GetCommit(Sha1 sha);
 
+    Task<Commit> GetCommitAsync(Sha1 sha, CancellationToken cancellationToken = default);
+
     IEnumerable<Diff> GetCommitDiff(Sha1 sha);
+
+    IAsyncEnumerable<Diff> GetCommitDiffAsync(Sha1 sha, CancellationToken cancellationToken = default);
 
     IEnumerable<Ref> GetCommitRefs(Sha1 sha, CommitRefType type = CommitRefType.All);
 

--- a/NGitLab/Impl/CommitClient.cs
+++ b/NGitLab/Impl/CommitClient.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -26,6 +28,11 @@ public class CommitClient : ICommitClient
     public Commit GetCommit(string @ref)
     {
         return _api.Get().To<Commit>(_repoPath + $"/commits/{@ref}");
+    }
+    
+    public Task<Commit> GetCommitAsync(string @ref, CancellationToken cancellationToken = default)
+    {
+        return _api.Get().ToAsync<Commit>(_repoPath + $"/commits/{@ref}", cancellationToken);
     }
 
     public Commit CherryPick(CommitCherryPick cherryPick)

--- a/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/Impl/HttpRequestor.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using NGitLab.Impl.Json;
 using NGitLab.Models;
 
@@ -212,8 +214,9 @@ public partial class HttpRequestor : IHttpRequestor
                 var request = new GitLabRequest(nextUrlToLoad, MethodType.Get, data: null, _apiToken, _options);
                 using (var response = await request.GetResponseAsync(_options, cancellationToken).ConfigureAwait(false))
                 {
-                    nextUrlToLoad = GetNextPageUrl(response);
-
+                    NameValueCollection queryParameters = HttpUtility.ParseQueryString(_startUrl.Query);
+                    nextUrlToLoad = queryParameters["page"] is null ? GetNextPageUrl(response) : null;
+                    
                     using var stream = response.GetResponseStream();
                     responseText = await ReadTextAsync(stream).ConfigureAwait(false);
                 }
@@ -233,8 +236,9 @@ public partial class HttpRequestor : IHttpRequestor
                 var request = new GitLabRequest(nextUrlToLoad, MethodType.Get, data: null, _apiToken, _options);
                 using (var response = request.GetResponse(_options))
                 {
-                    nextUrlToLoad = GetNextPageUrl(response);
-
+                    NameValueCollection queryParameters = HttpUtility.ParseQueryString(_startUrl.Query);
+                    nextUrlToLoad = queryParameters["page"] is null? GetNextPageUrl(response) : null;
+                    
                     using var stream = response.GetResponseStream();
                     responseText = ReadText(stream);
                 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -34,6 +34,8 @@ NGitLab.GetCommitsRequest.FirstParent.set -> void
 NGitLab.GetCommitsRequest.GetCommitsRequest() -> void
 NGitLab.GetCommitsRequest.MaxResults.get -> int
 NGitLab.GetCommitsRequest.MaxResults.set -> void
+NGitLab.GetCommitsRequest.Page.get -> uint?
+NGitLab.GetCommitsRequest.Page.set -> void
 NGitLab.GetCommitsRequest.Path.get -> string
 NGitLab.GetCommitsRequest.Path.set -> void
 NGitLab.GetCommitsRequest.PerPage.get -> uint
@@ -152,6 +154,7 @@ NGitLab.ICommitClient
 NGitLab.ICommitClient.CherryPick(NGitLab.Models.CommitCherryPick cherryPick) -> NGitLab.Models.Commit
 NGitLab.ICommitClient.Create(NGitLab.Models.CommitCreate commit) -> NGitLab.Models.Commit
 NGitLab.ICommitClient.GetCommit(string ref) -> NGitLab.Models.Commit
+NGitLab.ICommitClient.GetCommitAsync(string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.ICommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.ICommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.ICommitStatusClient
@@ -519,6 +522,7 @@ NGitLab.Impl.CommitClient.CommitClient(NGitLab.Impl.API api, int projectId) -> v
 NGitLab.Impl.CommitClient.CommitClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitClient.Create(NGitLab.Models.CommitCreate commit) -> NGitLab.Models.Commit
 NGitLab.Impl.CommitClient.GetCommit(string ref) -> NGitLab.Models.Commit
+NGitLab.Impl.CommitClient.GetCommitAsync(string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.Impl.CommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.Impl.CommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.CommitStatusClient
@@ -910,10 +914,13 @@ NGitLab.Impl.RepositoryClient.Contributors.get -> NGitLab.IContributorClient
 NGitLab.Impl.RepositoryClient.Files.get -> NGitLab.IFilesClient
 NGitLab.Impl.RepositoryClient.GetArchive(System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.RepositoryClient.GetCommit(NGitLab.Sha1 sha) -> NGitLab.Models.Commit
+NGitLab.Impl.RepositoryClient.GetCommitAsync(NGitLab.Sha1 sha, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Diff>
+NGitLab.Impl.RepositoryClient.GetCommitDiffAsync(NGitLab.Sha1 sha, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<NGitLab.Models.Diff>
 NGitLab.Impl.RepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.Impl.RepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.Impl.RepositoryClient.GetCommitsAsync(NGitLab.GetCommitsRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.RepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
@@ -1139,10 +1146,13 @@ NGitLab.IRepositoryClient.Contributors.get -> NGitLab.IContributorClient
 NGitLab.IRepositoryClient.Files.get -> NGitLab.IFilesClient
 NGitLab.IRepositoryClient.GetArchive(System.Action<System.IO.Stream> parser) -> void
 NGitLab.IRepositoryClient.GetCommit(NGitLab.Sha1 sha) -> NGitLab.Models.Commit
+NGitLab.IRepositoryClient.GetCommitAsync(NGitLab.Sha1 sha, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Diff>
+NGitLab.IRepositoryClient.GetCommitDiffAsync(NGitLab.Sha1 sha, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<NGitLab.Models.Diff>
 NGitLab.IRepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.IRepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.IRepositoryClient.GetCommitsAsync(NGitLab.GetCommitsRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.IRepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.IRepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>


### PR DESCRIPTION
Added a `Page` property to control pagination, helping to avoid unnecessary data fetches.
Introduced asynchronous support for the following methods: GetCommits, GetCommit, and GetCommitDiff.