### PR TITLE
Add FailureReason to JobBasic

### DIFF
--- a/NGitLab.Mock/Job.cs
+++ b/NGitLab.Mock/Job.cs
@@ -38,6 +38,8 @@ public sealed class Job : GitLabObject
 
     public bool AllowFailure { get; set; }
 
+    public string FailureReason { get; set; }
+
     public User User { get; set; }
 
     public string WebUrl => Server.MakeUrl($"{Project.PathWithNamespace}/-/jobs/{Id.ToString(CultureInfo.InvariantCulture)}");
@@ -84,6 +86,7 @@ public sealed class Job : GitLabObject
             Duration = Duration,
             TagList = TagList,
             QueuedDuration = QueuedDuration,
+            FailureReason = FailureReason,
         };
     }
 
@@ -118,6 +121,7 @@ public sealed class Job : GitLabObject
             },
             Status = Status,
             AllowFailure = AllowFailure,
+            FailureReason = FailureReason,
             Tag = Tag,
             User = User?.ToClientUser(),
             WebUrl = WebUrl,
@@ -149,6 +153,7 @@ public sealed class Job : GitLabObject
             Duration = Duration,
             TagList = TagList,
             QueuedDuration = QueuedDuration,
+            FailureReason = FailureReason,
         };
     }
 }

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -572,6 +572,8 @@ NGitLab.Mock.Job.DownstreamPipeline.get -> NGitLab.Mock.Pipeline
 NGitLab.Mock.Job.DownstreamPipeline.set -> void
 NGitLab.Mock.Job.Duration.get -> float?
 NGitLab.Mock.Job.Duration.set -> void
+NGitLab.Mock.Job.FailureReason.get -> string
+NGitLab.Mock.Job.FailureReason.set -> void
 NGitLab.Mock.Job.FinishedAt.get -> System.DateTime
 NGitLab.Mock.Job.FinishedAt.set -> void
 NGitLab.Mock.Job.Id.get -> int

--- a/NGitLab/Models/JobBasic.cs
+++ b/NGitLab/Models/JobBasic.cs
@@ -59,6 +59,9 @@ public class JobBasic
     [JsonPropertyName("tag_list")]
     public string[] TagList { get; set; }
 
+    [JsonPropertyName("failure_reason")]
+    public string FailureReason { get; set; }
+
     public class JobPipeline
     {
         [JsonPropertyName("id")]

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2253,6 +2253,8 @@ NGitLab.Models.JobArtifactQuery.RefName.get -> string
 NGitLab.Models.JobArtifactQuery.RefName.set -> void
 NGitLab.Models.JobBasic
 NGitLab.Models.JobBasic.Commit.get -> NGitLab.Models.Commit
+NGitLab.Models.JobBasic.FailureReason.get -> string
+NGitLab.Models.JobBasic.FailureReason.set -> void
 NGitLab.Models.JobBasic.JobBasic() -> void
 NGitLab.Models.JobBasic.JobPipeline.JobPipeline() -> void
 NGitLab.Models.JobBasic.JobPipeline.ProjectId.get -> int


### PR DESCRIPTION
Adds the `failure_reason` that is returned from the jobs endpoints to JobBasic 