### PR TITLE
Create the 'test-dependencies' NuGet group in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,10 @@ updates:
           - 'System.*'
         exclude-patterns:
           - 'Microsoft.Playwright'
+      test-dependencies:
+        patterns:
+          - 'coverlet.collector'
+          - 'FluentAssertions'
+          - 'Microsoft.Playwright'
+          - 'NSubstitute'
+          - '*NUnit*'


### PR DESCRIPTION
In a little more than a week, [6 `dependabot` PRs were created, 4 of which to update test dependencies](https://github.com/ubisoft/NGitLab/pulls?q=is%3Apr+is%3Aclosed+closed%3A2024-11-04..2024-11-12+). If the latter had been grouped, we would have wound up with 2 PRs instead of 4.

Bundle updates of test dependencies together.