### PR TITLE
Further tweak dependabot.yml to resolve warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'docker'
-    directory: '/'
-    schedule:
-      interval: weekly
-    rebase-strategy: auto
-    open-pull-requests-limit: 20
-
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -22,13 +15,6 @@ updates:
       github-actions:
         patterns:
           - '*'
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: weekly
-    rebase-strategy: auto
-    open-pull-requests-limit: 20
 
   - package-ecosystem: 'nuget'
     directory: '/'


### PR DESCRIPTION
Address the following warnings:  

> **Dependabot couldn't find a Dockerfile**
> Dependabot requires a Dockerfile to evaluate your Docker dependencies. It had expected to find one at the path: `/Dockerfile`.
>
> If this isn't a Docker project, you may wish to disable updates for it in the `.github/dependabot.yml` config file in this repo.

> **Dependabot couldn't find a package.json**
> Dependabot requires a package.json to evaluate your JavaScript dependencies. It had expected to find one at the path: `/package.json`.
>
> If this isn't a JavaScript project, you may wish to disable updates for it in the `.github/dependabot.yml` config file in this repo.