### PR TITLE
Event's ID exccess the int.max, it should be long

### DIFF
--- a/NGitLab.Mock/Event.cs
+++ b/NGitLab.Mock/Event.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Mock;
 
 public sealed class Event : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Title { get; set; }
 


### PR DESCRIPTION
We got json deserlize exception when pulling events for a user. 
The Id should be `long`.