### PR TITLE
Event's Id sould be long type

### DIFF
--- a/NGitLab.Mock/Event.cs
+++ b/NGitLab.Mock/Event.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Mock;
 
 public sealed class Event : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Title { get; set; }
 

--- a/NGitLab.Mock/EventCollection.cs
+++ b/NGitLab.Mock/EventCollection.cs
@@ -68,7 +68,7 @@ public sealed class EventCollection : Collection<Event>
         return events;
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(evt => evt.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab/Models/Event.cs
+++ b/NGitLab/Models/Event.cs
@@ -10,7 +10,7 @@ namespace NGitLab.Models;
 public class Event
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("title")]
     public string Title { get; set; }


### PR DESCRIPTION
We got json deserialize exception when loading events for an user.

As the 'Id' field overflows integer. So it has to be long.