### PR TITLE
Replace int IDs by long ones + a few more changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Authors>$(Company), NGitLab contributors</Authors>
 
     <!-- Compile Options -->
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <Deterministic>true</Deterministic>
     <Features>strict</Features>
     <TreatWarningsAsErrors Condition="'$(Configuration)' != 'Debug'">true</TreatWarningsAsErrors>

--- a/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
+++ b/NGitLab.Mock.Tests/MergeRequestsMockTests.cs
@@ -57,7 +57,7 @@ public class MergeRequestsMockTests
             .BuildServer();
 
         var client = server.CreateClient("user1");
-        var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { ApproverIds = new[] { 1 } }).ToArray();
+        var mergeRequests = client.MergeRequests.Get(new MergeRequestQuery { ApproverIds = [1L] }).ToArray();
 
         Assert.That(mergeRequests, Has.Length.EqualTo(1), "Merge requests count is invalid");
         Assert.That(mergeRequests[0].Title, Is.EqualTo("Merge request 2"), "Merge request found is invalid");

--- a/NGitLab.Mock.Tests/MilestonesMockTests.cs
+++ b/NGitLab.Mock.Tests/MilestonesMockTests.cs
@@ -103,8 +103,8 @@ public class MilestonesMockTests
     [Test]
     public void Test_projects_merge_request_can_be_found_from_milestone()
     {
-        const int ProjectId = 1;
-        const int MilestoneId = 1;
+        const long ProjectId = 1;
+        const long MilestoneId = 1;
         using var server = new GitLabConfig()
             .WithUser("user1", isDefault: true)
             .WithProject("Test", id: ProjectId, addDefaultUserAsMaintainer: true, configure: project => project
@@ -122,8 +122,8 @@ public class MilestonesMockTests
     [Test]
     public void Test_groups_merge_request_can_be_found_from_milestone()
     {
-        const int projectId = 1;
-        const int milestoneId = 1;
+        const long projectId = 1;
+        const long milestoneId = 1;
         using var server = new GitLabConfig()
             .WithUser("user1", isDefault: true)
             .WithGroup("parentGroup", id: projectId, configure: group => group

--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -213,7 +214,7 @@ public class ProjectsMockTests
         {
             Name = "MyProject",
             Path = "my-project",
-            NamespaceId = "my-group",
+            NamespaceId = server.Groups.First(g => string.Equals(g.Name, "MyGroup", StringComparison.Ordinal)).Id,
             Description = "Description",
             DefaultBranch = "foo",
             InitializeWithReadme = true,
@@ -228,7 +229,7 @@ public class ProjectsMockTests
         actual.Name.Should().Be(expected.Name);
         actual.Path.Should().Be(expected.Path);
         actual.Description.Should().Be(expected.Description);
-        actual.Namespace.FullPath.Should().Be(expected.NamespaceId);
+        actual.Namespace.Id.Should().Be(expected.NamespaceId);
         actual.NameWithNamespace.Should().Be($"MyGroup / {expected.Name}");
         actual.PathWithNamespace.Should().Be($"my-group/{expected.Path}");
         actual.DefaultBranch.Should().Be(expected.DefaultBranch);

--- a/NGitLab.Mock/Badge.cs
+++ b/NGitLab.Mock/Badge.cs
@@ -4,7 +4,7 @@ namespace NGitLab.Mock;
 
 public sealed class Badge : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string LinkUrl { get; set; }
 

--- a/NGitLab.Mock/BadgeCollection.cs
+++ b/NGitLab.Mock/BadgeCollection.cs
@@ -10,7 +10,7 @@ public sealed class BadgeCollection : Collection<Badge>
     {
     }
 
-    public Badge GetById(int id)
+    public Badge GetById(long id)
     {
         return this.FirstOrDefault(badge => badge.Id == id);
     }

--- a/NGitLab.Mock/Clients/BranchClient.cs
+++ b/NGitLab.Mock/Clients/BranchClient.cs
@@ -8,9 +8,9 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class BranchClient : ClientBase, IBranchClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
-    public BranchClient(ClientContext context, int projectId)
+    public BranchClient(ClientContext context, long projectId)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/ClientBase.cs
+++ b/NGitLab.Mock/Clients/ClientBase.cs
@@ -30,7 +30,7 @@ internal abstract class ClientBase
 
         var group = id switch
         {
-            int idInt => Server.AllGroups.FindById(idInt),
+            long idLong => Server.AllGroups.FindById(idLong),
             string idStr => Server.AllGroups.FindGroup(idStr),
             IIdOrPathAddressable gid when gid.Path != null => Server.AllGroups.FindByNamespacedPath(gid.Path),
             IIdOrPathAddressable gid => Server.AllGroups.FindById(gid.Id),
@@ -78,7 +78,7 @@ internal abstract class ClientBase
 
         var project = id switch
         {
-            int idInt => Server.AllProjects.FindById(idInt),
+            long idLong => Server.AllProjects.FindById(idLong),
             string idStr => Server.AllProjects.FindProject(idStr),
             IIdOrPathAddressable pid when pid.Path != null => Server.AllProjects.FindByNamespacedPath(pid.Path),
             IIdOrPathAddressable pid => Server.AllProjects.FindById(pid.Id),
@@ -116,7 +116,7 @@ internal abstract class ClientBase
         return project;
     }
 
-    protected User GetUser(int userId)
+    protected User GetUser(long userId)
     {
         var user = Server.Users.GetById(userId);
         if (user == null)
@@ -125,7 +125,7 @@ internal abstract class ClientBase
         return user;
     }
 
-    protected Issue GetIssue(int projectId, int issueId)
+    protected Issue GetIssue(long projectId, long issueId)
     {
         var project = GetProject(projectId, ProjectPermission.View);
         var issue = project.Issues.GetByIid(issueId);
@@ -135,7 +135,7 @@ internal abstract class ClientBase
         return issue;
     }
 
-    protected Milestone GetMilestone(int projectId, int milestoneId)
+    protected Milestone GetMilestone(long projectId, long milestoneId)
     {
         var project = GetProject(projectId, ProjectPermission.View);
         var milestone = project.Milestones.GetByIid(milestoneId);
@@ -145,7 +145,7 @@ internal abstract class ClientBase
         return milestone;
     }
 
-    protected MergeRequest GetMergeRequest(int projectId, int mergeRequestIid)
+    protected MergeRequest GetMergeRequest(long projectId, long mergeRequestIid)
     {
         var project = GetProject(projectId, ProjectPermission.View);
         var mergeRequest = project.MergeRequests.GetByIid(mergeRequestIid);

--- a/NGitLab.Mock/Clients/ClusterClient.cs
+++ b/NGitLab.Mock/Clients/ClusterClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ClusterClient : ClientBase, IClusterClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ClusterClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/CommitClient.cs
+++ b/NGitLab.Mock/Clients/CommitClient.cs
@@ -7,7 +7,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class CommitClient : ClientBase, ICommitClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public CommitClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/CommitStatusClient.cs
+++ b/NGitLab.Mock/Clients/CommitStatusClient.cs
@@ -7,7 +7,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class CommitStatusClient : ClientBase, ICommitStatusClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public CommitStatusClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ContributorClient.cs
+++ b/NGitLab.Mock/Clients/ContributorClient.cs
@@ -8,9 +8,9 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ContributorClient : ClientBase, IContributorClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
-    public ContributorClient(ClientContext context, int projectId)
+    public ContributorClient(ClientContext context, long projectId)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/EnvironmentClient.cs
+++ b/NGitLab.Mock/Clients/EnvironmentClient.cs
@@ -10,7 +10,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class EnvironmentClient : ClientBase, IEnvironmentClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public EnvironmentClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -25,20 +25,20 @@ internal sealed class EnvironmentClient : ClientBase, IEnvironmentClient
         throw new NotImplementedException();
     }
 
-    public void Delete(int environmentId)
+    public void Delete(long environmentId)
     {
         throw new NotImplementedException();
     }
 
-    public EnvironmentInfo Edit(int environmentId, string externalUrl) => Edit(environmentId, null, externalUrl);
+    public EnvironmentInfo Edit(long environmentId, string externalUrl) => Edit(environmentId, null, externalUrl);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public EnvironmentInfo Edit(int environmentId, string name, string externalUrl)
+    public EnvironmentInfo Edit(long environmentId, string name, string externalUrl)
     {
         throw new NotImplementedException();
     }
 
-    public EnvironmentInfo Stop(int environmentId)
+    public EnvironmentInfo Stop(long environmentId)
     {
         throw new NotImplementedException();
     }
@@ -48,12 +48,12 @@ internal sealed class EnvironmentClient : ClientBase, IEnvironmentClient
         return GitLabCollectionResponse.Create(Array.Empty<EnvironmentInfo>());
     }
 
-    public EnvironmentInfo GetById(int environmentId)
+    public EnvironmentInfo GetById(long environmentId)
     {
         throw new NotImplementedException();
     }
 
-    public Task<EnvironmentInfo> GetByIdAsync(int environmentId, CancellationToken cancellationToken = default)
+    public Task<EnvironmentInfo> GetByIdAsync(long environmentId, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/EventClient.cs
+++ b/NGitLab.Mock/Clients/EventClient.cs
@@ -6,15 +6,15 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class EventClient : ClientBase, IEventClient
 {
-    private readonly int? _userId;
-    private readonly int? _projectId;
+    private readonly long? _userId;
+    private readonly long? _projectId;
 
     public EventClient(ClientContext context)
         : base(context)
     {
     }
 
-    public EventClient(ClientContext context, int? userId = null, ProjectId? projectId = null)
+    public EventClient(ClientContext context, long? userId = null, ProjectId? projectId = null)
         : base(context)
     {
         _userId = userId;

--- a/NGitLab.Mock/Clients/FileClient.cs
+++ b/NGitLab.Mock/Clients/FileClient.cs
@@ -8,9 +8,9 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class FileClient : ClientBase, IFilesClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
-    public FileClient(ClientContext context, int projectId)
+    public FileClient(ClientContext context, long projectId)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/GitLabClient.cs
+++ b/NGitLab.Mock/Clients/GitLabClient.cs
@@ -20,8 +20,6 @@ internal sealed class GitLabClient : ClientBase, IGitLabClient
 
     public IMembersClient Members => new MembersClient(Context);
 
-    public ICommitClient GetCommits(int projectId) => GetCommits((long)projectId);
-
     public ICommitClient GetCommits(ProjectId projectId) => new CommitClient(Context, projectId);
 
     public IIssueClient Issues => new IssueClient(Context);
@@ -58,100 +56,56 @@ internal sealed class GitLabClient : ClientBase, IGitLabClient
 
     public IEventClient GetEvents() => new EventClient(Context);
 
-    public IEventClient GetUserEvents(int userId) => new EventClient(Context, userId);
-
-    public IEventClient GetProjectEvents(int projectId) => GetProjectEvents((long)projectId);
+    public IEventClient GetUserEvents(long userId) => new EventClient(Context, userId);
 
     public IEventClient GetProjectEvents(ProjectId projectId) => new EventClient(Context, null, projectId);
 
-    public ICommitStatusClient GetCommitStatus(int projectId) => GetCommitStatus((long)projectId);
-
     public ICommitStatusClient GetCommitStatus(ProjectId projectId) => new CommitStatusClient(Context, projectId);
-
-    public IEnvironmentClient GetEnvironmentClient(int projectId) => GetEnvironmentClient((long)projectId);
 
     public IEnvironmentClient GetEnvironmentClient(ProjectId projectId) => new EnvironmentClient(Context, projectId);
 
-    public IClusterClient GetClusterClient(int projectId) => GetClusterClient((long)projectId);
-
     public IClusterClient GetClusterClient(ProjectId projectId) => new ClusterClient(Context, projectId);
-
-    public IGroupBadgeClient GetGroupBadgeClient(int groupId) => GetGroupBadgeClient((long)groupId);
 
     public IGroupBadgeClient GetGroupBadgeClient(GroupId groupId) => new GroupBadgeClient(Context, groupId);
 
-    public IGroupVariableClient GetGroupVariableClient(int groupId) => GetGroupVariableClient((long)groupId);
-
     public IGroupVariableClient GetGroupVariableClient(GroupId groupId) => new GroupVariableClient(Context, groupId);
 
-    public IJobClient GetJobs(int projectId) => GetJobs((long)projectId);
-
     public IJobClient GetJobs(ProjectId projectId) => new JobClient(Context, projectId);
-
-    public IMergeRequestClient GetMergeRequest(int projectId) => GetMergeRequest((long)projectId);
 
     public IMergeRequestClient GetMergeRequest(ProjectId projectId) => new MergeRequestClient(Context, projectId);
 
     public IMergeRequestClient GetGroupMergeRequest(GroupId groupId) => new MergeRequestClient(Context, groupId);
 
-    public IMilestoneClient GetMilestone(int projectId) => GetMilestone((long)projectId);
-
     public IMilestoneClient GetMilestone(ProjectId projectId) => new MilestoneClient(Context, projectId, MilestoneScope.Projects);
-
-    public IMilestoneClient GetGroupMilestone(int groupId) => GetGroupMilestone((long)groupId);
 
     public IMilestoneClient GetGroupMilestone(GroupId groupId) => new MilestoneClient(Context, groupId, MilestoneScope.Groups);
 
-    public IReleaseClient GetReleases(int projectId) => GetReleases((long)projectId);
-
     public IReleaseClient GetReleases(ProjectId projectId) => new ReleaseClient(Context, projectId);
-
-    public IPipelineClient GetPipelines(int projectId) => GetPipelines((long)projectId);
 
     public IPipelineClient GetPipelines(ProjectId projectId) => new PipelineClient(Context, jobClient: GetJobs(projectId), projectId: projectId);
 
     public IPipelineScheduleClient GetPipelineSchedules(ProjectId projectId)
         => new PipelineScheduleClient(Context, projectId);
 
-    public IProjectBadgeClient GetProjectBadgeClient(int projectId) => GetProjectBadgeClient((long)projectId);
-
     public IProjectBadgeClient GetProjectBadgeClient(ProjectId projectId) => new ProjectBadgeClient(Context, projectId);
-
-    public IProjectIssueNoteClient GetProjectIssueNoteClient(int projectId) => GetProjectIssueNoteClient((long)projectId);
 
     public IProjectIssueNoteClient GetProjectIssueNoteClient(ProjectId projectId) => new ProjectIssueNoteClient(Context, projectId);
 
-    public IProjectVariableClient GetProjectVariableClient(int projectId) => GetProjectVariableClient((long)projectId);
-
     public IProjectVariableClient GetProjectVariableClient(ProjectId projectId) => new ProjectVariableClient(Context, projectId);
-
-    public IRepositoryClient GetRepository(int projectId) => GetRepository((long)projectId);
 
     public IRepositoryClient GetRepository(ProjectId projectId) => new RepositoryClient(Context, projectId);
 
-    public ITriggerClient GetTriggers(int projectId) => GetTriggers((long)projectId);
-
     public ITriggerClient GetTriggers(ProjectId projectId) => new TriggerClient(Context, projectId);
-
-    public IWikiClient GetWikiClient(int projectId) => GetWikiClient((long)projectId);
 
     public IWikiClient GetWikiClient(ProjectId projectId) => new WikiClient(Context, projectId);
 
-    public IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(int projectId) => GetProjectLevelApprovalRulesClient((long)projectId);
-
     public IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(ProjectId projectId) => new ProjectLevelApprovalRulesClient(Context, projectId);
-
-    public IProtectedBranchClient GetProtectedBranchClient(int projectId) => GetProtectedBranchClient((long)projectId);
 
     public IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId) => new ProtectedBranchClient(Context, projectId);
 
     public IProtectedTagClient GetProtectedTagClient(ProjectId projectId) => new ProtectedTagClient(Context, projectId);
 
-    public ISearchClient GetGroupSearchClient(int groupId) => GetGroupSearchClient((long)groupId);
-
     public ISearchClient GetGroupSearchClient(GroupId groupId) => new GroupSearchClient(Context, groupId);
-
-    public ISearchClient GetProjectSearchClient(int projectId) => GetProjectSearchClient((long)projectId);
 
     public ISearchClient GetProjectSearchClient(ProjectId projectId) => new ProjectSearchClient(Context, projectId);
 

--- a/NGitLab.Mock/Clients/GroupBadgeClient.cs
+++ b/NGitLab.Mock/Clients/GroupBadgeClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class GroupBadgeClient : ClientBase, IGroupBadgeClient
 {
-    private readonly int _groupId;
+    private readonly long _groupId;
 
     public GroupBadgeClient(ClientContext context, GroupId groupId)
         : base(context)
@@ -14,7 +14,7 @@ internal sealed class GroupBadgeClient : ClientBase, IGroupBadgeClient
         _groupId = Server.AllGroups.FindGroup(groupId.ValueAsString()).Id;
     }
 
-    public Models.Badge this[int id]
+    public Models.Badge this[long id]
     {
         get
         {
@@ -53,7 +53,7 @@ internal sealed class GroupBadgeClient : ClientBase, IGroupBadgeClient
         }
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         EnsureUserIsAuthenticated();
 
@@ -69,7 +69,7 @@ internal sealed class GroupBadgeClient : ClientBase, IGroupBadgeClient
         }
     }
 
-    public Models.Badge Update(int id, BadgeUpdate badge)
+    public Models.Badge Update(long id, BadgeUpdate badge)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/GroupClient.cs
+++ b/NGitLab.Mock/Clients/GroupClient.cs
@@ -67,7 +67,7 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
         return Create(group);
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -83,7 +83,7 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         Delete(id);
@@ -148,7 +148,7 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
         return new(page, all.Length > PagedResponse.MaxQueryCountLimit ? null : all.Length);
     }
 
-    public Models.Group this[int id] => GetGroup(id);
+    public Models.Group this[long id] => GetGroup(id);
 
     public Models.Group this[string fullPath] => GetGroup(fullPath);
 
@@ -167,7 +167,7 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
 
     public Task<Models.Group> GetByFullPathAsync(string fullPath, CancellationToken cancellationToken = default) => GetGroupAsync(fullPath, cancellationToken);
 
-    public Task<Models.Group> GetByIdAsync(int id, CancellationToken cancellationToken = default) => GetGroupAsync(id, cancellationToken);
+    public Task<Models.Group> GetByIdAsync(long id, CancellationToken cancellationToken = default) => GetGroupAsync(id, cancellationToken);
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
     public async Task<Models.Group> GetGroupAsync(GroupId groupId, CancellationToken cancellationToken = default)
@@ -176,12 +176,12 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
         return GetGroup(groupId);
     }
 
-    public void Restore(int id)
+    public void Restore(long id)
     {
         throw new NotImplementedException();
     }
 
-    public async Task RestoreAsync(int id, CancellationToken cancellationToken = default)
+    public async Task RestoreAsync(long id, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         Restore(id);
@@ -197,13 +197,13 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
         return GitLabCollectionResponse.Create(Search(search));
     }
 
-    public IEnumerable<Models.Project> SearchProjects(int groupId, string search) =>
+    public IEnumerable<Models.Project> SearchProjects(long groupId, string search) =>
         SearchProjectsAsync(groupId, new GroupProjectsQuery
         {
             Search = search,
         });
 
-    public GitLabCollectionResponse<Models.Project> GetProjectsAsync(int groupId, GroupProjectsQuery query) => SearchProjectsAsync(groupId, query);
+    public GitLabCollectionResponse<Models.Project> GetProjectsAsync(long groupId, GroupProjectsQuery query) => SearchProjectsAsync(groupId, query);
 
     public GitLabCollectionResponse<Models.Project> SearchProjectsAsync(GroupId groupId, GroupProjectsQuery query)
     {
@@ -263,7 +263,7 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
         return new(page, all.Length > PagedResponse.MaxQueryCountLimit ? null : all.Length);
     }
 
-    public Models.Group Update(int id, GroupUpdate groupUpdate)
+    public Models.Group Update(long id, GroupUpdate groupUpdate)
     {
         using (Context.BeginOperationScope())
         {
@@ -319,13 +319,13 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<Models.Group> UpdateAsync(int id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default)
+    public async Task<Models.Group> UpdateAsync(long id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return Update(id, groupUpdate);
     }
 
-    public GitLabCollectionResponse<Models.Group> GetSubgroupsByIdAsync(int id, SubgroupQuery query = null) => GetSubgroupsAsync(id, query);
+    public GitLabCollectionResponse<Models.Group> GetSubgroupsByIdAsync(long id, SubgroupQuery query = null) => GetSubgroupsAsync(id, query);
 
     public GitLabCollectionResponse<Models.Group> GetSubgroupsByFullPathAsync(string fullPath, SubgroupQuery query = null) => GetSubgroupsAsync(fullPath, query);
 

--- a/NGitLab.Mock/Clients/GroupHooksClient.cs
+++ b/NGitLab.Mock/Clients/GroupHooksClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
 {
-    public int _groupId { get; }
+    public long _groupId { get; }
 
     public GroupHooksClient(ClientContext context, GroupId groupId)
         : base(context)
@@ -26,7 +26,7 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
         }
     }
 
-    public Models.GroupHook this[int hookId]
+    public Models.GroupHook this[long hookId]
     {
         get
         {
@@ -49,7 +49,7 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
         }
     }
 
-    public Models.GroupHook Update(int hookId, GroupHookUpsert hook)
+    public Models.GroupHook Update(long hookId, GroupHookUpsert hook)
     {
         using (Context.BeginOperationScope())
         {
@@ -71,7 +71,7 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
         }
     }
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/GroupSearchClient.cs
+++ b/NGitLab.Mock/Clients/GroupSearchClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 internal sealed class GroupSearchClient : ClientBase, ISearchClient
 {
     private readonly ClientContext _context;
-    private readonly int _groupId;
+    private readonly long _groupId;
 
     public GroupSearchClient(ClientContext context, GroupId groupId)
         : base(context)

--- a/NGitLab.Mock/Clients/GroupVariableClient.cs
+++ b/NGitLab.Mock/Clients/GroupVariableClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class GroupVariableClient : ClientBase, IGroupVariableClient
 {
-    private readonly int _groupId;
+    private readonly long _groupId;
 
     public GroupVariableClient(ClientContext context, GroupId groupId)
         : base(context)

--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -129,7 +129,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         return Edit(issueEdit);
     }
 
-    public IEnumerable<Models.ResourceLabelEvent> ResourceLabelEvents(int projectId, int issueIid)
+    public IEnumerable<Models.ResourceLabelEvent> ResourceLabelEvents(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -138,7 +138,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<Models.ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<Models.ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -149,7 +149,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public IEnumerable<Models.ResourceMilestoneEvent> ResourceMilestoneEvents(int projectId, int issueIid)
+    public IEnumerable<Models.ResourceMilestoneEvent> ResourceMilestoneEvents(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -158,7 +158,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<Models.ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<Models.ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -169,7 +169,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public IEnumerable<Models.ResourceStateEvent> ResourceStateEvents(int projectId, int issueIid)
+    public IEnumerable<Models.ResourceStateEvent> ResourceStateEvents(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -178,7 +178,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<Models.ResourceStateEvent> ResourceStateEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<Models.ResourceStateEvent> ResourceStateEventsAsync(long projectId, long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -189,37 +189,37 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public IEnumerable<Models.MergeRequest> RelatedTo(int projectId, int issueId)
+    public IEnumerable<Models.MergeRequest> RelatedTo(long projectId, long issueId)
     {
         throw new NotImplementedException();
     }
 
-    public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<Models.MergeRequest> RelatedToAsync(long projectId, long issueIid)
     {
         throw new NotImplementedException();
     }
 
-    public IEnumerable<Models.MergeRequest> ClosedBy(int projectId, int issueId)
+    public IEnumerable<Models.MergeRequest> ClosedBy(long projectId, long issueId)
     {
         throw new NotImplementedException();
     }
 
-    public GitLabCollectionResponse<Models.MergeRequest> ClosedByAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<Models.MergeRequest> ClosedByAsync(long projectId, long issueIid)
     {
         throw new NotImplementedException();
     }
 
-    public Task<TimeStats> TimeStatsAsync(int projectId, int issueIid, CancellationToken cancellationToken = default)
+    public Task<TimeStats> TimeStatsAsync(long projectId, long issueIid, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public Task<Models.Issue> CloneAsync(int projectId, int issueIid, IssueClone issueClone, CancellationToken cancellationToken = default)
+    public Task<Models.Issue> CloneAsync(long projectId, long issueIid, IssueClone issueClone, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public IEnumerable<Models.Issue> ForProject(int projectId)
+    public IEnumerable<Models.Issue> ForProject(long projectId)
     {
         using (Context.BeginOperationScope())
         {
@@ -233,22 +233,22 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<Models.Issue> ForProjectAsync(int projectId)
+    public GitLabCollectionResponse<Models.Issue> ForProjectAsync(long projectId)
     {
         return GitLabCollectionResponse.Create(ForProject(projectId));
     }
 
-    public GitLabCollectionResponse<Models.Issue> ForGroupsAsync(int groupId)
+    public GitLabCollectionResponse<Models.Issue> ForGroupsAsync(long groupId)
     {
         throw new NotImplementedException();
     }
 
-    public GitLabCollectionResponse<Models.Issue> ForGroupsAsync(int groupId, IssueQuery query)
+    public GitLabCollectionResponse<Models.Issue> ForGroupsAsync(long groupId, IssueQuery query)
     {
         throw new NotImplementedException();
     }
 
-    public Models.Issue Get(int projectId, int issueId)
+    public Models.Issue Get(long projectId, long issueId)
     {
         using (Context.BeginOperationScope())
         {
@@ -260,7 +260,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<Models.Issue> GetAsync(int projectId, int issueId, CancellationToken cancellationToken = default)
+    public async Task<Models.Issue> GetAsync(long projectId, long issueId, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return Get(projectId, issueId);
@@ -281,7 +281,7 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         return GitLabCollectionResponse.Create(Get(query));
     }
 
-    public IEnumerable<Models.Issue> Get(int projectId, IssueQuery query)
+    public IEnumerable<Models.Issue> Get(long projectId, IssueQuery query)
     {
         using (Context.BeginOperationScope())
         {
@@ -291,28 +291,28 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<Models.Issue> GetAsync(int projectId, IssueQuery query)
+    public GitLabCollectionResponse<Models.Issue> GetAsync(long projectId, IssueQuery query)
     {
         return GitLabCollectionResponse.Create(Get(projectId, query));
     }
 
-    public async Task<Models.Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
+    public async Task<Models.Issue> GetByIdAsync(long issueId, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return GetById(issueId);
     }
 
-    public GitLabCollectionResponse<Models.Issue> LinkedToAsync(int projectId, int issueId)
+    public GitLabCollectionResponse<Models.Issue> LinkedToAsync(long projectId, long issueId)
     {
         throw new NotImplementedException();
     }
 
-    public bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId)
+    public bool CreateLinkBetweenIssues(long sourceProjectId, long sourceIssueId, long targetProjectId, long targetIssueId)
     {
         throw new NotImplementedException();
     }
 
-    public Models.Issue GetById(int issueId)
+    public Models.Issue GetById(long issueId)
     {
         using (Context.BeginOperationScope())
         {
@@ -452,12 +452,12 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         return issues;
     }
 
-    public IEnumerable<Participant> GetParticipants(ProjectId projectId, int issueIid)
+    public IEnumerable<Participant> GetParticipants(ProjectId projectId, long issueIid)
     {
         throw new NotImplementedException();
     }
 
-    public Models.Issue Unsubscribe(ProjectId projectId, int issueIid)
+    public Models.Issue Unsubscribe(ProjectId projectId, long issueIid)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/JobClient.cs
+++ b/NGitLab.Mock/Clients/JobClient.cs
@@ -11,7 +11,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class JobClient : ClientBase, IJobClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public JobClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -19,7 +19,7 @@ internal sealed class JobClient : ClientBase, IJobClient
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
-    public Models.Job Get(int jobId)
+    public Models.Job Get(long jobId)
     {
         using (Context.BeginOperationScope())
         {
@@ -34,18 +34,18 @@ internal sealed class JobClient : ClientBase, IJobClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<Models.Job> GetAsync(int jobId, CancellationToken cancellationToken = default)
+    public async Task<Models.Job> GetAsync(long jobId, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return Get(jobId);
     }
 
-    public byte[] GetJobArtifacts(int jobId)
+    public byte[] GetJobArtifacts(long jobId)
     {
         throw new NotImplementedException();
     }
 
-    public byte[] GetJobArtifact(int jobId, string path)
+    public byte[] GetJobArtifact(long jobId, string path)
     {
         throw new NotImplementedException();
     }
@@ -88,7 +88,7 @@ internal sealed class JobClient : ClientBase, IJobClient
         return GitLabCollectionResponse.Create(GetJobs(query));
     }
 
-    public string GetTrace(int jobId)
+    public string GetTrace(long jobId)
     {
         using (Context.BeginOperationScope())
         {
@@ -103,13 +103,13 @@ internal sealed class JobClient : ClientBase, IJobClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<string> GetTraceAsync(int jobId, CancellationToken cancellationToken = default)
+    public async Task<string> GetTraceAsync(long jobId, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return GetTrace(jobId);
     }
 
-    public Models.Job RunAction(int jobId, JobAction action)
+    public Models.Job RunAction(long jobId, JobAction action)
     {
         using (Context.BeginOperationScope())
         {
@@ -140,7 +140,7 @@ internal sealed class JobClient : ClientBase, IJobClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<Models.Job> RunActionAsync(int jobId, JobAction action, CancellationToken cancellationToken = default)
+    public async Task<Models.Job> RunActionAsync(long jobId, JobAction action, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return RunAction(jobId, action);

--- a/NGitLab.Mock/Clients/LabelClient.cs
+++ b/NGitLab.Mock/Clients/LabelClient.cs
@@ -13,7 +13,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
     {
     }
 
-    public Models.Label CreateProjectLabel(int projectId, ProjectLabelCreate label)
+    public Models.Label CreateProjectLabel(long projectId, ProjectLabelCreate label)
     {
         using (Context.BeginOperationScope())
         {
@@ -33,7 +33,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public Models.Label CreateGroupLabel(int groupId, GroupLabelCreate label)
+    public Models.Label CreateGroupLabel(long groupId, GroupLabelCreate label)
     {
         using (Context.BeginOperationScope())
         {
@@ -53,7 +53,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public Models.Label DeleteProjectLabel(int projectId, ProjectLabelDelete label)
+    public Models.Label DeleteProjectLabel(long projectId, ProjectLabelDelete label)
     {
         using (Context.BeginOperationScope())
         {
@@ -74,7 +74,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public Models.Label EditProjectLabel(int projectId, ProjectLabelEdit label)
+    public Models.Label EditProjectLabel(long projectId, ProjectLabelEdit label)
     {
         using (Context.BeginOperationScope())
         {
@@ -112,7 +112,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public Models.Label EditGroupLabel(int groupId, GroupLabelEdit label)
+    public Models.Label EditGroupLabel(long groupId, GroupLabelEdit label)
     {
         using (Context.BeginOperationScope())
         {
@@ -150,7 +150,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public IEnumerable<Models.Label> ForGroup(int groupId)
+    public IEnumerable<Models.Label> ForGroup(long groupId)
     {
         using (Context.BeginOperationScope())
         {
@@ -159,7 +159,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    public IEnumerable<Models.Label> ForProject(int projectId)
+    public IEnumerable<Models.Label> ForProject(long projectId)
     {
         using (Context.BeginOperationScope())
         {
@@ -168,7 +168,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    public Models.Label GetGroupLabel(int groupId, string name)
+    public Models.Label GetGroupLabel(long groupId, string name)
     {
         using (Context.BeginOperationScope())
         {
@@ -177,7 +177,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    public Models.Label GetProjectLabel(int projectId, string name)
+    public Models.Label GetProjectLabel(long projectId, string name)
     {
         using (Context.BeginOperationScope())
         {
@@ -187,7 +187,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public Models.Label GetLabel(int projectId, string name)
+    public Models.Label GetLabel(long projectId, string name)
     {
         return GetProjectLabel(projectId, name);
     }

--- a/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
@@ -5,10 +5,10 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class MergeRequestApprovalClient : ClientBase, IMergeRequestApprovalClient
 {
-    private readonly int _projectId;
-    private readonly int _mergeRequestIid;
+    private readonly long _projectId;
+    private readonly long _mergeRequestIid;
 
-    public MergeRequestApprovalClient(ClientContext context, int projectId, int mergeRequestIid)
+    public MergeRequestApprovalClient(ClientContext context, long projectId, long mergeRequestIid)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/MergeRequestChangeClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestChangeClient.cs
@@ -5,10 +5,10 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class  MergeRequestChangeClient : ClientBase, IMergeRequestChangeClient
 {
-    private readonly int _projectId;
-    private readonly int _mergeRequestIid;
+    private readonly long _projectId;
+    private readonly long _mergeRequestIid;
 
-    public MergeRequestChangeClient(ClientContext context, int projectId, int mergeRequestIid)
+    public MergeRequestChangeClient(ClientContext context, long projectId, long mergeRequestIid)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -12,7 +12,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
 {
-    private readonly int? _projectId;
+    private readonly long? _projectId;
 
     public MergeRequestClient(ClientContext context)
         : base(context)
@@ -40,7 +40,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
             throw new InvalidOperationException("Valid only for a specific project");
     }
 
-    public Models.MergeRequest this[int iid]
+    public Models.MergeRequest this[long iid]
     {
         get
         {
@@ -58,7 +58,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Task<Models.MergeRequest> GetByIidAsync(int iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default)
+    public Task<Models.MergeRequest> GetByIidAsync(long iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(this[iid]);
     }
@@ -84,7 +84,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Models.MergeRequest Accept(int mergeRequestIid, MergeRequestAccept message)
+    public Models.MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message)
     {
         return Accept(mergeRequestIid, new MergeRequestMerge
         {
@@ -93,7 +93,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         });
     }
 
-    public Models.MergeRequest Accept(int mergeRequestIid, MergeRequestMerge message)
+    public Models.MergeRequest Accept(long mergeRequestIid, MergeRequestMerge message)
     {
         AssertProjectId();
         using (Context.BeginOperationScope())
@@ -148,7 +148,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Models.MergeRequest Approve(int mergeRequestIid, MergeRequestApprove message)
+    public Models.MergeRequest Approve(long mergeRequestIid, MergeRequestApprove message)
     {
         AssertProjectId();
 
@@ -194,7 +194,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public RebaseResult Rebase(int mergeRequestIid)
+    public RebaseResult Rebase(long mergeRequestIid)
     {
         AssertProjectId();
         using (Context.BeginOperationScope())
@@ -209,7 +209,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Task<RebaseResult> RebaseAsync(int mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default)
+    public Task<RebaseResult> RebaseAsync(long mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(Rebase(mergeRequestIid));
     }
@@ -242,21 +242,21 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public IMergeRequestChangeClient Changes(int mergeRequestIid)
+    public IMergeRequestChangeClient Changes(long mergeRequestIid)
     {
         AssertProjectId();
 
         return new MergeRequestChangeClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
-    public IMergeRequestApprovalClient ApprovalClient(int mergeRequestIid)
+    public IMergeRequestApprovalClient ApprovalClient(long mergeRequestIid)
     {
         AssertProjectId();
 
         return new MergeRequestApprovalClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
-    public Models.MergeRequest Close(int mergeRequestIid)
+    public Models.MergeRequest Close(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -278,21 +278,21 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public IMergeRequestCommentClient Comments(int mergeRequestIid)
+    public IMergeRequestCommentClient Comments(long mergeRequestIid)
     {
         AssertProjectId();
 
         return new MergeRequestCommentClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
-    public IMergeRequestCommitClient Commits(int mergeRequestIid)
+    public IMergeRequestCommitClient Commits(long mergeRequestIid)
     {
         AssertProjectId();
 
         return new MergeRequestCommitClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
-    public Models.MergeRequest CancelMergeWhenPipelineSucceeds(int mergeRequestIid)
+    public Models.MergeRequest CancelMergeWhenPipelineSucceeds(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -380,7 +380,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public void Delete(int mergeRequestIid)
+    public void Delete(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -548,7 +548,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         return mergeRequests.Select(mr => mr.ToMergeRequestClient()).ToList();
     }
 
-    public IEnumerable<Author> GetParticipants(int mergeRequestIid)
+    public IEnumerable<Author> GetParticipants(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -566,7 +566,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public IEnumerable<PipelineBasic> GetPipelines(int mergeRequestIid)
+    public IEnumerable<PipelineBasic> GetPipelines(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -588,7 +588,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Models.MergeRequest Reopen(int mergeRequestIid)
+    public Models.MergeRequest Reopen(long mergeRequestIid)
     {
         AssertProjectId();
 
@@ -610,7 +610,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public Models.MergeRequest Update(int mergeRequestIid, MergeRequestUpdate mergeRequestUpdate)
+    public Models.MergeRequest Update(long mergeRequestIid, MergeRequestUpdate mergeRequestUpdate)
     {
         AssertProjectId();
 
@@ -707,29 +707,29 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public IEnumerable<Models.Issue> ClosesIssues(int mergeRequestIid)
+    public IEnumerable<Models.Issue> ClosesIssues(long mergeRequestIid)
     {
         throw new NotImplementedException();
     }
 
-    public GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(int mergeRequestIid)
+    public GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(long mergeRequestIid)
     {
         throw new NotImplementedException();
     }
 
-    public Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default)
+    public Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }
 
-    public IMergeRequestDiscussionClient Discussions(int mergeRequestIid)
+    public IMergeRequestDiscussionClient Discussions(long mergeRequestIid)
     {
         AssertProjectId();
 
         return new MergeRequestDiscussionClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
-    public GitLabCollectionResponse<Models.ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<Models.ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long mergeRequestIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -740,7 +740,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public GitLabCollectionResponse<Models.ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<Models.ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long mergeRequestIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -751,7 +751,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
-    public GitLabCollectionResponse<Models.ResourceStateEvent> ResourceStateEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<Models.ResourceStateEvent> ResourceStateEventsAsync(long projectId, long mergeRequestIid)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/MergeRequestCommentClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestCommentClient.cs
@@ -7,10 +7,10 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class MergeRequestCommentClient : ClientBase, IMergeRequestCommentClient
 {
-    private readonly int _projectId;
-    private readonly int _mergeRequestIid;
+    private readonly long _projectId;
+    private readonly long _mergeRequestIid;
 
-    public MergeRequestCommentClient(ClientContext context, int projectId, int mergeRequestIid)
+    public MergeRequestCommentClient(ClientContext context, long projectId, long mergeRequestIid)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/MergeRequestCommitClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestCommitClient.cs
@@ -6,10 +6,10 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class MergeRequestCommitClient : ClientBase, IMergeRequestCommitClient
 {
-    private readonly int _projectId;
-    private readonly int _mergeRequestIid;
+    private readonly long _projectId;
+    private readonly long _mergeRequestIid;
 
-    public MergeRequestCommitClient(ClientContext context, int projectId, int mergeRequestIid)
+    public MergeRequestCommitClient(ClientContext context, long projectId, long mergeRequestIid)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/MergeRequestDiscussionClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestDiscussionClient.cs
@@ -9,10 +9,10 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class MergeRequestDiscussionClient : ClientBase, IMergeRequestDiscussionClient
 {
-    private readonly int _projectId;
-    private readonly int _mergeRequestIid;
+    private readonly long _projectId;
+    private readonly long _mergeRequestIid;
 
-    public MergeRequestDiscussionClient(ClientContext context, int projectId, int mergeRequestIid)
+    public MergeRequestDiscussionClient(ClientContext context, long projectId, long mergeRequestIid)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/MilestoneClient.cs
+++ b/NGitLab.Mock/Clients/MilestoneClient.cs
@@ -10,7 +10,7 @@ namespace NGitLab.Mock;
 
 internal sealed class MilestoneClient : ClientBase, IMilestoneClient
 {
-    private readonly int _resourceId;
+    private readonly long _resourceId;
 
     public MilestoneClient(ClientContext context, IIdOrPathAddressable id, MilestoneScope scope)
         : base(context)
@@ -24,7 +24,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         Scope = scope;
     }
 
-    public Models.Milestone this[int id]
+    public Models.Milestone this[long id]
     {
         get
         {
@@ -39,7 +39,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
 
     public MilestoneScope Scope { get; }
 
-    public Models.Milestone Activate(int milestoneId)
+    public Models.Milestone Activate(long milestoneId)
     {
         using (Context.BeginOperationScope())
         {
@@ -49,7 +49,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         }
     }
 
-    public IEnumerable<Models.MergeRequest> GetMergeRequests(int milestoneId)
+    public IEnumerable<Models.MergeRequest> GetMergeRequests(long milestoneId)
     {
         using (Context.BeginOperationScope())
         {
@@ -78,7 +78,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         return Get(new MilestoneQuery { State = state });
     }
 
-    public Models.Milestone Close(int milestoneId)
+    public Models.Milestone Close(long milestoneId)
     {
         using (Context.BeginOperationScope())
         {
@@ -118,7 +118,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         }
     }
 
-    public void Delete(int milestoneId)
+    public void Delete(long milestoneId)
     {
         using (Context.BeginOperationScope())
         {
@@ -171,7 +171,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         }
     }
 
-    public Models.Milestone Update(int milestoneId, MilestoneUpdate milestone)
+    public Models.Milestone Update(long milestoneId, MilestoneUpdate milestone)
     {
         using (Context.BeginOperationScope())
         {
@@ -201,7 +201,7 @@ internal sealed class MilestoneClient : ClientBase, IMilestoneClient
         }
     }
 
-    private Milestone GetMilestone(int milestoneId, bool editing)
+    private Milestone GetMilestone(long milestoneId, bool editing)
     {
         Milestone milestone;
 

--- a/NGitLab.Mock/Clients/NamespacesClient.cs
+++ b/NGitLab.Mock/Clients/NamespacesClient.cs
@@ -11,7 +11,7 @@ internal sealed class NamespacesClient : ClientBase, INamespacesClient
     {
     }
 
-    public Namespace this[int id] => throw new NotImplementedException();
+    public Namespace this[long id] => throw new NotImplementedException();
 
     public Namespace this[string fullPath] => throw new NotImplementedException();
 

--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -11,7 +11,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class PipelineClient : ClientBase, IPipelineClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
     private readonly IJobClient _jobClient;
 
     public PipelineClient(ClientContext context, IJobClient jobClient, ProjectId projectId)
@@ -21,7 +21,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
-    public Models.Pipeline this[int id]
+    public Models.Pipeline this[long id]
     {
         get
         {
@@ -84,7 +84,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public void Delete(int pipelineId)
+    public void Delete(long pipelineId)
     {
         using (Context.BeginOperationScope())
         {
@@ -94,7 +94,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public IEnumerable<PipelineVariable> GetVariables(int pipelineId)
+    public IEnumerable<PipelineVariable> GetVariables(long pipelineId)
     {
         using (Context.BeginOperationScope())
         {
@@ -104,7 +104,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public TestReport GetTestReports(int pipelineId)
+    public TestReport GetTestReports(long pipelineId)
     {
         using (Context.BeginOperationScope())
         {
@@ -114,7 +114,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public TestReportSummary GetTestReportsSummary(int pipelineId)
+    public TestReportSummary GetTestReportsSummary(long pipelineId)
     {
         using (Context.BeginOperationScope())
         {
@@ -139,7 +139,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public Models.Job[] GetJobs(int pipelineId)
+    public Models.Job[] GetJobs(long pipelineId)
     {
         using (Context.BeginOperationScope())
         {
@@ -259,7 +259,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         return pipelines.OrderBy(expression);
     }
 
-    public async Task<Models.Pipeline> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<Models.Pipeline> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return this[id];
@@ -287,12 +287,12 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         return GitLabCollectionResponse.Create(Search(query));
     }
 
-    public GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(int pipelineId)
+    public GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(long pipelineId)
     {
         return GitLabCollectionResponse.Create(GetVariables(pipelineId));
     }
 
-    public Task<Models.Pipeline> RetryAsync(int pipelineId, CancellationToken cancellationToken = default)
+    public Task<Models.Pipeline> RetryAsync(long pipelineId, CancellationToken cancellationToken = default)
     {
         using (Context.BeginOperationScope())
         {
@@ -306,7 +306,7 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    public Task<Models.Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
+    public Task<Models.Pipeline> UpdateMetadataAsync(long pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/PipelineScheduleClient.cs
+++ b/NGitLab.Mock/Clients/PipelineScheduleClient.cs
@@ -17,7 +17,7 @@ internal class PipelineScheduleClient : ClientBase, IPipelineScheduleClient
         _projectId = projectId;
     }
 
-    public Models.PipelineSchedule this[int id]
+    public Models.PipelineSchedule this[long id]
     {
         get
         {
@@ -48,7 +48,7 @@ internal class PipelineScheduleClient : ClientBase, IPipelineScheduleClient
     public GitLabCollectionResponse<PipelineScheduleBasic> GetAllAsync()
         => GitLabCollectionResponse.Create(All);
 
-    public GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(int id)
+    public GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -61,7 +61,7 @@ internal class PipelineScheduleClient : ClientBase, IPipelineScheduleClient
         }
     }
 
-    public async Task<Models.PipelineSchedule> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<Models.PipelineSchedule> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
 

--- a/NGitLab.Mock/Clients/ProjectBadgeClient.cs
+++ b/NGitLab.Mock/Clients/ProjectBadgeClient.cs
@@ -7,7 +7,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectBadgeClient : ClientBase, IProjectBadgeClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProjectBadgeClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -15,7 +15,7 @@ internal sealed class ProjectBadgeClient : ClientBase, IProjectBadgeClient
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
-    public Models.Badge this[int id]
+    public Models.Badge this[long id]
     {
         get
         {
@@ -66,7 +66,7 @@ internal sealed class ProjectBadgeClient : ClientBase, IProjectBadgeClient
         }
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         EnsureUserIsAuthenticated();
 
@@ -82,7 +82,7 @@ internal sealed class ProjectBadgeClient : ClientBase, IProjectBadgeClient
         }
     }
 
-    public Models.Badge Update(int id, BadgeUpdate badge)
+    public Models.Badge Update(long id, BadgeUpdate badge)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -212,10 +212,8 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
                 case ProjectQueryScope.Owned:
                     projects = projects.Where(p => p.IsUserOwner(Context.User));
                     break;
-                case ProjectQueryScope.Visible:
-                    projects = projects.Where(p => p.CanUserViewProject(Context.User));
-                    break;
                 case ProjectQueryScope.All:
+                    projects = projects.Where(p => p.CanUserViewProject(Context.User));
                     break;
             }
 

--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -17,7 +17,7 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
     {
     }
 
-    public Models.Project this[int id]
+    public Models.Project this[long id]
     {
         get
         {
@@ -133,7 +133,7 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
         return parentGroup;
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -152,13 +152,13 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
         }
     }
 
-    public void Archive(int id)
+    public void Archive(long id)
     {
         var project = GetProject(id, ProjectPermission.Edit);
         project.Archived = true;
     }
 
-    public void Unarchive(int id)
+    public void Unarchive(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -249,9 +249,9 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
         }
     }
 
-    public Models.Project GetById(int id, SingleProjectQuery query) => this[id];
+    public Models.Project GetById(long id, SingleProjectQuery query) => this[id];
 
-    public Task<Models.Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default) =>
+    public Task<Models.Project> GetByIdAsync(long id, SingleProjectQuery query, CancellationToken cancellationToken = default) =>
         GetAsync(new ProjectId(id), query, cancellationToken);
 
     public Task<Models.Project> GetByNamespacedPathAsync(string path, SingleProjectQuery query = null, CancellationToken cancellationToken = default) =>

--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -81,7 +82,7 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
         {
             project.Name ??= project.Path;
 
-            var parentGroup = GetParentGroup(project.NamespaceId);
+            var parentGroup = GetParentGroup(project.NamespaceId?.ToString(CultureInfo.InvariantCulture));
 
             var newProject = new Project(name: project.Name, path: project.Path)
             {

--- a/NGitLab.Mock/Clients/ProjectHooksClient.cs
+++ b/NGitLab.Mock/Clients/ProjectHooksClient.cs
@@ -6,9 +6,9 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectHooksClient : ClientBase, IProjectHooksClient
 {
-    public int ProjectId { get; }
+    public long ProjectId { get; }
 
-    public ProjectHooksClient(ClientContext context, int projectId)
+    public ProjectHooksClient(ClientContext context, long projectId)
         : base(context)
     {
         ProjectId = projectId;
@@ -26,7 +26,7 @@ internal sealed class ProjectHooksClient : ClientBase, IProjectHooksClient
         }
     }
 
-    public Models.ProjectHook this[int hookId]
+    public Models.ProjectHook this[long hookId]
     {
         get
         {
@@ -49,7 +49,7 @@ internal sealed class ProjectHooksClient : ClientBase, IProjectHooksClient
         }
     }
 
-    public Models.ProjectHook Update(int hookId, ProjectHookUpsert hook)
+    public Models.ProjectHook Update(long hookId, ProjectHookUpsert hook)
     {
         using (Context.BeginOperationScope())
         {
@@ -69,7 +69,7 @@ internal sealed class ProjectHooksClient : ClientBase, IProjectHooksClient
         }
     }
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/ProjectIssueNoteClient.cs
+++ b/NGitLab.Mock/Clients/ProjectIssueNoteClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProjectIssueNoteClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -44,7 +44,7 @@ internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClie
         }
     }
 
-    public IEnumerable<Models.ProjectIssueNote> ForIssue(int issueIid)
+    public IEnumerable<Models.ProjectIssueNote> ForIssue(long issueIid)
     {
         using (Context.BeginOperationScope())
         {
@@ -52,7 +52,7 @@ internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClie
         }
     }
 
-    public Models.ProjectIssueNote Get(int issueIid, int noteId)
+    public Models.ProjectIssueNote Get(long issueIid, long noteId)
     {
         using (Context.BeginOperationScope())
         {
@@ -60,7 +60,7 @@ internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClie
         }
     }
 
-    private Issue GetIssue(int issueIid)
+    private Issue GetIssue(long issueIid)
     {
         var project = GetProject(_projectId, ProjectPermission.View);
         var issue = project.Issues.FirstOrDefault(iss => iss.Iid == issueIid);
@@ -73,7 +73,7 @@ internal sealed class ProjectIssueNoteClient : ClientBase, IProjectIssueNoteClie
         return issue;
     }
 
-    private ProjectIssueNote GetIssueNote(int issueIid, int issueNoteId)
+    private ProjectIssueNote GetIssueNote(long issueIid, long issueNoteId)
     {
         var issue = GetIssue(issueIid);
         var note = issue.Notes.FirstOrDefault(n => n.Id == issueNoteId);

--- a/NGitLab.Mock/Clients/ProjectLevelApprovalRulesClient.cs
+++ b/NGitLab.Mock/Clients/ProjectLevelApprovalRulesClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectLevelApprovalRulesClient : ClientBase, IProjectLevelApprovalRulesClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProjectLevelApprovalRulesClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -19,7 +19,7 @@ internal sealed class ProjectLevelApprovalRulesClient : ClientBase, IProjectLeve
         throw new NotImplementedException();
     }
 
-    public ApprovalRule UpdateProjectLevelApprovalRule(int approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate)
+    public ApprovalRule UpdateProjectLevelApprovalRule(long approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate)
     {
         throw new NotImplementedException();
     }
@@ -29,7 +29,7 @@ internal sealed class ProjectLevelApprovalRulesClient : ClientBase, IProjectLeve
         throw new NotImplementedException();
     }
 
-    public void DeleteProjectLevelRule(int approvalRuleIdToDelete)
+    public void DeleteProjectLevelRule(long approvalRuleIdToDelete)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/ProjectSearchClient.cs
+++ b/NGitLab.Mock/Clients/ProjectSearchClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 internal sealed class ProjectSearchClient : ClientBase, ISearchClient
 {
     private readonly ClientContext _context;
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProjectSearchClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ProjectVariableClient.cs
+++ b/NGitLab.Mock/Clients/ProjectVariableClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectVariableClient : ClientBase, IProjectVariableClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProjectVariableClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ProtectedBranchClient.cs
+++ b/NGitLab.Mock/Clients/ProtectedBranchClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProtectedBranchClient : ClientBase, IProtectedBranchClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProtectedBranchClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ProtectedTagClient.cs
+++ b/NGitLab.Mock/Clients/ProtectedTagClient.cs
@@ -7,7 +7,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProtectedTagClient : ClientBase, IProtectedTagClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ProtectedTagClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ReleaseClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseClient.cs
@@ -11,7 +11,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ReleaseClient : ClientBase, IReleaseClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public ReleaseClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/ReleaseLinkClient.cs
+++ b/NGitLab.Mock/Clients/ReleaseLinkClient.cs
@@ -6,17 +6,17 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ReleaseLinkClient : ClientBase, IReleaseLinkClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
     private readonly string _tagName;
 
-    public ReleaseLinkClient(ClientContext context, int projectId, string tagName)
+    public ReleaseLinkClient(ClientContext context, long projectId, string tagName)
         : base(context)
     {
         _projectId = projectId;
         _tagName = tagName;
     }
 
-    public ReleaseLink this[int id] => throw new NotImplementedException();
+    public ReleaseLink this[long id] => throw new NotImplementedException();
 
     public IEnumerable<ReleaseLink> All => throw new NotImplementedException();
 
@@ -25,12 +25,12 @@ internal sealed class ReleaseLinkClient : ClientBase, IReleaseLinkClient
         throw new NotImplementedException();
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         throw new NotImplementedException();
     }
 
-    public ReleaseLink Update(int id, ReleaseLinkUpdate data)
+    public ReleaseLink Update(long id, ReleaseLinkUpdate data)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -9,7 +9,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class RepositoryClient : ClientBase, IRepositoryClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public RepositoryClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -45,7 +45,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
     {
     }
 
-    public Models.Runner this[int id]
+    public Models.Runner this[long id]
     {
         get
         {
@@ -59,7 +59,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
 
     public void Delete(Models.Runner runner) => Delete(runner.Id);
 
-    public void Delete(int runnerId)
+    public void Delete(long runnerId)
     {
         using (Context.BeginOperationScope())
         {
@@ -87,7 +87,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         }
     }
 
-    public Models.Runner Update(int runnerId, RunnerUpdate runnerUpdate)
+    public Models.Runner Update(long runnerId, RunnerUpdate runnerUpdate)
     {
         using (Context.BeginOperationScope())
         {
@@ -105,7 +105,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         }
     }
 
-    public IEnumerable<Models.Runner> OfGroup(int groupId)
+    public IEnumerable<Models.Runner> OfGroup(long groupId)
     {
         using (Context.BeginOperationScope())
         {
@@ -114,12 +114,12 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         }
     }
 
-    public GitLabCollectionResponse<Models.Runner> OfGroupAsync(int groupId)
+    public GitLabCollectionResponse<Models.Runner> OfGroupAsync(long groupId)
     {
         return GitLabCollectionResponse.Create(OfGroup(groupId));
     }
 
-    public IEnumerable<Models.Runner> OfProject(int projectId)
+    public IEnumerable<Models.Runner> OfProject(long projectId)
     {
         using (Context.BeginOperationScope())
         {
@@ -128,23 +128,23 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         }
     }
 
-    public GitLabCollectionResponse<Models.Runner> OfProjectAsync(int projectId)
+    public GitLabCollectionResponse<Models.Runner> OfProjectAsync(long projectId)
     {
         return GitLabCollectionResponse.Create(OfProject(projectId));
     }
 
-    public IEnumerable<Models.Job> GetJobs(int runnerId, JobScope jobScope)
+    public IEnumerable<Models.Job> GetJobs(long runnerId, JobScope jobScope)
     {
         throw new NotImplementedException();
     }
 
-    public IEnumerable<Models.Job> GetJobs(int runnerId, JobStatus? status = null)
+    public IEnumerable<Models.Job> GetJobs(long runnerId, JobStatus? status = null)
     {
         throw new NotImplementedException();
     }
 
     [Obsolete("Use OfProject() or OfGroup() instead")]
-    IEnumerable<Models.Runner> IRunnerClient.GetAvailableRunners(int projectId)
+    IEnumerable<Models.Runner> IRunnerClient.GetAvailableRunners(long projectId)
     {
         return OfProject(projectId);
     }
@@ -154,7 +154,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         throw new NotImplementedException();
     }
 
-    public Models.Runner EnableRunner(int projectId, RunnerId runnerId)
+    public Models.Runner EnableRunner(long projectId, RunnerId runnerId)
     {
         using (Context.BeginOperationScope())
         {
@@ -174,13 +174,13 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
     }
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Would be an infinite recursion")]
-    public async Task<Models.Runner> EnableRunnerAsync(int projectId, RunnerId runnerId, CancellationToken cancellationToken = default)
+    public async Task<Models.Runner> EnableRunnerAsync(long projectId, RunnerId runnerId, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return EnableRunner(projectId, runnerId);
     }
 
-    public void DisableRunner(int projectId, RunnerId runnerId)
+    public void DisableRunner(long projectId, RunnerId runnerId)
     {
         using (Context.BeginOperationScope())
         {
@@ -205,7 +205,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         return runners;
     }
 
-    private Runner GetServerRunner(int id)
+    private Runner GetServerRunner(long id)
     {
         return GetOwnedRunners().FirstOrDefault(runner => runner.Id == id) ?? throw new GitLabNotFoundException();
     }

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -94,7 +94,6 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
             var runner = this[runnerId] ?? throw new GitLabNotFoundException();
             var runnerOnServer = GetServerRunner(runnerId);
 
-            runnerOnServer.Active = runnerUpdate.IsActive() ?? runnerOnServer.IsActive();
             runnerOnServer.Paused = runnerUpdate.Paused ?? runnerOnServer.Paused;
             runnerOnServer.TagList = runnerUpdate.TagList ?? runnerOnServer.TagList;
             runnerOnServer.Description = !string.IsNullOrEmpty(runnerUpdate.Description) ? runnerUpdate.Description : runnerOnServer.Description;
@@ -224,7 +223,7 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
             var group = Server.AllGroups.SingleOrDefault(g => string.Equals(g.RunnersToken, request.Token, StringComparison.Ordinal));
             if (group != null)
             {
-                var runner = group.AddRunner(request.Description, active: !request.Paused ?? true, paused: request.Paused ?? false, tagList: request.TagList, runUntagged: request.RunUntagged ?? false, locked: request.Locked ?? true);
+                var runner = group.AddRunner(request.Description, paused: request.Paused ?? false, tagList: request.TagList, runUntagged: request.RunUntagged ?? false, locked: request.Locked ?? true);
                 return runner.ToClientRunner(Context.User);
             }
 

--- a/NGitLab.Mock/Clients/RunnerClient.cs
+++ b/NGitLab.Mock/Clients/RunnerClient.cs
@@ -132,11 +132,6 @@ internal sealed class RunnerClient : ClientBase, IRunnerClient
         return GitLabCollectionResponse.Create(OfProject(projectId));
     }
 
-    public IEnumerable<Models.Job> GetJobs(long runnerId, JobScope jobScope)
-    {
-        throw new NotImplementedException();
-    }
-
     public IEnumerable<Models.Job> GetJobs(long runnerId, JobStatus? status = null)
     {
         throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/SnippetClient.cs
+++ b/NGitLab.Mock/Clients/SnippetClient.cs
@@ -36,27 +36,27 @@ internal sealed class SnippetClient : ClientBase, ISnippetClient
         throw new NotImplementedException();
     }
 
-    public void Delete(int snippetId)
+    public void Delete(long snippetId)
     {
         throw new NotImplementedException();
     }
 
-    public void Delete(int projectId, int snippetId)
+    public void Delete(long projectId, long snippetId)
     {
         throw new NotImplementedException();
     }
 
-    public IEnumerable<Snippet> ForProject(int projectId)
+    public IEnumerable<Snippet> ForProject(long projectId)
     {
         throw new NotImplementedException();
     }
 
-    public Snippet Get(int projectId, int snippetId)
+    public Snippet Get(long projectId, long snippetId)
     {
         throw new NotImplementedException();
     }
 
-    public void GetContent(int projectId, int snippetId, Action<Stream> parser)
+    public void GetContent(long projectId, long snippetId, Action<Stream> parser)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/SystemHookClient.cs
+++ b/NGitLab.Mock/Clients/SystemHookClient.cs
@@ -12,7 +12,7 @@ internal sealed class SystemHookClient : ClientBase, ISystemHookClient
     {
     }
 
-    public Models.SystemHook this[int hookId]
+    public Models.SystemHook this[long hookId]
     {
         get
         {
@@ -61,7 +61,7 @@ internal sealed class SystemHookClient : ClientBase, ISystemHookClient
         }
     }
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         AssertIsAdmin();
         using (Context.BeginOperationScope())

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -36,7 +36,7 @@ internal sealed class TagClient : ClientBase, ITagClient
         using (Context.BeginOperationScope())
         {
             var project = GetProject(_projectId, ProjectPermission.Contribute);
-            var createdTag = project.Repository.CreateTag(Context.User, tag.Name, tag.Ref, tag.Message, tag.ReleaseDescription);
+            var createdTag = project.Repository.CreateTag(Context.User, tag.Name, tag.Ref, tag.Message);
 
             return ToTagClient(createdTag);
         }

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -12,9 +12,9 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class TagClient : ClientBase, ITagClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
-    public TagClient(ClientContext context, int projectId)
+    public TagClient(ClientContext context, long projectId)
         : base(context)
     {
         _projectId = projectId;

--- a/NGitLab.Mock/Clients/TriggerClient.cs
+++ b/NGitLab.Mock/Clients/TriggerClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class TriggerClient : ClientBase, ITriggerClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public TriggerClient(ClientContext context, ProjectId projectId)
         : base(context)
@@ -14,7 +14,7 @@ internal sealed class TriggerClient : ClientBase, ITriggerClient
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
-    public Trigger this[int id] => throw new NotImplementedException();
+    public Trigger this[long id] => throw new NotImplementedException();
 
     public IEnumerable<Trigger> All => throw new NotImplementedException();
 

--- a/NGitLab.Mock/Clients/UserClient.cs
+++ b/NGitLab.Mock/Clients/UserClient.cs
@@ -14,7 +14,7 @@ internal sealed class UserClient : ClientBase, IUserClient
     {
     }
 
-    public Models.User this[int id]
+    public Models.User this[long id]
     {
         get
         {
@@ -83,7 +83,7 @@ internal sealed class UserClient : ClientBase, IUserClient
         return CreateToken(tokenRequest);
     }
 
-    public void Delete(int id)
+    public void Delete(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -98,7 +98,7 @@ internal sealed class UserClient : ClientBase, IUserClient
         }
     }
 
-    public void Activate(int id)
+    public void Activate(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -113,7 +113,7 @@ internal sealed class UserClient : ClientBase, IUserClient
         }
     }
 
-    public void Deactivate(int id)
+    public void Deactivate(long id)
     {
         using (Context.BeginOperationScope())
         {
@@ -154,12 +154,12 @@ internal sealed class UserClient : ClientBase, IUserClient
         }
     }
 
-    public ISshKeyClient SShKeys(int userId)
+    public ISshKeyClient SShKeys(long userId)
     {
         throw new NotImplementedException();
     }
 
-    public Models.User Update(int id, UserUpsert userUpsert)
+    public Models.User Update(long id, UserUpsert userUpsert)
     {
         using (Context.BeginOperationScope())
         {
@@ -178,7 +178,7 @@ internal sealed class UserClient : ClientBase, IUserClient
         }
     }
 
-    public async Task<Models.User> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<Models.User> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
         return this[id];

--- a/NGitLab.Mock/Clients/WikiClient.cs
+++ b/NGitLab.Mock/Clients/WikiClient.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class WikiClient : ClientBase, IWikiClient
 {
-    private readonly int _projectId;
+    private readonly long _projectId;
 
     public WikiClient(ClientContext context, ProjectId projectId)
         : base(context)

--- a/NGitLab.Mock/Config/ConfigSerializer.cs
+++ b/NGitLab.Mock/Config/ConfigSerializer.cs
@@ -193,11 +193,11 @@ internal sealed class ConfigSerializer
             return false;
         }
 
-        if (type == typeof(int))
+        if (type == typeof(long))
         {
-            if (valueObj is string valueString && int.TryParse(valueString, out var valueInt))
+            if (valueObj is string valueString && long.TryParse(valueString, out var valueLong))
             {
-                value = valueInt;
+                value = valueLong;
                 return true;
             }
 

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -196,7 +196,7 @@ public static class GitLabHelpers
     /// <param name="visibility">Visibility.</param>
     /// <param name="addDefaultUserAsMaintainer">Define default user as maintainer.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabConfig WithGroup(this GitLabConfig config, string? name = null, int id = default, string? @namespace = null, string? description = null, VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, Action<GitLabGroup>? configure = null)
+    public static GitLabConfig WithGroup(this GitLabConfig config, string? name = null, long id = default, string? @namespace = null, string? description = null, VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, Action<GitLabGroup>? configure = null)
     {
         return WithGroup(config, name, group =>
         {
@@ -231,7 +231,7 @@ public static class GitLabHelpers
     /// <param name="visibility">Optional visibility.</param>
     /// <param name="addDefaultUserAsMaintainer">Optionally define default user as maintainer.</param>
     /// <param name="configure">Optional configuration method</param>
-    public static GitLabConfig WithGroupOfFullPath(this GitLabConfig config, string fullPath, string? name = null, int id = default, string? description = null, VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, Action<GitLabGroup>? configure = null)
+    public static GitLabConfig WithGroupOfFullPath(this GitLabConfig config, string fullPath, string? name = null, long id = default, string? description = null, VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, Action<GitLabGroup>? configure = null)
     {
         if (string.IsNullOrWhiteSpace(fullPath))
             throw new ArgumentNullException(nameof(fullPath));
@@ -283,7 +283,7 @@ public static class GitLabHelpers
     /// <param name="clonePath">Path where to clone repository after server resolving</param>
     /// <param name="cloneParameters">Parameters passed to clone command</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabConfig WithProject(this GitLabConfig config, string? name = null, int id = default, string? @namespace = null, string? description = null,
+    public static GitLabConfig WithProject(this GitLabConfig config, string? name = null, long id = default, string? @namespace = null, string? description = null,
                                            string? defaultBranch = null, VisibilityLevel visibility = VisibilityLevel.Internal, bool initialCommit = false,
                                            bool addDefaultUserAsMaintainer = false, string? clonePath = null, string? cloneParameters = null, Action<GitLabProject>? configure = null)
     {
@@ -336,7 +336,7 @@ public static class GitLabHelpers
     /// <param name="clonePath">Path where to clone repository after server resolving</param>
     /// <param name="cloneParameters">Parameters passed to clone command</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabConfig WithProjectOfFullPath(this GitLabConfig config, string? fullPath, string? name = null, int id = default, string? description = null,
+    public static GitLabConfig WithProjectOfFullPath(this GitLabConfig config, string? fullPath, string? name = null, long id = default, string? description = null,
                                                      string? defaultBranch = null, VisibilityLevel visibility = VisibilityLevel.Internal, bool initialCommit = false,
                                                      bool addDefaultUserAsMaintainer = false, string? clonePath = null, string? cloneParameters = null, Action<GitLabProject>? configure = null)
     {
@@ -575,7 +575,7 @@ public static class GitLabHelpers
     /// <param name="closedAt">Close date time.</param>
     /// <param name="labels">Labels names.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabProject WithIssue(this GitLabProject project, string? title = null, int id = default, string? description = null, string? author = null, string? assignee = null, string? milestone = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, IEnumerable<string>? labels = null, Action<GitLabIssue>? configure = null)
+    public static GitLabProject WithIssue(this GitLabProject project, string? title = null, long id = default, string? description = null, string? author = null, string? assignee = null, string? milestone = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, IEnumerable<string>? labels = null, Action<GitLabIssue>? configure = null)
     {
         return WithIssue(project, title, author, issue =>
         {
@@ -674,7 +674,7 @@ public static class GitLabHelpers
     /// <param name="labels">Labels names.</param>
     /// <param name="milestone">Milestone name.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabProject WithMergeRequest(this GitLabProject project, string? sourceBranch = null, string? title = null, int id = default, string? targetBranch = null, string? description = null, string? author = null, string? assignee = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, DateTime? mergedAt = null, IEnumerable<string>? approvers = null, IEnumerable<string>? labels = null, string? milestone = null, Action<GitLabMergeRequest>? configure = null)
+    public static GitLabProject WithMergeRequest(this GitLabProject project, string? sourceBranch = null, string? title = null, long id = default, string? targetBranch = null, string? description = null, string? author = null, string? assignee = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, DateTime? mergedAt = null, IEnumerable<string>? approvers = null, IEnumerable<string>? labels = null, string? milestone = null, Action<GitLabMergeRequest>? configure = null)
     {
         return WithMergeRequest(project, sourceBranch, title, author, mergeRequest =>
         {
@@ -849,7 +849,7 @@ public static class GitLabHelpers
     /// <param name="updatedAt">Update date time.</param>
     /// <param name="closedAt">Close date time.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabGroup WithMilestone(this GitLabGroup group, string title, int id = default, string? description = null, DateTime? dueDate = null, DateTime? startDate = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, Action<GitLabMilestone>? configure = null)
+    public static GitLabGroup WithMilestone(this GitLabGroup group, string title, long id = default, string? description = null, DateTime? dueDate = null, DateTime? startDate = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, Action<GitLabMilestone>? configure = null)
     {
         return WithMilestone(group, title, milestone =>
         {
@@ -900,7 +900,7 @@ public static class GitLabHelpers
     /// <param name="updatedAt">Update date time.</param>
     /// <param name="closedAt">Close date time.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabProject WithMilestone(this GitLabProject project, string title, int id = default, string? description = null, DateTime? dueDate = null, DateTime? startDate = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, Action<GitLabMilestone>? configure = null)
+    public static GitLabProject WithMilestone(this GitLabProject project, string title, long id = default, string? description = null, DateTime? dueDate = null, DateTime? startDate = null, DateTime? createdAt = null, DateTime? updatedAt = null, DateTime? closedAt = null, Action<GitLabMilestone>? configure = null)
     {
         return WithMilestone(project, title, milestone =>
         {
@@ -980,7 +980,7 @@ public static class GitLabHelpers
     /// <param name="resolvable">Indicates if comment is resolvable.</param>
     /// <param name="resolved">Indicates if comment is resolved.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabIssue WithComment(this GitLabIssue issue, string? message = null, int id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
+    public static GitLabIssue WithComment(this GitLabIssue issue, string? message = null, long id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
     {
         return WithComment<GitLabIssue>(issue, message, id, author, system, createdAt, updatedAt, thread, resolvable, resolved, configure);
     }
@@ -999,12 +999,12 @@ public static class GitLabHelpers
     /// <param name="resolvable">Indicates if comment is resolvable.</param>
     /// <param name="resolved">Indicates if comment is resolved.</param>
     /// <param name="configure">Configuration method</param>
-    public static GitLabMergeRequest WithComment(this GitLabMergeRequest mergeRequest, string? message = null, int id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
+    public static GitLabMergeRequest WithComment(this GitLabMergeRequest mergeRequest, string? message = null, long id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
     {
         return WithComment<GitLabMergeRequest>(mergeRequest, message, id, author, system, createdAt, updatedAt, thread, resolvable, resolved, configure);
     }
 
-    private static T WithComment<T>(this T obj, string? message, int id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
+    private static T WithComment<T>(this T obj, string? message, long id = default, string? author = null, bool system = false, DateTime? createdAt = null, DateTime? updatedAt = null, string? thread = null, bool resolvable = false, bool resolved = false, Action<GitLabComment>? configure = null)
         where T : GitLabObject
     {
         return WithComment(obj, message, comment =>
@@ -1034,7 +1034,7 @@ public static class GitLabHelpers
     /// <param name="author">Author username (required if default user not defined)</param>
     /// <param name="createdAt">Creation date time.</param>
     /// <param name="updatedAt">Update date time.</param>
-    public static GitLabIssue WithSystemComment(this GitLabIssue issue, string? message = null, string? innerHtml = null, int id = default, string? author = null, DateTime? createdAt = null, DateTime? updatedAt = null)
+    public static GitLabIssue WithSystemComment(this GitLabIssue issue, string? message = null, string? innerHtml = null, long id = default, string? author = null, DateTime? createdAt = null, DateTime? updatedAt = null)
     {
         return WithSystemComment<GitLabIssue>(issue, message, innerHtml, id, author, createdAt, updatedAt);
     }
@@ -1049,12 +1049,12 @@ public static class GitLabHelpers
     /// <param name="author">Author username (required if default user not defined)</param>
     /// <param name="createdAt">Creation date time.</param>
     /// <param name="updatedAt">Update date time.</param>
-    public static GitLabMergeRequest WithSystemComment(this GitLabMergeRequest mergeRequest, string? message = null, string? innerHtml = null, int id = default, string? author = null, DateTime? createdAt = null, DateTime? updatedAt = null)
+    public static GitLabMergeRequest WithSystemComment(this GitLabMergeRequest mergeRequest, string? message = null, string? innerHtml = null, long id = default, string? author = null, DateTime? createdAt = null, DateTime? updatedAt = null)
     {
         return WithSystemComment<GitLabMergeRequest>(mergeRequest, message, innerHtml, id, author, createdAt, updatedAt);
     }
 
-    private static T WithSystemComment<T>(this T obj, string? message, string? innerHtml, int id, string? author, DateTime? createdAt, DateTime? updatedAt)
+    private static T WithSystemComment<T>(this T obj, string? message, string? innerHtml, long id, string? author, DateTime? createdAt, DateTime? updatedAt)
         where T : GitLabObject
     {
         var body = innerHtml == null ? message : $"{message}\n\n{innerHtml}";

--- a/NGitLab.Mock/Config/GitLabObject.cs
+++ b/NGitLab.Mock/Config/GitLabObject.cs
@@ -8,7 +8,7 @@ public abstract class GitLabObject
     {
     }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [YamlIgnore]
     public object ParentObject { get; internal set; }

--- a/NGitLab.Mock/Event.cs
+++ b/NGitLab.Mock/Event.cs
@@ -5,11 +5,11 @@ namespace NGitLab.Mock;
 
 public sealed class Event : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Title { get; set; }
 
-    public int ProjectId { get; set; }
+    public long ProjectId { get; set; }
 
     public DynamicEnum<EventAction> Action { get; set; }
 
@@ -21,7 +21,7 @@ public sealed class Event : GitLabObject
 
     public string TargetTitle { get; set; }
 
-    public int AuthorId { get; set; }
+    public long AuthorId { get; set; }
 
     public string AuthorUserName { get; set; }
 

--- a/NGitLab.Mock/EventCollection.cs
+++ b/NGitLab.Mock/EventCollection.cs
@@ -25,7 +25,7 @@ public sealed class EventCollection : Collection<Event>
         base.Add(item);
     }
 
-    internal IEnumerable<Event> Get(EventQuery query, int? userId, int? projectId)
+    internal IEnumerable<Event> Get(EventQuery query, long? userId, long? projectId)
     {
         var events = this.AsQueryable();
 
@@ -68,7 +68,7 @@ public sealed class EventCollection : Collection<Event>
         return events;
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(evt => evt.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/GitLabServer.cs
+++ b/NGitLab.Mock/GitLabServer.cs
@@ -13,23 +13,23 @@ namespace NGitLab.Mock;
 public sealed class GitLabServer : GitLabObject, IDisposable
 {
     // Setting to a 'magic' high value to avoid having equalities between IDs and IiDs
-    private int _lastProjectId = 10000;
-    private int _lastGroupId = 10000;
-    private int _lastMergeRequestId = 10000;
-    private int _lastRunnerId = 10000;
-    private int _lastIssueId = 10000;
-    private int _lastMilestoneId = 10000;
-    private int _lastPipelineId = 10000;
-    private int _lastPipelineScheduleId = 10000;
-    private int _lastJobId = 10000;
-    private int _lastBadgeId = 10000;
-    private int _lastLabelId = 10000;
-    private int _lastProtectedBranchId = 10000;
-    private int _lastResourceLabelEventId = 10000;
-    private int _lastResourceMilestoneEventId = 10000;
-    private int _lastResourceStateEventId = 10000;
-    private int _lastTokenId = 10000;
-    private int _lastRegistrationTokenId = 10000;
+    private long _lastProjectId = 10000;
+    private long _lastGroupId = 10000;
+    private long _lastMergeRequestId = 10000;
+    private long _lastRunnerId = 10000;
+    private long _lastIssueId = 10000;
+    private long _lastMilestoneId = 10000;
+    private long _lastPipelineId = 10000;
+    private long _lastPipelineScheduleId = 10000;
+    private long _lastJobId = 10000;
+    private long _lastBadgeId = 10000;
+    private long _lastLabelId = 10000;
+    private long _lastProtectedBranchId = 10000;
+    private long _lastResourceLabelEventId = 10000;
+    private long _lastResourceMilestoneEventId = 10000;
+    private long _lastResourceStateEventId = 10000;
+    private long _lastTokenId = 10000;
+    private long _lastRegistrationTokenId = 10000;
 
     public event EventHandler ClientOperation;
 
@@ -105,35 +105,35 @@ public sealed class GitLabServer : GitLabObject, IDisposable
         }
     }
 
-    internal int GetNewGroupId() => Interlocked.Increment(ref _lastGroupId);
+    internal long GetNewGroupId() => Interlocked.Increment(ref _lastGroupId);
 
-    internal int GetNewProjectId() => Interlocked.Increment(ref _lastProjectId);
+    internal long GetNewProjectId() => Interlocked.Increment(ref _lastProjectId);
 
-    internal int GetNewMergeRequestId() => Interlocked.Increment(ref _lastMergeRequestId);
+    internal long GetNewMergeRequestId() => Interlocked.Increment(ref _lastMergeRequestId);
 
-    internal int GetNewIssueId() => Interlocked.Increment(ref _lastIssueId);
+    internal long GetNewIssueId() => Interlocked.Increment(ref _lastIssueId);
 
-    internal int GetNewMilestoneId() => Interlocked.Increment(ref _lastMilestoneId);
+    internal long GetNewMilestoneId() => Interlocked.Increment(ref _lastMilestoneId);
 
-    internal int GetNewRunnerId() => Interlocked.Increment(ref _lastRunnerId);
+    internal long GetNewRunnerId() => Interlocked.Increment(ref _lastRunnerId);
 
-    internal int GetNewPipelineId() => Interlocked.Increment(ref _lastPipelineId);
+    internal long GetNewPipelineId() => Interlocked.Increment(ref _lastPipelineId);
 
-    internal int GetNewPipelineScheduleId() => Interlocked.Increment(ref _lastPipelineScheduleId);
+    internal long GetNewPipelineScheduleId() => Interlocked.Increment(ref _lastPipelineScheduleId);
 
-    internal int GetNewJobId() => Interlocked.Increment(ref _lastJobId);
+    internal long GetNewJobId() => Interlocked.Increment(ref _lastJobId);
 
-    internal int GetNewBadgeId() => Interlocked.Increment(ref _lastBadgeId);
+    internal long GetNewBadgeId() => Interlocked.Increment(ref _lastBadgeId);
 
-    internal int GetNewLabelId() => Interlocked.Increment(ref _lastLabelId);
+    internal long GetNewLabelId() => Interlocked.Increment(ref _lastLabelId);
 
-    internal int GetNewProtectedBranchId() => Interlocked.Increment(ref _lastProtectedBranchId);
+    internal long GetNewProtectedBranchId() => Interlocked.Increment(ref _lastProtectedBranchId);
 
-    internal int GetNewResourceLabelEventId() => Interlocked.Increment(ref _lastResourceLabelEventId);
+    internal long GetNewResourceLabelEventId() => Interlocked.Increment(ref _lastResourceLabelEventId);
 
-    internal int GetNewResourceMilestoneEventId() => Interlocked.Increment(ref _lastResourceMilestoneEventId);
+    internal long GetNewResourceMilestoneEventId() => Interlocked.Increment(ref _lastResourceMilestoneEventId);
 
-    internal int GetNewResourceStateEventId() => Interlocked.Increment(ref _lastResourceStateEventId);
+    internal long GetNewResourceStateEventId() => Interlocked.Increment(ref _lastResourceStateEventId);
 
     internal string GetNewRunnerToken() => MakeToken(Convert.ToString(Interlocked.Increment(ref _lastTokenId)));
 

--- a/NGitLab.Mock/Group.cs
+++ b/NGitLab.Mock/Group.cs
@@ -249,14 +249,13 @@ public sealed class Group : GitLabObject
         return accessLevel.HasValue && accessLevel.Value >= AccessLevel.Developer;
     }
 
-    public Runner AddRunner(string description, long id = default, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true)
+    public Runner AddRunner(string description, long id = default, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null)
     {
         var runner = new Runner
         {
             Name = name,
             Description = description,
             Paused = paused,
-            Active = active,
             Locked = locked,
             IsShared = isShared,
             IpAddress = "0.0.0.0",

--- a/NGitLab.Mock/Group.cs
+++ b/NGitLab.Mock/Group.cs
@@ -36,7 +36,7 @@ public sealed class Group : GitLabObject
         IsUserNamespace = true;
     }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Name
     {
@@ -249,7 +249,7 @@ public sealed class Group : GitLabObject
         return accessLevel.HasValue && accessLevel.Value >= AccessLevel.Developer;
     }
 
-    public Runner AddRunner(string description, int id = default, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true)
+    public Runner AddRunner(string description, long id = default, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true)
     {
         var runner = new Runner
         {
@@ -270,7 +270,7 @@ public sealed class Group : GitLabObject
         return runner;
     }
 
-    public bool RemoveRunner(int runnerId)
+    public bool RemoveRunner(long runnerId)
     {
         return RegisteredRunners.Remove(runnerId);
     }

--- a/NGitLab.Mock/GroupHook.cs
+++ b/NGitLab.Mock/GroupHook.cs
@@ -6,7 +6,7 @@ public sealed class GroupHook : GitLabObject
 {
     public new Group Parent => (Group)base.Parent;
 
-    public int Id { get; internal set; }
+    public long Id { get; internal set; }
 
     public Uri Url { get; set; }
 

--- a/NGitLab.Mock/GroupHookCollection.cs
+++ b/NGitLab.Mock/GroupHookCollection.cs
@@ -23,7 +23,7 @@ public class GroupHookCollection : Collection<GroupHook>
         base.Add(item);
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(hook => hook.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/Issue.cs
+++ b/NGitLab.Mock/Issue.cs
@@ -9,11 +9,11 @@ public sealed class Issue : GitLabObject
 {
     public Project Project => (Project)Parent;
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
-    public int Iid { get; set; }
+    public long Iid { get; set; }
 
-    public int ProjectId => Project.Id;
+    public long ProjectId => Project.Id;
 
     public string Title { get; set; }
 

--- a/NGitLab.Mock/IssueCollection.cs
+++ b/NGitLab.Mock/IssueCollection.cs
@@ -10,7 +10,7 @@ public sealed class IssueCollection : Collection<Issue>
     {
     }
 
-    public Issue GetByIid(int issueId)
+    public Issue GetByIid(long issueId)
     {
         return this.FirstOrDefault(i => i.Iid == issueId);
     }
@@ -37,7 +37,7 @@ public sealed class IssueCollection : Collection<Issue>
         base.Add(item);
     }
 
-    private int GetNewIid()
+    private long GetNewIid()
     {
         return this.Select(i => i.Iid).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/Job.cs
+++ b/NGitLab.Mock/Job.cs
@@ -8,7 +8,7 @@ public sealed class Job : GitLabObject
 {
     public string Name { get; set; }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Ref { get; set; }
 

--- a/NGitLab.Mock/JobCollection.cs
+++ b/NGitLab.Mock/JobCollection.cs
@@ -10,7 +10,7 @@ public sealed class JobCollection : Collection<Job>
     {
     }
 
-    public Job GetById(int id)
+    public Job GetById(long id)
     {
         return this.FirstOrDefault(job => job.Id == id);
     }

--- a/NGitLab.Mock/Label.cs
+++ b/NGitLab.Mock/Label.cs
@@ -6,7 +6,7 @@ public sealed class Label : GitLabObject
 
     public Group Group => Parent as Group;
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Name { get; set; }
 

--- a/NGitLab.Mock/LabelsCollection.cs
+++ b/NGitLab.Mock/LabelsCollection.cs
@@ -10,7 +10,7 @@ public sealed class LabelsCollection : Collection<Label>
     {
     }
 
-    public Label GetById(int id)
+    public Label GetById(long id)
     {
         return this.FirstOrDefault(l => l.Id == id);
     }

--- a/NGitLab.Mock/MergeRequest.cs
+++ b/NGitLab.Mock/MergeRequest.cs
@@ -30,9 +30,9 @@ public sealed class MergeRequest : GitLabObject
 
     public Project Project => (Project)Parent;
 
-    public int Id { get; internal set; }
+    public long Id { get; internal set; }
 
-    public int Iid { get; internal set; }
+    public long Iid { get; internal set; }
 
     public string Title { get; set; }
 

--- a/NGitLab.Mock/MergeRequestCollection.cs
+++ b/NGitLab.Mock/MergeRequestCollection.cs
@@ -12,7 +12,7 @@ public sealed class MergeRequestCollection : Collection<MergeRequest>
     {
     }
 
-    public MergeRequest GetByIid(int iid)
+    public MergeRequest GetByIid(long iid)
     {
         return this.FirstOrDefault(mr => mr.Iid == iid);
     }
@@ -87,7 +87,7 @@ public sealed class MergeRequestCollection : Collection<MergeRequest>
         return mergeRequest;
     }
 
-    private int GetNewIid()
+    private long GetNewIid()
     {
         return this.Select(mr => mr.Iid).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/MergeRequestComment.cs
+++ b/NGitLab.Mock/MergeRequestComment.cs
@@ -6,9 +6,9 @@ public sealed class MergeRequestComment : Note
 
     public override string NoteableType => "MergeRequest";
 
-    public override int NoticableId => Parent.Id;
+    public override long NoticableId => Parent.Id;
 
-    public override int NoticableIid => Parent.Iid;
+    public override long NoticableIid => Parent.Iid;
 
     internal Models.MergeRequestComment ToMergeRequestCommentClient()
     {

--- a/NGitLab.Mock/Milestone.cs
+++ b/NGitLab.Mock/Milestone.cs
@@ -9,9 +9,9 @@ public sealed class Milestone : GitLabObject
 
     public Group Group => Parent as Group;
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
-    public int Iid { get; set; }
+    public long Iid { get; set; }
 
     public string Title { get; set; }
 

--- a/NGitLab.Mock/MilestoneCollection.cs
+++ b/NGitLab.Mock/MilestoneCollection.cs
@@ -10,7 +10,7 @@ public sealed class MilestoneCollection : Collection<Milestone>
     {
     }
 
-    public Milestone GetByIid(int iid)
+    public Milestone GetByIid(long iid)
     {
         return this.FirstOrDefault(i => i.Iid == iid);
     }
@@ -37,7 +37,7 @@ public sealed class MilestoneCollection : Collection<Milestone>
         base.Add(item);
     }
 
-    private int GetNewIid()
+    private long GetNewIid()
     {
         return this.Select(i => i.Iid).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/Note.cs
+++ b/NGitLab.Mock/Note.cs
@@ -24,9 +24,9 @@ public abstract class Note : GitLabObject
 
     public bool System { get; set; }
 
-    public abstract int NoticableId { get; }
+    public abstract long NoticableId { get; }
 
-    public abstract int NoticableIid { get; }
+    public abstract long NoticableIid { get; }
 
     public abstract string NoteableType { get; }
 

--- a/NGitLab.Mock/Pipeline.cs
+++ b/NGitLab.Mock/Pipeline.cs
@@ -16,9 +16,9 @@ public sealed class Pipeline : GitLabObject
 
     internal bool IsDownStreamPipeline { get; set; }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
-    public int ProjectId => Project?.Id ?? 0;
+    public long ProjectId => Project?.Id ?? 0;
 
     public JobStatus Status { get; set; }
 

--- a/NGitLab.Mock/PipelineCollection.cs
+++ b/NGitLab.Mock/PipelineCollection.cs
@@ -14,7 +14,7 @@ public sealed class PipelineCollection : Collection<Pipeline>
                    throw new ArgumentException("Parent must be a Project", nameof(parent));
     }
 
-    public Pipeline GetById(int id)
+    public Pipeline GetById(long id)
     {
         return this.FirstOrDefault(pipeline => pipeline.Id == id);
     }

--- a/NGitLab.Mock/PipelineSchedule.cs
+++ b/NGitLab.Mock/PipelineSchedule.cs
@@ -9,7 +9,7 @@ public sealed class PipelineSchedule : GitLabObject
 {
     public Project Project => (Project)Parent;
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Description { get; set; }
 

--- a/NGitLab.Mock/PipelineScheduleCollection.cs
+++ b/NGitLab.Mock/PipelineScheduleCollection.cs
@@ -13,7 +13,7 @@ public class PipelineScheduleCollection : Collection<PipelineSchedule>
         _project = project;
     }
 
-    public PipelineSchedule GetById(int id)
+    public PipelineSchedule GetById(long id)
     {
         return this.FirstOrDefault(x => x.Id == id);
     }

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -43,7 +43,7 @@ public sealed class Project : GitLabObject
         ApprovalsBeforeMerge = 0;
     }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Name { get; set; }
 
@@ -99,7 +99,7 @@ public sealed class Project : GitLabObject
 
     public bool Mirror { get; set; }
 
-    public int MirrorUserId { get; set; }
+    public long MirrorUserId { get; set; }
 
     public bool MirrorTriggerBuilds { get; set; }
 
@@ -361,12 +361,12 @@ public sealed class Project : GitLabObject
         return mr;
     }
 
-    public bool RemoveRunner(int runnerId)
+    public bool RemoveRunner(long runnerId)
     {
         return RegisteredRunners.Remove(runnerId);
     }
 
-    public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, int id)
+    public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, long id)
     {
         var runner = new Runner
         {

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -382,7 +382,7 @@ public sealed class Project : GitLabObject
         };
 
         RegisteredRunners.Add(runner);
-        if (paused)
+        if (!paused)
         {
             EnabledRunners.Add(new RunnerRef(runner));
         }

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -366,13 +366,13 @@ public sealed class Project : GitLabObject
         return RegisteredRunners.Remove(runnerId);
     }
 
-    public Runner AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, long id)
+    public Runner AddRunner(string name, string description, bool paused, bool locked, bool isShared, bool runUntagged, long id)
     {
         var runner = new Runner
         {
             Name = name,
             Description = description,
-            Active = active,
+            Paused = paused,
             Locked = locked,
             IsShared = isShared,
             IpAddress = "0.0.0.0",
@@ -382,7 +382,7 @@ public sealed class Project : GitLabObject
         };
 
         RegisteredRunners.Add(runner);
-        if (active)
+        if (paused)
         {
             EnabledRunners.Add(new RunnerRef(runner));
         }

--- a/NGitLab.Mock/ProjectHook.cs
+++ b/NGitLab.Mock/ProjectHook.cs
@@ -6,7 +6,7 @@ public sealed class ProjectHook : GitLabObject
 {
     public new Project Parent => (Project)base.Parent;
 
-    public int Id { get; internal set; }
+    public long Id { get; internal set; }
 
     public Uri Url { get; set; }
 

--- a/NGitLab.Mock/ProjectHookCollection.cs
+++ b/NGitLab.Mock/ProjectHookCollection.cs
@@ -23,7 +23,7 @@ public class ProjectHookCollection : Collection<ProjectHook>
         base.Add(item);
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(hook => hook.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/ProjectIssueNote.cs
+++ b/NGitLab.Mock/ProjectIssueNote.cs
@@ -6,9 +6,9 @@ public sealed class ProjectIssueNote : Note
 
     public override string NoteableType => "Issue";
 
-    public override int NoticableId => Parent.Id;
+    public override long NoticableId => Parent.Id;
 
-    public override int NoticableIid => Parent.Iid;
+    public override long NoticableIid => Parent.Iid;
 
     internal Models.ProjectIssueNote ToProjectIssueNote()
     {

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -429,7 +429,7 @@ NGitLab.Mock.GitLabServer.Users.get -> NGitLab.Mock.UserCollection
 NGitLab.Mock.GitLabServer.Version.get -> NGitLab.Models.GitLabVersion
 NGitLab.Mock.GitLabServer.Version.set -> void
 NGitLab.Mock.Group
-NGitLab.Mock.Group.AddRunner(string description, long id = 0, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true) -> NGitLab.Mock.Runner
+NGitLab.Mock.Group.AddRunner(string description, long id = 0, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null) -> NGitLab.Mock.Runner
 NGitLab.Mock.Group.AllProjects.get -> System.Collections.Generic.IEnumerable<NGitLab.Mock.Project>
 NGitLab.Mock.Group.Badges.get -> NGitLab.Mock.BadgeCollection
 NGitLab.Mock.Group.CanUserAddGroup(NGitLab.Mock.User user) -> bool
@@ -872,7 +872,7 @@ NGitLab.Mock.Project.AccessibleMergeRequests.get -> bool
 NGitLab.Mock.Project.AccessibleMergeRequests.set -> void
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged) -> NGitLab.Mock.Runner
-NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, long id) -> NGitLab.Mock.Runner
+NGitLab.Mock.Project.AddRunner(string name, string description, bool paused, bool locked, bool isShared, bool runUntagged, long id) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.get -> bool
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.set -> void
 NGitLab.Mock.Project.ApprovalsBeforeMerge.get -> int
@@ -1148,8 +1148,6 @@ NGitLab.Mock.ResourceStateEvent.User.set -> void
 NGitLab.Mock.ResourceStateEventCollection
 NGitLab.Mock.ResourceStateEventCollection.ResourceStateEventCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.Runner
-NGitLab.Mock.Runner.Active.get -> bool
-NGitLab.Mock.Runner.Active.set -> void
 NGitLab.Mock.Runner.ContactedAt.get -> System.DateTime
 NGitLab.Mock.Runner.ContactedAt.set -> void
 NGitLab.Mock.Runner.Description.get -> string

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -1,10 +1,10 @@
 abstract NGitLab.Mock.File.Content.get -> byte[]
 abstract NGitLab.Mock.Note.NoteableType.get -> string
-abstract NGitLab.Mock.Note.NoticableId.get -> int
-abstract NGitLab.Mock.Note.NoticableIid.get -> int
+abstract NGitLab.Mock.Note.NoticableId.get -> long
+abstract NGitLab.Mock.Note.NoticableIid.get -> long
 NGitLab.Mock.Badge
 NGitLab.Mock.Badge.Badge() -> void
-NGitLab.Mock.Badge.Id.get -> int
+NGitLab.Mock.Badge.Id.get -> long
 NGitLab.Mock.Badge.Id.set -> void
 NGitLab.Mock.Badge.ImageUrl.get -> string
 NGitLab.Mock.Badge.ImageUrl.set -> void
@@ -19,7 +19,7 @@ NGitLab.Mock.Badge.ToBadgeModel() -> NGitLab.Models.Badge
 NGitLab.Mock.BadgeCollection
 NGitLab.Mock.BadgeCollection.Add(string linkUrl, string imageUrl) -> NGitLab.Mock.Badge
 NGitLab.Mock.BadgeCollection.BadgeCollection(NGitLab.Mock.GitLabObject parent) -> void
-NGitLab.Mock.BadgeCollection.GetById(int id) -> NGitLab.Mock.Badge
+NGitLab.Mock.BadgeCollection.GetById(long id) -> NGitLab.Mock.Badge
 NGitLab.Mock.Change
 NGitLab.Mock.Change.AMode.get -> long
 NGitLab.Mock.Change.AMode.set -> void
@@ -277,7 +277,7 @@ NGitLab.Mock.Config.GitLabMilestone.UpdatedAt.set -> void
 NGitLab.Mock.Config.GitLabMilestonesCollection
 NGitLab.Mock.Config.GitLabObject
 NGitLab.Mock.Config.GitLabObject.GitLabObject() -> void
-NGitLab.Mock.Config.GitLabObject.Id.get -> int
+NGitLab.Mock.Config.GitLabObject.Id.get -> long
 NGitLab.Mock.Config.GitLabObject.Id.set -> void
 NGitLab.Mock.Config.GitLabObject.ParentObject.get -> object
 NGitLab.Mock.Config.GitLabObject<TParent>
@@ -367,18 +367,18 @@ NGitLab.Mock.EffectiveUserPermission.User.get -> NGitLab.Mock.User
 NGitLab.Mock.Event
 NGitLab.Mock.Event.Action.get -> NGitLab.DynamicEnum<NGitLab.Models.EventAction>
 NGitLab.Mock.Event.Action.set -> void
-NGitLab.Mock.Event.AuthorId.get -> int
+NGitLab.Mock.Event.AuthorId.get -> long
 NGitLab.Mock.Event.AuthorId.set -> void
 NGitLab.Mock.Event.AuthorUserName.get -> string
 NGitLab.Mock.Event.AuthorUserName.set -> void
 NGitLab.Mock.Event.CreatedAt.get -> System.DateTime
 NGitLab.Mock.Event.CreatedAt.set -> void
 NGitLab.Mock.Event.Event() -> void
-NGitLab.Mock.Event.Id.get -> int
+NGitLab.Mock.Event.Id.get -> long
 NGitLab.Mock.Event.Id.set -> void
 NGitLab.Mock.Event.Note.get -> NGitLab.Mock.Note
 NGitLab.Mock.Event.Note.set -> void
-NGitLab.Mock.Event.ProjectId.get -> int
+NGitLab.Mock.Event.ProjectId.get -> long
 NGitLab.Mock.Event.ProjectId.set -> void
 NGitLab.Mock.Event.PushData.get -> NGitLab.Models.PushData
 NGitLab.Mock.Event.PushData.set -> void
@@ -429,7 +429,7 @@ NGitLab.Mock.GitLabServer.Users.get -> NGitLab.Mock.UserCollection
 NGitLab.Mock.GitLabServer.Version.get -> NGitLab.Models.GitLabVersion
 NGitLab.Mock.GitLabServer.Version.set -> void
 NGitLab.Mock.Group
-NGitLab.Mock.Group.AddRunner(string description, int id = 0, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true) -> NGitLab.Mock.Runner
+NGitLab.Mock.Group.AddRunner(string description, long id = 0, string name = "gitlab-runner", bool paused = false, bool locked = true, bool isShared = false, bool runUntagged = false, string[] tagList = null, bool active = true) -> NGitLab.Mock.Runner
 NGitLab.Mock.Group.AllProjects.get -> System.Collections.Generic.IEnumerable<NGitLab.Mock.Project>
 NGitLab.Mock.Group.Badges.get -> NGitLab.Mock.BadgeCollection
 NGitLab.Mock.Group.CanUserAddGroup(NGitLab.Mock.User user) -> bool
@@ -453,7 +453,7 @@ NGitLab.Mock.Group.Group(NGitLab.Mock.User user) -> void
 NGitLab.Mock.Group.Group(string name) -> void
 NGitLab.Mock.Group.Groups.get -> NGitLab.Mock.GroupCollection
 NGitLab.Mock.Group.Hooks.get -> NGitLab.Mock.GroupHookCollection
-NGitLab.Mock.Group.Id.get -> int
+NGitLab.Mock.Group.Id.get -> long
 NGitLab.Mock.Group.Id.set -> void
 NGitLab.Mock.Group.IsUserNamespace.get -> bool
 NGitLab.Mock.Group.IsUserOwner(NGitLab.Mock.User user) -> bool
@@ -471,7 +471,7 @@ NGitLab.Mock.Group.PathWithNameSpace.get -> string
 NGitLab.Mock.Group.Permissions.get -> NGitLab.Mock.PermissionCollection
 NGitLab.Mock.Group.Projects.get -> NGitLab.Mock.ProjectCollection
 NGitLab.Mock.Group.RegisteredRunners.get -> NGitLab.Mock.RunnerCollection
-NGitLab.Mock.Group.RemoveRunner(int runnerId) -> bool
+NGitLab.Mock.Group.RemoveRunner(long runnerId) -> bool
 NGitLab.Mock.Group.RequestAccessEnabled.get -> bool
 NGitLab.Mock.Group.RequestAccessEnabled.set -> void
 NGitLab.Mock.Group.RunnersToken.get -> string
@@ -489,7 +489,7 @@ NGitLab.Mock.GroupHook.CreatedAt.set -> void
 NGitLab.Mock.GroupHook.EnableSslVerification.get -> bool
 NGitLab.Mock.GroupHook.EnableSslVerification.set -> void
 NGitLab.Mock.GroupHook.GroupHook() -> void
-NGitLab.Mock.GroupHook.Id.get -> int
+NGitLab.Mock.GroupHook.Id.get -> long
 NGitLab.Mock.GroupHook.IssuesEvents.get -> bool
 NGitLab.Mock.GroupHook.IssuesEvents.set -> void
 NGitLab.Mock.GroupHook.JobEvents.get -> bool
@@ -530,9 +530,9 @@ NGitLab.Mock.Issue.CreatedAt.get -> System.DateTimeOffset
 NGitLab.Mock.Issue.CreatedAt.set -> void
 NGitLab.Mock.Issue.Description.get -> string
 NGitLab.Mock.Issue.Description.set -> void
-NGitLab.Mock.Issue.Id.get -> int
+NGitLab.Mock.Issue.Id.get -> long
 NGitLab.Mock.Issue.Id.set -> void
-NGitLab.Mock.Issue.Iid.get -> int
+NGitLab.Mock.Issue.Iid.get -> long
 NGitLab.Mock.Issue.Iid.set -> void
 NGitLab.Mock.Issue.Issue() -> void
 NGitLab.Mock.Issue.Labels.get -> string[]
@@ -542,7 +542,7 @@ NGitLab.Mock.Issue.Milestone.set -> void
 NGitLab.Mock.Issue.Notes.get -> System.Collections.Generic.IList<NGitLab.Mock.ProjectIssueNote>
 NGitLab.Mock.Issue.Notes.set -> void
 NGitLab.Mock.Issue.Project.get -> NGitLab.Mock.Project
-NGitLab.Mock.Issue.ProjectId.get -> int
+NGitLab.Mock.Issue.ProjectId.get -> long
 NGitLab.Mock.Issue.State.get -> NGitLab.Mock.IssueState
 NGitLab.Mock.Issue.State.set -> void
 NGitLab.Mock.Issue.Title.get -> string
@@ -552,7 +552,7 @@ NGitLab.Mock.Issue.UpdatedAt.get -> System.DateTimeOffset
 NGitLab.Mock.Issue.UpdatedAt.set -> void
 NGitLab.Mock.Issue.WebUrl.get -> string
 NGitLab.Mock.IssueCollection
-NGitLab.Mock.IssueCollection.GetByIid(int issueId) -> NGitLab.Mock.Issue
+NGitLab.Mock.IssueCollection.GetByIid(long issueId) -> NGitLab.Mock.Issue
 NGitLab.Mock.IssueCollection.IssueCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.IssueState
 NGitLab.Mock.IssueState.closed = 1 -> NGitLab.Mock.IssueState
@@ -576,7 +576,7 @@ NGitLab.Mock.Job.FailureReason.get -> string
 NGitLab.Mock.Job.FailureReason.set -> void
 NGitLab.Mock.Job.FinishedAt.get -> System.DateTime
 NGitLab.Mock.Job.FinishedAt.set -> void
-NGitLab.Mock.Job.Id.get -> int
+NGitLab.Mock.Job.Id.get -> long
 NGitLab.Mock.Job.Id.set -> void
 NGitLab.Mock.Job.Job() -> void
 NGitLab.Mock.Job.JobToken.get -> string
@@ -611,7 +611,7 @@ NGitLab.Mock.JobCollection
 NGitLab.Mock.JobCollection.Add(NGitLab.Mock.Job job, NGitLab.Mock.Pipeline pipeline) -> NGitLab.Mock.Job
 NGitLab.Mock.JobCollection.AddNew() -> NGitLab.Mock.Job
 NGitLab.Mock.JobCollection.AddNew(NGitLab.Mock.Pipeline pipeline) -> NGitLab.Mock.Job
-NGitLab.Mock.JobCollection.GetById(int id) -> NGitLab.Mock.Job
+NGitLab.Mock.JobCollection.GetById(long id) -> NGitLab.Mock.Job
 NGitLab.Mock.JobCollection.JobCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.Label
 NGitLab.Mock.Label.Color.get -> string
@@ -619,7 +619,7 @@ NGitLab.Mock.Label.Color.set -> void
 NGitLab.Mock.Label.Description.get -> string
 NGitLab.Mock.Label.Description.set -> void
 NGitLab.Mock.Label.Group.get -> NGitLab.Mock.Group
-NGitLab.Mock.Label.Id.get -> int
+NGitLab.Mock.Label.Id.get -> long
 NGitLab.Mock.Label.Id.set -> void
 NGitLab.Mock.Label.Label() -> void
 NGitLab.Mock.Label.Name.get -> string
@@ -628,7 +628,7 @@ NGitLab.Mock.Label.Project.get -> NGitLab.Mock.Project
 NGitLab.Mock.Label.ToClientLabel() -> NGitLab.Models.Label
 NGitLab.Mock.LabelsCollection
 NGitLab.Mock.LabelsCollection.Add(string name = null, string color = null, string description = null) -> NGitLab.Mock.Label
-NGitLab.Mock.LabelsCollection.GetById(int id) -> NGitLab.Mock.Label
+NGitLab.Mock.LabelsCollection.GetById(long id) -> NGitLab.Mock.Label
 NGitLab.Mock.LabelsCollection.GetByName(string name) -> NGitLab.Mock.Label
 NGitLab.Mock.LabelsCollection.LabelsCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.LintCI
@@ -665,8 +665,8 @@ NGitLab.Mock.MergeRequest.GetDiscussions() -> System.Collections.Generic.IEnumer
 NGitLab.Mock.MergeRequest.HasConflicts.get -> bool
 NGitLab.Mock.MergeRequest.HeadPipeline.get -> NGitLab.Mock.Pipeline
 NGitLab.Mock.MergeRequest.HeadSha.get -> string
-NGitLab.Mock.MergeRequest.Id.get -> int
-NGitLab.Mock.MergeRequest.Iid.get -> int
+NGitLab.Mock.MergeRequest.Id.get -> long
+NGitLab.Mock.MergeRequest.Iid.get -> long
 NGitLab.Mock.MergeRequest.Labels.get -> System.Collections.Generic.IList<string>
 NGitLab.Mock.MergeRequest.MergeCommitSha.get -> NGitLab.Sha1?
 NGitLab.Mock.MergeRequest.MergeCommitSha.set -> void
@@ -710,7 +710,7 @@ NGitLab.Mock.MergeRequestCollection
 NGitLab.Mock.MergeRequestCollection.Add(NGitLab.Mock.Project sourceProject, string sourceBranch, string targetBranch, string title, NGitLab.Mock.User user) -> NGitLab.Mock.MergeRequest
 NGitLab.Mock.MergeRequestCollection.Add(string sourceBranch, string targetBranch, string title, NGitLab.Mock.User user) -> NGitLab.Mock.MergeRequest
 NGitLab.Mock.MergeRequestCollection.AddNew(NGitLab.Mock.User author, string title = null, bool addCommit = false) -> NGitLab.Mock.MergeRequest
-NGitLab.Mock.MergeRequestCollection.GetByIid(int iid) -> NGitLab.Mock.MergeRequest
+NGitLab.Mock.MergeRequestCollection.GetByIid(long iid) -> NGitLab.Mock.MergeRequest
 NGitLab.Mock.MergeRequestCollection.MergeRequestCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.MergeRequestComment
 NGitLab.Mock.MergeRequestComment.MergeRequestComment() -> void
@@ -724,9 +724,9 @@ NGitLab.Mock.Milestone.Description.set -> void
 NGitLab.Mock.Milestone.DueDate.get -> System.DateTimeOffset
 NGitLab.Mock.Milestone.DueDate.set -> void
 NGitLab.Mock.Milestone.Group.get -> NGitLab.Mock.Group
-NGitLab.Mock.Milestone.Id.get -> int
+NGitLab.Mock.Milestone.Id.get -> long
 NGitLab.Mock.Milestone.Id.set -> void
-NGitLab.Mock.Milestone.Iid.get -> int
+NGitLab.Mock.Milestone.Iid.get -> long
 NGitLab.Mock.Milestone.Iid.set -> void
 NGitLab.Mock.Milestone.Milestone() -> void
 NGitLab.Mock.Milestone.Project.get -> NGitLab.Mock.Project
@@ -740,7 +740,7 @@ NGitLab.Mock.Milestone.ToClientMilestone() -> NGitLab.Models.Milestone
 NGitLab.Mock.Milestone.UpdatedAt.get -> System.DateTimeOffset
 NGitLab.Mock.Milestone.UpdatedAt.set -> void
 NGitLab.Mock.MilestoneCollection
-NGitLab.Mock.MilestoneCollection.GetByIid(int iid) -> NGitLab.Mock.Milestone
+NGitLab.Mock.MilestoneCollection.GetByIid(long iid) -> NGitLab.Mock.Milestone
 NGitLab.Mock.MilestoneCollection.MilestoneCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.MilestoneState
 NGitLab.Mock.MilestoneState.active = 0 -> NGitLab.Mock.MilestoneState
@@ -803,13 +803,13 @@ NGitLab.Mock.Pipeline.Duration.get -> System.TimeSpan?
 NGitLab.Mock.Pipeline.Duration.set -> void
 NGitLab.Mock.Pipeline.FinishedAt.get -> System.DateTimeOffset?
 NGitLab.Mock.Pipeline.FinishedAt.set -> void
-NGitLab.Mock.Pipeline.Id.get -> int
+NGitLab.Mock.Pipeline.Id.get -> long
 NGitLab.Mock.Pipeline.Id.set -> void
 NGitLab.Mock.Pipeline.Name.get -> string
 NGitLab.Mock.Pipeline.Name.set -> void
 NGitLab.Mock.Pipeline.Pipeline(string ref) -> void
 NGitLab.Mock.Pipeline.Project.get -> NGitLab.Mock.Project
-NGitLab.Mock.Pipeline.ProjectId.get -> int
+NGitLab.Mock.Pipeline.ProjectId.get -> long
 NGitLab.Mock.Pipeline.Ref.get -> string
 NGitLab.Mock.Pipeline.Ref.set -> void
 NGitLab.Mock.Pipeline.Sha.get -> NGitLab.Sha1
@@ -836,7 +836,7 @@ NGitLab.Mock.Pipeline.YamlError.get -> string
 NGitLab.Mock.Pipeline.YamlError.set -> void
 NGitLab.Mock.PipelineCollection
 NGitLab.Mock.PipelineCollection.Add(string ref, NGitLab.JobStatus status, NGitLab.Mock.User user) -> NGitLab.Mock.Pipeline
-NGitLab.Mock.PipelineCollection.GetById(int id) -> NGitLab.Mock.Pipeline
+NGitLab.Mock.PipelineCollection.GetById(long id) -> NGitLab.Mock.Pipeline
 NGitLab.Mock.PipelineCollection.PipelineCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.PipelineSchedule
 NGitLab.Mock.PipelineSchedule.Active.get -> bool
@@ -848,7 +848,7 @@ NGitLab.Mock.PipelineSchedule.Cron.get -> string
 NGitLab.Mock.PipelineSchedule.Cron.set -> void
 NGitLab.Mock.PipelineSchedule.Description.get -> string
 NGitLab.Mock.PipelineSchedule.Description.set -> void
-NGitLab.Mock.PipelineSchedule.Id.get -> int
+NGitLab.Mock.PipelineSchedule.Id.get -> long
 NGitLab.Mock.PipelineSchedule.Id.set -> void
 NGitLab.Mock.PipelineSchedule.NextRunAt.get -> System.DateTime
 NGitLab.Mock.PipelineSchedule.NextRunAt.set -> void
@@ -865,14 +865,14 @@ NGitLab.Mock.PipelineSchedule.UpdatedAt.set -> void
 NGitLab.Mock.PipelineSchedule.Variables.get -> System.Collections.Generic.IDictionary<string, string>
 NGitLab.Mock.PipelineSchedule.Variables.set -> void
 NGitLab.Mock.PipelineScheduleCollection
-NGitLab.Mock.PipelineScheduleCollection.GetById(int id) -> NGitLab.Mock.PipelineSchedule
+NGitLab.Mock.PipelineScheduleCollection.GetById(long id) -> NGitLab.Mock.PipelineSchedule
 NGitLab.Mock.PipelineScheduleCollection.PipelineScheduleCollection(NGitLab.Mock.Project project) -> void
 NGitLab.Mock.Project
 NGitLab.Mock.Project.AccessibleMergeRequests.get -> bool
 NGitLab.Mock.Project.AccessibleMergeRequests.set -> void
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged) -> NGitLab.Mock.Runner
-NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, int id) -> NGitLab.Mock.Runner
+NGitLab.Mock.Project.AddRunner(string name, string description, bool active, bool locked, bool isShared, bool runUntagged, long id) -> NGitLab.Mock.Runner
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.get -> bool
 NGitLab.Mock.Project.AllThreadsMustBeResolvedToMerge.set -> void
 NGitLab.Mock.Project.ApprovalsBeforeMerge.get -> int
@@ -910,7 +910,7 @@ NGitLab.Mock.Project.GroupRunnersEnabled.get -> bool
 NGitLab.Mock.Project.GroupRunnersEnabled.set -> void
 NGitLab.Mock.Project.Hooks.get -> NGitLab.Mock.ProjectHookCollection
 NGitLab.Mock.Project.HttpUrl.get -> string
-NGitLab.Mock.Project.Id.get -> int
+NGitLab.Mock.Project.Id.get -> long
 NGitLab.Mock.Project.Id.set -> void
 NGitLab.Mock.Project.ImportStatus.get -> string
 NGitLab.Mock.Project.ImportStatus.set -> void
@@ -932,7 +932,7 @@ NGitLab.Mock.Project.MirrorOverwritesDivergedBranches.get -> bool
 NGitLab.Mock.Project.MirrorOverwritesDivergedBranches.set -> void
 NGitLab.Mock.Project.MirrorTriggerBuilds.get -> bool
 NGitLab.Mock.Project.MirrorTriggerBuilds.set -> void
-NGitLab.Mock.Project.MirrorUserId.get -> int
+NGitLab.Mock.Project.MirrorUserId.get -> long
 NGitLab.Mock.Project.MirrorUserId.set -> void
 NGitLab.Mock.Project.Name.get -> string
 NGitLab.Mock.Project.Name.set -> void
@@ -950,7 +950,7 @@ NGitLab.Mock.Project.ProtectedBranches.get -> NGitLab.Mock.ProtectedBranchCollec
 NGitLab.Mock.Project.RegisteredRunners.get -> NGitLab.Mock.RunnerCollection
 NGitLab.Mock.Project.Releases.get -> NGitLab.Mock.ReleaseCollection
 NGitLab.Mock.Project.Remove() -> void
-NGitLab.Mock.Project.RemoveRunner(int runnerId) -> bool
+NGitLab.Mock.Project.RemoveRunner(long runnerId) -> bool
 NGitLab.Mock.Project.Repository.get -> NGitLab.Mock.Repository
 NGitLab.Mock.Project.RepositoryAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Project.RepositoryAccessLevel.set -> void
@@ -976,7 +976,7 @@ NGitLab.Mock.ProjectHook.CreatedAt.get -> System.DateTime
 NGitLab.Mock.ProjectHook.CreatedAt.set -> void
 NGitLab.Mock.ProjectHook.EnableSslVerification.get -> bool
 NGitLab.Mock.ProjectHook.EnableSslVerification.set -> void
-NGitLab.Mock.ProjectHook.Id.get -> int
+NGitLab.Mock.ProjectHook.Id.get -> long
 NGitLab.Mock.ProjectHook.IssuesEvents.get -> bool
 NGitLab.Mock.ProjectHook.IssuesEvents.set -> void
 NGitLab.Mock.ProjectHook.JobEvents.get -> bool
@@ -1097,11 +1097,11 @@ NGitLab.Mock.ResourceLabelEvent.Action.get -> NGitLab.Models.ResourceLabelEventA
 NGitLab.Mock.ResourceLabelEvent.Action.set -> void
 NGitLab.Mock.ResourceLabelEvent.CreatedAt.get -> System.DateTime
 NGitLab.Mock.ResourceLabelEvent.CreatedAt.set -> void
-NGitLab.Mock.ResourceLabelEvent.Id.get -> int
+NGitLab.Mock.ResourceLabelEvent.Id.get -> long
 NGitLab.Mock.ResourceLabelEvent.Id.set -> void
 NGitLab.Mock.ResourceLabelEvent.Label.get -> NGitLab.Mock.Label
 NGitLab.Mock.ResourceLabelEvent.Label.set -> void
-NGitLab.Mock.ResourceLabelEvent.ResourceId.get -> int
+NGitLab.Mock.ResourceLabelEvent.ResourceId.get -> long
 NGitLab.Mock.ResourceLabelEvent.ResourceId.set -> void
 NGitLab.Mock.ResourceLabelEvent.ResourceLabelEvent() -> void
 NGitLab.Mock.ResourceLabelEvent.ResourceType.get -> string
@@ -1116,11 +1116,11 @@ NGitLab.Mock.ResourceMilestoneEvent.Action.get -> NGitLab.Models.ResourceMilesto
 NGitLab.Mock.ResourceMilestoneEvent.Action.set -> void
 NGitLab.Mock.ResourceMilestoneEvent.CreatedAt.get -> System.DateTime
 NGitLab.Mock.ResourceMilestoneEvent.CreatedAt.set -> void
-NGitLab.Mock.ResourceMilestoneEvent.Id.get -> int
+NGitLab.Mock.ResourceMilestoneEvent.Id.get -> long
 NGitLab.Mock.ResourceMilestoneEvent.Id.set -> void
 NGitLab.Mock.ResourceMilestoneEvent.Milestone.get -> NGitLab.Mock.Milestone
 NGitLab.Mock.ResourceMilestoneEvent.Milestone.set -> void
-NGitLab.Mock.ResourceMilestoneEvent.ResourceId.get -> int
+NGitLab.Mock.ResourceMilestoneEvent.ResourceId.get -> long
 NGitLab.Mock.ResourceMilestoneEvent.ResourceId.set -> void
 NGitLab.Mock.ResourceMilestoneEvent.ResourceMilestoneEvent() -> void
 NGitLab.Mock.ResourceMilestoneEvent.ResourceType.get -> string
@@ -1133,9 +1133,9 @@ NGitLab.Mock.ResourceMilestoneEventCollection.ResourceMilestoneEventCollection(N
 NGitLab.Mock.ResourceStateEvent
 NGitLab.Mock.ResourceStateEvent.CreatedAt.get -> System.DateTime
 NGitLab.Mock.ResourceStateEvent.CreatedAt.set -> void
-NGitLab.Mock.ResourceStateEvent.Id.get -> int
+NGitLab.Mock.ResourceStateEvent.Id.get -> long
 NGitLab.Mock.ResourceStateEvent.Id.set -> void
-NGitLab.Mock.ResourceStateEvent.ResourceId.get -> int
+NGitLab.Mock.ResourceStateEvent.ResourceId.get -> long
 NGitLab.Mock.ResourceStateEvent.ResourceId.set -> void
 NGitLab.Mock.ResourceStateEvent.ResourceStateEvent() -> void
 NGitLab.Mock.ResourceStateEvent.ResourceType.get -> string
@@ -1154,7 +1154,7 @@ NGitLab.Mock.Runner.ContactedAt.get -> System.DateTime
 NGitLab.Mock.Runner.ContactedAt.set -> void
 NGitLab.Mock.Runner.Description.get -> string
 NGitLab.Mock.Runner.Description.set -> void
-NGitLab.Mock.Runner.Id.get -> int
+NGitLab.Mock.Runner.Id.get -> long
 NGitLab.Mock.Runner.Id.set -> void
 NGitLab.Mock.Runner.IpAddress.get -> string
 NGitLab.Mock.Runner.IpAddress.set -> void
@@ -1181,10 +1181,10 @@ NGitLab.Mock.Runner.Token.set -> void
 NGitLab.Mock.Runner.Version.get -> string
 NGitLab.Mock.Runner.Version.set -> void
 NGitLab.Mock.RunnerCollection
-NGitLab.Mock.RunnerCollection.Remove(int id) -> bool
+NGitLab.Mock.RunnerCollection.Remove(long id) -> bool
 NGitLab.Mock.RunnerCollection.RunnerCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.RunnerRef
-NGitLab.Mock.RunnerRef.Id.get -> int
+NGitLab.Mock.RunnerRef.Id.get -> long
 NGitLab.Mock.RunnerRef.RunnerRef(NGitLab.Mock.Runner runner) -> void
 NGitLab.Mock.RunnerRefCollection
 NGitLab.Mock.RunnerRefCollection.RunnerRefCollection(NGitLab.Mock.GitLabObject parent) -> void
@@ -1197,7 +1197,7 @@ NGitLab.Mock.SystemHook.CreatedAt.get -> System.DateTime
 NGitLab.Mock.SystemHook.CreatedAt.set -> void
 NGitLab.Mock.SystemHook.EnableSslVerification.get -> bool
 NGitLab.Mock.SystemHook.EnableSslVerification.set -> void
-NGitLab.Mock.SystemHook.Id.get -> int
+NGitLab.Mock.SystemHook.Id.get -> long
 NGitLab.Mock.SystemHook.MergeRequestsEvents.get -> bool
 NGitLab.Mock.SystemHook.MergeRequestsEvents.set -> void
 NGitLab.Mock.SystemHook.PushEvents.get -> bool
@@ -1233,7 +1233,7 @@ NGitLab.Mock.User.CreatedAt.get -> System.DateTime
 NGitLab.Mock.User.CreatedAt.set -> void
 NGitLab.Mock.User.Email.get -> string
 NGitLab.Mock.User.Email.set -> void
-NGitLab.Mock.User.Id.get -> int
+NGitLab.Mock.User.Id.get -> long
 NGitLab.Mock.User.Id.set -> void
 NGitLab.Mock.User.Identities.get -> NGitLab.Models.Identity[]
 NGitLab.Mock.User.Identities.set -> void
@@ -1252,12 +1252,12 @@ NGitLab.Mock.User.WebUrl.get -> string
 NGitLab.Mock.UserCollection
 NGitLab.Mock.UserCollection.Add(string userName) -> NGitLab.Mock.User
 NGitLab.Mock.UserCollection.AddNew(string name = null) -> NGitLab.Mock.User
-NGitLab.Mock.UserCollection.GetById(int id) -> NGitLab.Mock.User
+NGitLab.Mock.UserCollection.GetById(long id) -> NGitLab.Mock.User
 NGitLab.Mock.UserCollection.GetById(string id) -> NGitLab.Mock.User
 NGitLab.Mock.UserCollection.UserCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.UserRef
 NGitLab.Mock.UserRef.Email.get -> string
-NGitLab.Mock.UserRef.Id.get -> int
+NGitLab.Mock.UserRef.Id.get -> long
 NGitLab.Mock.UserRef.Name.get -> string
 NGitLab.Mock.UserRef.ToClientAssignee() -> NGitLab.Models.Assignee
 NGitLab.Mock.UserRef.ToClientAuthor() -> NGitLab.Models.Author
@@ -1279,8 +1279,8 @@ override NGitLab.Mock.JobCollection.Add(NGitLab.Mock.Job job) -> void
 override NGitLab.Mock.LabelsCollection.Add(NGitLab.Mock.Label label) -> void
 override NGitLab.Mock.MergeRequestCollection.Add(NGitLab.Mock.MergeRequest mergeRequest) -> void
 override NGitLab.Mock.MergeRequestComment.NoteableType.get -> string
-override NGitLab.Mock.MergeRequestComment.NoticableId.get -> int
-override NGitLab.Mock.MergeRequestComment.NoticableIid.get -> int
+override NGitLab.Mock.MergeRequestComment.NoticableId.get -> long
+override NGitLab.Mock.MergeRequestComment.NoticableIid.get -> long
 override NGitLab.Mock.MilestoneCollection.Add(NGitLab.Mock.Milestone item) -> void
 override NGitLab.Mock.NonTextFile.Content.get -> byte[]
 override NGitLab.Mock.NoteCollection<T>.Add(T item) -> void
@@ -1289,8 +1289,8 @@ override NGitLab.Mock.PipelineScheduleCollection.Add(NGitLab.Mock.PipelineSchedu
 override NGitLab.Mock.ProjectCollection.Add(NGitLab.Mock.Project project) -> void
 override NGitLab.Mock.ProjectHookCollection.Add(NGitLab.Mock.ProjectHook item) -> void
 override NGitLab.Mock.ProjectIssueNote.NoteableType.get -> string
-override NGitLab.Mock.ProjectIssueNote.NoticableId.get -> int
-override NGitLab.Mock.ProjectIssueNote.NoticableIid.get -> int
+override NGitLab.Mock.ProjectIssueNote.NoticableId.get -> long
+override NGitLab.Mock.ProjectIssueNote.NoticableIid.get -> long
 override NGitLab.Mock.ProtectedBranchCollection.Add(NGitLab.Mock.ProtectedBranch branch) -> void
 override NGitLab.Mock.ReleaseCollection.Add(NGitLab.Mock.ReleaseInfo release) -> void
 override NGitLab.Mock.ResourceLabelEventCollection.Add(NGitLab.Mock.ResourceLabelEvent item) -> void
@@ -1324,19 +1324,19 @@ static NGitLab.Mock.Config.GitLabHelpers.SetDefaultUser(this NGitLab.Mock.Config
 static NGitLab.Mock.Config.GitLabHelpers.SetDefaultVisibility(this NGitLab.Mock.Config.GitLabConfig config, NGitLab.Models.VisibilityLevel visibility) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.ToConfig(this NGitLab.Mock.GitLabServer server) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithApprover(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string approver) -> NGitLab.Mock.Config.GitLabMergeRequest
-static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, int id = 0, string author = null, bool system = false, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, string thread = null, bool resolvable = false, bool resolved = false, System.Action<NGitLab.Mock.Config.GitLabComment> configure = null) -> NGitLab.Mock.Config.GitLabIssue
+static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, long id = 0, string author = null, bool system = false, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, string thread = null, bool resolvable = false, bool resolved = false, System.Action<NGitLab.Mock.Config.GitLabComment> configure = null) -> NGitLab.Mock.Config.GitLabIssue
 static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabIssue issue, string message, System.Action<NGitLab.Mock.Config.GitLabComment> configure) -> NGitLab.Mock.Config.GitLabIssue
-static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, int id = 0, string author = null, bool system = false, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, string thread = null, bool resolvable = false, bool resolved = false, System.Action<NGitLab.Mock.Config.GitLabComment> configure = null) -> NGitLab.Mock.Config.GitLabMergeRequest
+static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, long id = 0, string author = null, bool system = false, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, string thread = null, bool resolvable = false, bool resolved = false, System.Action<NGitLab.Mock.Config.GitLabComment> configure = null) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message, System.Action<NGitLab.Mock.Config.GitLabComment> configure) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message = null, string user = null, string sourceBranch = null, string targetBranch = null, string fromBranch = null, System.Collections.Generic.IEnumerable<string> tags = null, string alias = null, System.Action<NGitLab.Mock.Config.GitLabCommit> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithCommit(this NGitLab.Mock.Config.GitLabProject project, string message, string user, System.Action<NGitLab.Mock.Config.GitLabCommit> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithFile(this NGitLab.Mock.Config.GitLabCommit commit, string relativePath, string content = "") -> NGitLab.Mock.Config.GitLabCommit
-static NGitLab.Mock.Config.GitLabHelpers.WithGroup(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithGroup(this NGitLab.Mock.Config.GitLabConfig config, string name = null, long id = 0, string namespace = null, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithGroup(this NGitLab.Mock.Config.GitLabConfig config, string name, System.Action<NGitLab.Mock.Config.GitLabGroup> configure) -> NGitLab.Mock.Config.GitLabConfig
-static NGitLab.Mock.Config.GitLabHelpers.WithGroupOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, int id = 0, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithGroupOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, long id = 0, string description = null, NGitLab.Models.VisibilityLevel? visibility = null, bool addDefaultUserAsMaintainer = false, System.Action<NGitLab.Mock.Config.GitLabGroup> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithGroupPermission(this NGitLab.Mock.Config.GitLabGroup grp, string groupName, NGitLab.Models.AccessLevel level) -> NGitLab.Mock.Config.GitLabGroup
 static NGitLab.Mock.Config.GitLabHelpers.WithGroupPermission(this NGitLab.Mock.Config.GitLabProject project, string groupName, NGitLab.Models.AccessLevel level) -> NGitLab.Mock.Config.GitLabProject
-static NGitLab.Mock.Config.GitLabHelpers.WithIssue(this NGitLab.Mock.Config.GitLabProject project, string title = null, int id = 0, string description = null, string author = null, string assignee = null, string milestone = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Collections.Generic.IEnumerable<string> labels = null, System.Action<NGitLab.Mock.Config.GitLabIssue> configure = null) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithIssue(this NGitLab.Mock.Config.GitLabProject project, string title = null, long id = 0, string description = null, string author = null, string assignee = null, string milestone = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Collections.Generic.IEnumerable<string> labels = null, System.Action<NGitLab.Mock.Config.GitLabIssue> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithIssue(this NGitLab.Mock.Config.GitLabProject project, string title, string author, System.Action<NGitLab.Mock.Config.GitLabIssue> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithJob(this NGitLab.Mock.Config.GitLabPipeline pipeline, string name = null, string stage = null, NGitLab.JobStatus status = NGitLab.JobStatus.Unknown, System.DateTime? createdAt = null, System.DateTime? startedAt = null, System.DateTime? finishedAt = null, bool allowFailure = false, NGitLab.Mock.Config.GitLabPipeline downstreamPipeline = null, System.Action<NGitLab.Mock.Config.GitLabJob> configure = null) -> NGitLab.Mock.Config.GitLabPipeline
 static NGitLab.Mock.Config.GitLabHelpers.WithLabel(this NGitLab.Mock.Config.GitLabGroup group, string name, string color = null, string description = null) -> NGitLab.Mock.Config.GitLabGroup
@@ -1344,20 +1344,20 @@ static NGitLab.Mock.Config.GitLabHelpers.WithLabel(this NGitLab.Mock.Config.GitL
 static NGitLab.Mock.Config.GitLabHelpers.WithLabel(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string label) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithLabel(this NGitLab.Mock.Config.GitLabProject project, string name, string color = null, string description = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithMergeCommit(this NGitLab.Mock.Config.GitLabProject project, string sourceBranch, string targetBranch = null, string user = null, bool deleteSourceBranch = false, System.Collections.Generic.IEnumerable<string> tags = null, System.Action<NGitLab.Mock.Config.GitLabCommit> configure = null) -> NGitLab.Mock.Config.GitLabProject
-static NGitLab.Mock.Config.GitLabHelpers.WithMergeRequest(this NGitLab.Mock.Config.GitLabProject project, string sourceBranch = null, string title = null, int id = 0, string targetBranch = null, string description = null, string author = null, string assignee = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.DateTime? mergedAt = null, System.Collections.Generic.IEnumerable<string> approvers = null, System.Collections.Generic.IEnumerable<string> labels = null, string milestone = null, System.Action<NGitLab.Mock.Config.GitLabMergeRequest> configure = null) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithMergeRequest(this NGitLab.Mock.Config.GitLabProject project, string sourceBranch = null, string title = null, long id = 0, string targetBranch = null, string description = null, string author = null, string assignee = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.DateTime? mergedAt = null, System.Collections.Generic.IEnumerable<string> approvers = null, System.Collections.Generic.IEnumerable<string> labels = null, string milestone = null, System.Action<NGitLab.Mock.Config.GitLabMergeRequest> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithMergeRequest(this NGitLab.Mock.Config.GitLabProject project, string sourceBranch, string title, string author, System.Action<NGitLab.Mock.Config.GitLabMergeRequest> configure) -> NGitLab.Mock.Config.GitLabProject
-static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabGroup group, string title, int id = 0, string description = null, System.DateTime? dueDate = null, System.DateTime? startDate = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure = null) -> NGitLab.Mock.Config.GitLabGroup
+static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabGroup group, string title, long id = 0, string description = null, System.DateTime? dueDate = null, System.DateTime? startDate = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure = null) -> NGitLab.Mock.Config.GitLabGroup
 static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabGroup group, string title, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure) -> NGitLab.Mock.Config.GitLabGroup
-static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabProject project, string title, int id = 0, string description = null, System.DateTime? dueDate = null, System.DateTime? startDate = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure = null) -> NGitLab.Mock.Config.GitLabProject
+static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabProject project, string title, long id = 0, string description = null, System.DateTime? dueDate = null, System.DateTime? startDate = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null, System.DateTime? closedAt = null, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithMilestone(this NGitLab.Mock.Config.GitLabProject project, string title, System.Action<NGitLab.Mock.Config.GitLabMilestone> configure) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithPipeline(this NGitLab.Mock.Config.GitLabProject project, string ref, System.Action<NGitLab.Mock.Config.GitLabPipeline> configure) -> NGitLab.Mock.Config.GitLabProject
-static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name = null, int id = 0, string namespace = null, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name = null, long id = 0, string namespace = null, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithProject(this NGitLab.Mock.Config.GitLabConfig config, string name, System.Action<NGitLab.Mock.Config.GitLabProject> configure) -> NGitLab.Mock.Config.GitLabConfig
-static NGitLab.Mock.Config.GitLabHelpers.WithProjectOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, int id = 0, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
+static NGitLab.Mock.Config.GitLabHelpers.WithProjectOfFullPath(this NGitLab.Mock.Config.GitLabConfig config, string fullPath, string name = null, long id = 0, string description = null, string defaultBranch = null, NGitLab.Models.VisibilityLevel visibility = NGitLab.Models.VisibilityLevel.Internal, bool initialCommit = false, bool addDefaultUserAsMaintainer = false, string clonePath = null, string cloneParameters = null, System.Action<NGitLab.Mock.Config.GitLabProject> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithRelease(this NGitLab.Mock.Config.GitLabProject project, string author, string tagName, System.DateTime? createdAt = null, System.DateTime? releasedAt = null) -> NGitLab.Mock.Config.GitLabProject
 static NGitLab.Mock.Config.GitLabHelpers.WithSubModule(this NGitLab.Mock.Config.GitLabCommit commit, string projectName) -> NGitLab.Mock.Config.GitLabCommit
-static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabIssue
-static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, string innerHtml = null, int id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabMergeRequest
+static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabIssue issue, string message = null, string innerHtml = null, long id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabIssue
+static NGitLab.Mock.Config.GitLabHelpers.WithSystemComment(this NGitLab.Mock.Config.GitLabMergeRequest mergeRequest, string message = null, string innerHtml = null, long id = 0, string author = null, System.DateTime? createdAt = null, System.DateTime? updatedAt = null) -> NGitLab.Mock.Config.GitLabMergeRequest
 static NGitLab.Mock.Config.GitLabHelpers.WithTag(this NGitLab.Mock.Config.GitLabCommit commit, string name) -> NGitLab.Mock.Config.GitLabCommit
 static NGitLab.Mock.Config.GitLabHelpers.WithUser(this NGitLab.Mock.Config.GitLabConfig config, string username, string name = null, string email = null, string avatarUrl = null, bool isAdmin = false, bool isDefault = false, System.Action<NGitLab.Mock.Config.GitLabUser> configure = null) -> NGitLab.Mock.Config.GitLabConfig
 static NGitLab.Mock.Config.GitLabHelpers.WithUser(this NGitLab.Mock.Config.GitLabConfig config, string username, System.Action<NGitLab.Mock.Config.GitLabUser> configure) -> NGitLab.Mock.Config.GitLabConfig

--- a/NGitLab.Mock/ResourceLabelEvent.cs
+++ b/NGitLab.Mock/ResourceLabelEvent.cs
@@ -5,13 +5,13 @@ namespace NGitLab.Mock;
 
 public sealed class ResourceLabelEvent : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public Author User { get; set; }
 
     public DateTime CreatedAt { get; set; }
 
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     public string ResourceType { get; set; }
 

--- a/NGitLab.Mock/ResourceLabelEventCollection.cs
+++ b/NGitLab.Mock/ResourceLabelEventCollection.cs
@@ -25,7 +25,7 @@ public sealed class ResourceLabelEventCollection : Collection<ResourceLabelEvent
         base.Add(item);
     }
 
-    internal IEnumerable<ResourceLabelEvent> Get(int? resourceId)
+    internal IEnumerable<ResourceLabelEvent> Get(long? resourceId)
     {
         var resourceLabelEvents = this.AsQueryable();
 
@@ -37,12 +37,12 @@ public sealed class ResourceLabelEventCollection : Collection<ResourceLabelEvent
         return resourceLabelEvents;
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(rle => rle.Id).DefaultIfEmpty().Max() + 1;
     }
 
-    internal void CreateResourceLabelEvents(User currentUser, string[] previousLabels, string[] newLabels, int resourceId, string resourceType)
+    internal void CreateResourceLabelEvents(User currentUser, string[] previousLabels, string[] newLabels, long resourceId, string resourceType)
     {
         foreach (var label in previousLabels)
         {

--- a/NGitLab.Mock/ResourceMilestoneEvent.cs
+++ b/NGitLab.Mock/ResourceMilestoneEvent.cs
@@ -5,13 +5,13 @@ namespace NGitLab.Mock;
 
 public sealed class ResourceMilestoneEvent : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public Author User { get; set; }
 
     public DateTime CreatedAt { get; set; }
 
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     public string ResourceType { get; set; }
 

--- a/NGitLab.Mock/ResourceMilestoneEventCollection.cs
+++ b/NGitLab.Mock/ResourceMilestoneEventCollection.cs
@@ -25,7 +25,7 @@ public sealed class ResourceMilestoneEventCollection : Collection<ResourceMilest
         base.Add(item);
     }
 
-    internal IEnumerable<ResourceMilestoneEvent> Get(int? resourceId)
+    internal IEnumerable<ResourceMilestoneEvent> Get(long? resourceId)
     {
         var resourceMilestoneEvents = this.AsQueryable();
 
@@ -37,12 +37,12 @@ public sealed class ResourceMilestoneEventCollection : Collection<ResourceMilest
         return resourceMilestoneEvents;
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(rle => rle.Id).DefaultIfEmpty().Max() + 1;
     }
 
-    internal void CreateResourceMilestoneEvents(User currentUser, int resourceId, Milestone previousMilestone, Milestone newMilestone, string resourceType)
+    internal void CreateResourceMilestoneEvents(User currentUser, long resourceId, Milestone previousMilestone, Milestone newMilestone, string resourceType)
     {
         if (previousMilestone is null)
         {
@@ -59,7 +59,7 @@ public sealed class ResourceMilestoneEventCollection : Collection<ResourceMilest
         }
     }
 
-    internal void CreateResourceMilestoneEvent(User currentUser, int resourceId, Milestone milestone, ResourceMilestoneEventAction action, string resourceType)
+    internal void CreateResourceMilestoneEvent(User currentUser, long resourceId, Milestone milestone, ResourceMilestoneEventAction action, string resourceType)
     {
         Add(new ResourceMilestoneEvent()
         {

--- a/NGitLab.Mock/ResourceStateEvent.cs
+++ b/NGitLab.Mock/ResourceStateEvent.cs
@@ -5,13 +5,13 @@ namespace NGitLab.Mock;
 
 public sealed class ResourceStateEvent : GitLabObject
 {
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public Author User { get; set; }
 
     public DateTime CreatedAt { get; set; }
 
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     public string ResourceType { get; set; }
 

--- a/NGitLab.Mock/ResourceStateEventCollection.cs
+++ b/NGitLab.Mock/ResourceStateEventCollection.cs
@@ -25,7 +25,7 @@ public sealed class ResourceStateEventCollection : Collection<ResourceStateEvent
         base.Add(item);
     }
 
-    internal IEnumerable<ResourceStateEvent> Get(int? resourceId)
+    internal IEnumerable<ResourceStateEvent> Get(long? resourceId)
     {
         var resourceStateEvents = this.AsQueryable();
 
@@ -37,12 +37,12 @@ public sealed class ResourceStateEventCollection : Collection<ResourceStateEvent
         return resourceStateEvents;
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(rle => rle.Id).DefaultIfEmpty().Max() + 1;
     }
 
-    internal void CreateResourceStateEvent(User currentUser, string state, int id, string resourceType)
+    internal void CreateResourceStateEvent(User currentUser, string state, long id, string resourceType)
     {
         Add(new ResourceStateEvent()
         {

--- a/NGitLab.Mock/Runner.cs
+++ b/NGitLab.Mock/Runner.cs
@@ -13,8 +13,6 @@ public sealed class Runner : GitLabObject
 
     public bool Paused { get; set; }
 
-    public bool Active { get; set; }
-
     public bool? Online { get; set; }
 
     public string Status { get; set; }
@@ -43,9 +41,7 @@ public sealed class Runner : GitLabObject
         {
             Id = Id,
             Name = Name,
-#pragma warning disable CS0618 // Type or member is obsolete
-            Active = Active,
-#pragma warning restore CS0618 // Type or member is obsolete
+            Paused = Paused,
             Online = Online ?? false,
             Status = Status,
             Description = Description,

--- a/NGitLab.Mock/Runner.cs
+++ b/NGitLab.Mock/Runner.cs
@@ -7,7 +7,7 @@ public sealed class Runner : GitLabObject
 {
     public new Project Parent => (Project)base.Parent;
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string Name { get; set; }
 

--- a/NGitLab.Mock/RunnerCollection.cs
+++ b/NGitLab.Mock/RunnerCollection.cs
@@ -28,7 +28,7 @@ public sealed class RunnerCollection : Collection<Runner>
         base.Add(item);
     }
 
-    public bool Remove(int id)
+    public bool Remove(long id)
     {
         var r = this.SingleOrDefault(r => r.Id == id);
         return Remove(r);

--- a/NGitLab.Mock/RunnerRef.cs
+++ b/NGitLab.Mock/RunnerRef.cs
@@ -7,7 +7,7 @@ public sealed class RunnerRef : GitLabObject
 {
     private readonly Runner _runner;
 
-    public int Id => _runner.Id;
+    public long Id => _runner.Id;
 
     public RunnerRef(Runner runner)
     {
@@ -17,11 +17,11 @@ public sealed class RunnerRef : GitLabObject
     public override bool Equals(object obj)
     {
         return obj is RunnerRef @ref &&
-               EqualityComparer<int>.Default.Equals(Id, @ref.Id);
+               EqualityComparer<long>.Default.Equals(Id, @ref.Id);
     }
 
     public override int GetHashCode()
     {
-        return -1771473357 + EqualityComparer<int>.Default.GetHashCode(Id);
+        return -1771473357 + EqualityComparer<long>.Default.GetHashCode(Id);
     }
 }

--- a/NGitLab.Mock/RunnersExtensions.cs
+++ b/NGitLab.Mock/RunnersExtensions.cs
@@ -6,22 +6,16 @@ internal static class RunnersExtensions
 {
     public static bool? IsActive(this RunnerRegister runner)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        return runner.Active ?? !runner.Paused;
-#pragma warning restore CS0618 // Type or member is obsolete
+        return !runner.Paused;
     }
 
     public static bool? IsActive(this RunnerUpdate runner)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        return runner.Active ?? !runner.Paused;
-#pragma warning restore CS0618 // Type or member is obsolete
+        return !runner.Paused;
     }
 
     public static bool IsActive(this Runner runner)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        return runner.Active || !runner.Paused;
-#pragma warning restore CS0618 // Type or member is obsolete
+        return !runner.Paused;
     }
 }

--- a/NGitLab.Mock/SystemHook.cs
+++ b/NGitLab.Mock/SystemHook.cs
@@ -4,7 +4,7 @@ namespace NGitLab.Mock;
 
 public sealed class SystemHook : GitLabObject
 {
-    public int Id { get; internal set; }
+    public long Id { get; internal set; }
 
     public Uri Url { get; set; }
 

--- a/NGitLab.Mock/SystemHookCollection.cs
+++ b/NGitLab.Mock/SystemHookCollection.cs
@@ -23,7 +23,7 @@ public class SystemHookCollection : Collection<SystemHook>
         base.Add(item);
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(hook => hook.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/User.cs
+++ b/NGitLab.Mock/User.cs
@@ -14,7 +14,7 @@ public sealed class User : GitLabObject
         State = UserState.active;
     }
 
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     public string UserName { get; }
 

--- a/NGitLab.Mock/UserCollection.cs
+++ b/NGitLab.Mock/UserCollection.cs
@@ -20,7 +20,7 @@ public sealed class UserCollection : Collection<User>
         return this.FirstOrDefault(u => StringComparer.OrdinalIgnoreCase.Equals(u.UserName, id));
     }
 
-    public User GetById(int id) => this.FirstOrDefault(user => user.Id == id);
+    public User GetById(long id) => this.FirstOrDefault(user => user.Id == id);
 
     public User AddNew(string name = null)
     {
@@ -77,7 +77,7 @@ public sealed class UserCollection : Collection<User>
         base.Add(user);
     }
 
-    private int GetNewId()
+    private long GetNewId()
     {
         return this.Select(user => user.Id).DefaultIfEmpty().Max() + 1;
     }

--- a/NGitLab.Mock/UserRef.cs
+++ b/NGitLab.Mock/UserRef.cs
@@ -12,7 +12,7 @@ public sealed class UserRef
         _user = user ?? throw new ArgumentNullException(nameof(user));
     }
 
-    public int Id => _user.Id;
+    public long Id => _user.Id;
 
     public string Name => _user.Name;
 

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -184,14 +184,14 @@ public sealed class GitLabTestContext : IDisposable
         }
     }
 
-    public Project CreateProject(int parentGroupId, Action<ProjectCreate> configure = null, bool initializeWithCommits = false) =>
+    public Project CreateProject(long parentGroupId, Action<ProjectCreate> configure = null, bool initializeWithCommits = false) =>
         CreateProject(initializeWithCommits: initializeWithCommits, configure: p =>
         {
             p.NamespaceId = new GroupId(parentGroupId).ValueAsString();
             configure?.Invoke(p);
         });
 
-    public Project CreateProject(int parentGroupId, string slug, string name = null, Action<ProjectCreate> configure = null, bool initializeWithCommits = false) =>
+    public Project CreateProject(long parentGroupId, string slug, string name = null, Action<ProjectCreate> configure = null, bool initializeWithCommits = false) =>
         CreateProject(parentGroupId, initializeWithCommits: initializeWithCommits, configure: p =>
         {
             p.Path = slug;
@@ -223,14 +223,14 @@ public sealed class GitLabTestContext : IDisposable
             configure?.Invoke(g);
         });
 
-    public Group CreateSubgroup(int parentGroupId, Action<GroupCreate> configure = null) =>
+    public Group CreateSubgroup(long parentGroupId, Action<GroupCreate> configure = null) =>
         CreateGroup(g =>
         {
             g.ParentId = parentGroupId;
             configure?.Invoke(g);
         });
 
-    public Group CreateSubgroup(int parentGroupId, string slug, string name = null, Action<GroupCreate> configure = null) =>
+    public Group CreateSubgroup(long parentGroupId, string slug, string name = null, Action<GroupCreate> configure = null) =>
         CreateSubgroup(parentGroupId, g =>
         {
             g.Path = slug;
@@ -334,7 +334,7 @@ public sealed class GitLabTestContext : IDisposable
                string.Equals(Environment.GetEnvironmentVariable("GITLAB_CI"), "true", StringComparison.OrdinalIgnoreCase);
     }
 
-    public async Task<IDisposable> StartRunnerForOneJobAsync(int projectId)
+    public async Task<IDisposable> StartRunnerForOneJobAsync(long projectId)
     {
         // Download runner (windows / linux, GitLab version)
         await s_prepareRunnerLock.WaitAsync().ConfigureAwait(false);

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -187,7 +187,7 @@ public sealed class GitLabTestContext : IDisposable
     public Project CreateProject(long parentGroupId, Action<ProjectCreate> configure = null, bool initializeWithCommits = false) =>
         CreateProject(initializeWithCommits: initializeWithCommits, configure: p =>
         {
-            p.NamespaceId = new GroupId(parentGroupId).ValueAsString();
+            p.NamespaceId = parentGroupId;
             configure?.Invoke(p);
         });
 

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -85,7 +85,7 @@ public class GroupsTests
         await GitLabTestContext.RetryUntilAsync(() => TryGetGroup(groupClient, group.Id), group => group == null || group.MarkedForDeletionOn != null, TimeSpan.FromMinutes(2));
     }
 
-    private static Group TryGetGroup(IGroupsClient groupClient, int groupId)
+    private static Group TryGetGroup(IGroupsClient groupClient, long groupId)
     {
         try
         {
@@ -473,7 +473,7 @@ public class GroupsTests
             Search = project.Name,
         }).ToArray();
 
-        Assert.That(projects.Select(p => p.Id), Is.EquivalentTo(new int[] { project.Id }));
+        Assert.That(projects.Select(p => p.Id), Is.EquivalentTo(new[] { project.Id }));
     }
 
     [Test]

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -30,7 +29,7 @@ public class GroupsTests
         using var context = await GitLabTestContext.CreateAsync();
         var groupClient = context.Client.Groups;
         var group = context.CreateGroup();
-        var project = context.Client.Projects.Create(new ProjectCreate { Name = "test", NamespaceId = group.Id.ToString(CultureInfo.InvariantCulture) });
+        var project = context.Client.Projects.Create(new ProjectCreate { Name = "test", NamespaceId = group.Id });
 
         group = groupClient[group.Id];
         Assert.That(group, Is.Not.Null);

--- a/NGitLab.Tests/JsonTests.cs
+++ b/NGitLab.Tests/JsonTests.cs
@@ -67,6 +67,6 @@ public class JsonTests
         public string Title;
 
         [JsonPropertyName("id")]
-        public int Id;
+        public long Id;
     }
 }

--- a/NGitLab.Tests/MembersClientTests.cs
+++ b/NGitLab.Tests/MembersClientTests.cs
@@ -170,7 +170,7 @@ public class MembersClientTests
         var user1Id = user1.Id.ToString();
 
         // Add the user to the top-level group as a Maintainer...
-        await client.Members.AddMemberToGroupAsync(group1, new()
+        await client.Members.AddMemberToGroupAsync(group1.Id, new()
         {
             AccessLevel = AccessLevel.Maintainer,
             UserId = user1Id,

--- a/NGitLab.Tests/Milestone/MilestoneClientTests.cs
+++ b/NGitLab.Tests/Milestone/MilestoneClientTests.cs
@@ -98,7 +98,7 @@ public class MilestoneClientTests
         Assert.That(mergeRequests, Has.Length.EqualTo(1), "The query retrieved all merged requests that assigned to the milestone.");
     }
 
-    private static Models.Milestone CreateMilestone(GitLabTestContext context, MilestoneScope scope, int id, string title)
+    private static Models.Milestone CreateMilestone(GitLabTestContext context, MilestoneScope scope, long id, string title)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         var milestone = milestoneClient.Create(new MilestoneCreate
@@ -120,7 +120,7 @@ public class MilestoneClientTests
         return milestone;
     }
 
-    private static Models.Milestone UpdateMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
+    private static Models.Milestone UpdateMilestone(GitLabTestContext context, MilestoneScope scope, long id, Models.Milestone milestone)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         var updatedMilestone = milestoneClient.Update(milestone.Id, new MilestoneUpdate
@@ -143,7 +143,7 @@ public class MilestoneClientTests
         return updatedMilestone;
     }
 
-    private static Models.Milestone UpdatePartialMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
+    private static Models.Milestone UpdatePartialMilestone(GitLabTestContext context, MilestoneScope scope, long id, Models.Milestone milestone)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         var updatedMilestone = milestoneClient.Update(milestone.Id, new MilestoneUpdate
@@ -163,7 +163,7 @@ public class MilestoneClientTests
         return updatedMilestone;
     }
 
-    private static Models.Milestone ActivateMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
+    private static Models.Milestone ActivateMilestone(GitLabTestContext context, MilestoneScope scope, long id, Models.Milestone milestone)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         var activeMilestone = milestoneClient.Activate(milestone.Id);
@@ -179,7 +179,7 @@ public class MilestoneClientTests
         return activeMilestone;
     }
 
-    private static Models.Milestone CloseMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
+    private static Models.Milestone CloseMilestone(GitLabTestContext context, MilestoneScope scope, long id, Models.Milestone milestone)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         var closedMilestone = milestoneClient.Close(milestone.Id);
@@ -195,7 +195,7 @@ public class MilestoneClientTests
         return closedMilestone;
     }
 
-    private static void DeleteMilestone(GitLabTestContext context, MilestoneScope scope, int id, Models.Milestone milestone)
+    private static void DeleteMilestone(GitLabTestContext context, MilestoneScope scope, long id, Models.Milestone milestone)
     {
         var milestoneClient = scope == MilestoneScope.Projects ? context.Client.GetMilestone(id) : context.Client.GetGroupMilestone(id);
         milestoneClient.Delete(milestone.Id);

--- a/NGitLab.Tests/Milestone/MilestoneClientTests.cs
+++ b/NGitLab.Tests/Milestone/MilestoneClientTests.cs
@@ -86,7 +86,7 @@ public class MilestoneClientTests
     {
         using var context = await GitLabTestContext.CreateAsync();
         var group = context.CreateGroup();
-        var (project, mergeRequest) = context.CreateMergeRequest(configureProject: project => project.NamespaceId = group.Id.ToString());
+        var (project, mergeRequest) = context.CreateMergeRequest(configureProject: project => project.NamespaceId = group.Id);
 
         var milestoneClient = context.Client.GetGroupMilestone(group.Id);
         var milestone = CreateMilestone(context, MilestoneScope.Groups, group.Id, "my-super-milestone");

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -751,7 +751,7 @@ public class ProjectsTests
             Search = group.Name,
         }).ToArray();
 
-        Assert.That(groups.Select(g => g.Id), Is.EquivalentTo(new int[] { group.Id }));
+        Assert.That(groups.Select(g => g.Id), Is.EquivalentTo(new[] { group.Id }));
     }
 
     [Test]
@@ -766,6 +766,6 @@ public class ProjectsTests
 
         var groups = projectClient.GetGroupsAsync(project.Id, new ProjectGroupsQuery()).ToArray();
 
-        Assert.That(groups.Select(g => g.Id), Is.EquivalentTo(new int[] { group.Id, subgroup.Id }));
+        Assert.That(groups.Select(g => g.Id), Is.EquivalentTo(new[] { group.Id, subgroup.Id }));
     }
 }

--- a/NGitLab/DynamicEnum.cs
+++ b/NGitLab/DynamicEnum.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable IDE0250 // Make struct 'readonly', this would be a breaking change
-#pragma warning disable MA0102  // Make member readonly, this would be a breaking change
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace NGitLab;
@@ -9,7 +7,7 @@ namespace NGitLab;
 /// Allows to expose enums without knowing all the possible values
 /// that can be serialized from the client.
 /// </summary>
-public struct DynamicEnum<TEnum> : IEquatable<DynamicEnum<TEnum>>, IEquatable<TEnum>
+public readonly struct DynamicEnum<TEnum> : IEquatable<DynamicEnum<TEnum>>, IEquatable<TEnum>
     where TEnum : struct, Enum
 {
     /// <summary>

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NGitLab.Extensions;
+﻿using NGitLab.Extensions;
 using NGitLab.Impl;
 using NGitLab.Models;
 

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -94,14 +94,6 @@ public class GitLabClient : IGitLabClient
         Lint = new LintClient(_api);
     }
 
-    [Obsolete("Use GitLabClient constructor instead")]
-    public static GitLabClient Connect(string hostUrl, string apiToken)
-        => new(hostUrl, apiToken);
-
-    [Obsolete("Use GitLabClient constructor instead")]
-    public static GitLabClient Connect(string hostUrl, string username, string password)
-        => new(hostUrl, username, password);
-
     public IEventClient GetEvents()
         => new EventClient(_api, "events");
 

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -105,35 +105,20 @@ public class GitLabClient : IGitLabClient
     public IEventClient GetEvents()
         => new EventClient(_api, "events");
 
-    public IEventClient GetUserEvents(int userId)
+    public IEventClient GetUserEvents(long userId)
         => new EventClient(_api, $"users/{userId.ToStringInvariant()}/events");
-
-    public IEventClient GetProjectEvents(int projectId)
-        => GetProjectEvents((long)projectId);
 
     public IEventClient GetProjectEvents(ProjectId projectId)
         => new EventClient(_api, $"projects/{projectId.ValueAsUriParameter()}/events");
 
-    public IRepositoryClient GetRepository(int projectId)
-        => GetRepository((long)projectId);
-
     public IRepositoryClient GetRepository(ProjectId projectId)
         => new RepositoryClient(_api, projectId);
-
-    public ICommitClient GetCommits(int projectId)
-        => GetCommits((long)projectId);
 
     public ICommitClient GetCommits(ProjectId projectId)
         => new CommitClient(_api, projectId);
 
-    public ICommitStatusClient GetCommitStatus(int projectId)
-        => GetCommitStatus((long)projectId);
-
     public ICommitStatusClient GetCommitStatus(ProjectId projectId)
         => new CommitStatusClient(_api, projectId);
-
-    public IPipelineClient GetPipelines(int projectId)
-        => GetPipelines((long)projectId);
 
     public IPipelineClient GetPipelines(ProjectId projectId)
         => new PipelineClient(_api, projectId);
@@ -141,20 +126,11 @@ public class GitLabClient : IGitLabClient
     public IPipelineScheduleClient GetPipelineSchedules(ProjectId projectId)
         => new PipelineScheduleClient(_api, projectId);
 
-    public ITriggerClient GetTriggers(int projectId)
-        => GetTriggers((long)projectId);
-
     public ITriggerClient GetTriggers(ProjectId projectId)
         => new TriggerClient(_api, projectId);
 
-    public IJobClient GetJobs(int projectId)
-        => GetJobs((long)projectId);
-
     public IJobClient GetJobs(ProjectId projectId)
         => new JobClient(_api, projectId);
-
-    public IMergeRequestClient GetMergeRequest(int projectId)
-        => GetMergeRequest((long)projectId);
 
     public IMergeRequestClient GetMergeRequest(ProjectId projectId)
         => new MergeRequestClient(_api, projectId);
@@ -162,80 +138,41 @@ public class GitLabClient : IGitLabClient
     public IMergeRequestClient GetGroupMergeRequest(GroupId groupId)
         => new MergeRequestClient(_api, groupId);
 
-    public IMilestoneClient GetMilestone(int projectId)
-        => GetMilestone((long)projectId);
-
     public IMilestoneClient GetMilestone(ProjectId projectId)
         => new MilestoneClient(_api, MilestoneScope.Projects, projectId);
-
-    public IMilestoneClient GetGroupMilestone(int groupId)
-        => GetGroupMilestone((long)groupId);
 
     public IMilestoneClient GetGroupMilestone(GroupId groupId)
         => new MilestoneClient(_api, MilestoneScope.Groups, groupId);
 
-    public IReleaseClient GetReleases(int projectId)
-        => GetReleases((long)projectId);
-
     public IReleaseClient GetReleases(ProjectId projectId)
         => new ReleaseClient(_api, projectId);
-
-    public IProjectIssueNoteClient GetProjectIssueNoteClient(int projectId)
-        => GetProjectIssueNoteClient((long)projectId);
 
     public IProjectIssueNoteClient GetProjectIssueNoteClient(ProjectId projectId)
         => new ProjectIssueNoteClient(_api, projectId);
 
-    public IEnvironmentClient GetEnvironmentClient(int projectId)
-        => GetEnvironmentClient((long)projectId);
-
     public IEnvironmentClient GetEnvironmentClient(ProjectId projectId)
         => new EnvironmentClient(_api, projectId);
-
-    public IClusterClient GetClusterClient(int projectId)
-        => GetClusterClient((long)projectId);
 
     public IClusterClient GetClusterClient(ProjectId projectId)
         => new ClusterClient(_api, projectId);
 
-    public IWikiClient GetWikiClient(int projectId)
-        => GetWikiClient((long)projectId);
-
     public IWikiClient GetWikiClient(ProjectId projectId)
         => new WikiClient(_api, projectId);
-
-    public IProjectBadgeClient GetProjectBadgeClient(int projectId)
-        => GetProjectBadgeClient((long)projectId);
 
     public IProjectBadgeClient GetProjectBadgeClient(ProjectId projectId)
         => new ProjectBadgeClient(_api, projectId);
 
-    public IGroupBadgeClient GetGroupBadgeClient(int groupId)
-        => GetGroupBadgeClient((long)groupId);
-
     public IGroupBadgeClient GetGroupBadgeClient(GroupId groupId)
         => new GroupBadgeClient(_api, groupId);
-
-    public IProjectVariableClient GetProjectVariableClient(int projectId)
-        => GetProjectVariableClient((long)projectId);
 
     public IProjectVariableClient GetProjectVariableClient(ProjectId projectId)
         => new ProjectVariableClient(_api, projectId);
 
-    public IGroupVariableClient GetGroupVariableClient(int groupId)
-        => GetGroupVariableClient((long)groupId);
-
     public IGroupVariableClient GetGroupVariableClient(GroupId groupId)
         => new GroupVariableClient(_api, groupId);
 
-    public IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(int projectId)
-        => GetProjectLevelApprovalRulesClient((long)projectId);
-
     public IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(ProjectId projectId)
         => new ProjectLevelApprovalRulesClient(_api, projectId);
-
-    public IProtectedBranchClient GetProtectedBranchClient(int projectId)
-        => GetProtectedBranchClient((long)projectId);
 
     public IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId)
         => new ProtectedBranchClient(_api, projectId);
@@ -243,14 +180,8 @@ public class GitLabClient : IGitLabClient
     public IProtectedTagClient GetProtectedTagClient(ProjectId projectId)
         => new ProtectedTagClient(_api, projectId);
 
-    public ISearchClient GetGroupSearchClient(int groupId)
-        => GetGroupSearchClient((long)groupId);
-
     public ISearchClient GetGroupSearchClient(GroupId groupId)
         => new SearchClient(_api, $"/groups/{groupId.ValueAsUriParameter()}/search");
-
-    public ISearchClient GetProjectSearchClient(int projectId)
-        => GetProjectSearchClient((long)projectId);
 
     public ISearchClient GetProjectSearchClient(ProjectId projectId)
         => new SearchClient(_api, $"/projects/{projectId.ValueAsUriParameter()}/search");

--- a/NGitLab/IDeploymentClient.cs
+++ b/NGitLab/IDeploymentClient.cs
@@ -11,7 +11,7 @@ public interface IDeploymentClient
     /// <param name="projectId">Project ID</param>
     /// <param name="query">Filtering and ordering query</param>
     /// <returns></returns>
-    IEnumerable<Deployment> Get(int projectId, DeploymentQuery query);
+    IEnumerable<Deployment> Get(long projectId, DeploymentQuery query);
 
     /// <summary>
     /// Return a deployment's associated Merge Requests
@@ -19,5 +19,5 @@ public interface IDeploymentClient
     /// <param name="projectId">Project ID</param>
     /// <param name="deploymentId">Deployment ID</param>
     /// <returns></returns>
-    IEnumerable<MergeRequest> GetMergeRequests(int projectId, int deploymentId);
+    IEnumerable<MergeRequest> GetMergeRequests(long projectId, long deploymentId);
 }

--- a/NGitLab/IEnvironmentClient.cs
+++ b/NGitLab/IEnvironmentClient.cs
@@ -33,7 +33,7 @@ public interface IEnvironmentClient
     /// - Renaming an environment with the API removed in GitLab 16.0.
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    EnvironmentInfo Edit(int environmentId, string name, string externalUrl);
+    EnvironmentInfo Edit(long environmentId, string name, string externalUrl);
 
     /// <summary>
     /// Updates an existing environment's external_url.
@@ -41,20 +41,20 @@ public interface IEnvironmentClient
     /// <param name="environmentId">The ID of the environment</param>
     /// <param name="externalUrl">The new external url</param>
     /// <returns>The updated environment</returns>
-    EnvironmentInfo Edit(int environmentId, string externalUrl);
+    EnvironmentInfo Edit(long environmentId, string externalUrl);
 
     /// <summary>
     /// Delete an environment.
     /// </summary>
     /// <param name="environmentId">The ID of the environment</param>
-    void Delete(int environmentId);
+    void Delete(long environmentId);
 
     /// <summary>
     /// Stop an environment.
     /// </summary>
     /// <param name="environmentId">The ID of the environment</param>
     /// <returns>The stopped environment</returns>
-    EnvironmentInfo Stop(int environmentId);
+    EnvironmentInfo Stop(long environmentId);
 
     /// <summary>
     /// List environments of the project
@@ -68,12 +68,12 @@ public interface IEnvironmentClient
     /// </summary>
     /// <param name="environmentId">The ID of the environment</param>
     /// <returns>The environment with the corresponding ID</returns>
-    EnvironmentInfo GetById(int environmentId);
+    EnvironmentInfo GetById(long environmentId);
 
     /// <summary>
     /// Get a specific environment
     /// </summary>
     /// <param name="environmentId">The ID of the environment</param>
     /// <returns>The environment with the corresponding ID</returns>
-    Task<EnvironmentInfo> GetByIdAsync(int environmentId, CancellationToken cancellationToken = default);
+    Task<EnvironmentInfo> GetByIdAsync(long environmentId, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/IEpicClient.cs
+++ b/NGitLab/IEpicClient.cs
@@ -11,7 +11,7 @@ public interface IEpicClient
     /// <param name="groupId">Group ID</param>
     /// <param name="query">Filtering and ordering query</param>
     /// <returns></returns>
-    IEnumerable<Epic> Get(int groupId, EpicQuery query);
+    IEnumerable<Epic> Get(long groupId, EpicQuery query);
 
     /// <summary>
     /// Return a group epic
@@ -19,14 +19,14 @@ public interface IEpicClient
     /// <param name="groupId">Group ID</param>
     /// <param name="epicId">Epic ID</param>
     /// <returns></returns>
-    Epic Get(int groupId, int epicId);
+    Epic Get(long groupId, long epicId);
 
     /// <summary>
     /// Return all issues that are assigned to an epic
     /// </summary>
     /// <param name="groupId">Group ID</param>
     /// <param name="epicId">Epic ID</param>
-    GitLabCollectionResponse<Issue> GetIssuesAsync(int groupId, int epicId);
+    GitLabCollectionResponse<Issue> GetIssuesAsync(long groupId, long epicId);
 
     /// <summary>
     /// Create an epic
@@ -34,7 +34,7 @@ public interface IEpicClient
     /// <param name="groupId">Group ID</param>
     /// <param name="epic">Epic to create</param>
     /// <returns></returns>
-    Epic Create(int groupId, EpicCreate epic);
+    Epic Create(long groupId, EpicCreate epic);
 
     /// <summary>
     /// Update an epic
@@ -42,5 +42,5 @@ public interface IEpicClient
     /// <param name="groupId">Group ID</param>
     /// <param name="epicEdit">New properties values</param>
     /// <returns></returns>
-    Epic Edit(int groupId, EpicEdit epicEdit);
+    Epic Edit(long groupId, EpicEdit epicEdit);
 }

--- a/NGitLab/IGitLabClient.cs
+++ b/NGitLab/IGitLabClient.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using NGitLab.Models;
+﻿using NGitLab.Models;
 
 namespace NGitLab;
 
@@ -31,70 +30,34 @@ public interface IGitLabClient
     /// <summary>
     /// Returns the events done by the specified user.
     /// </summary>
-    IEventClient GetUserEvents(int userId);
-
-    /// <summary>
-    /// Returns the events that occurred in the specified project.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IEventClient GetProjectEvents(int projectId);
+    IEventClient GetUserEvents(long userId);
 
     /// <summary>
     /// Returns the events that occurred in the specified project.
     /// </summary>
     IEventClient GetProjectEvents(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IRepositoryClient GetRepository(int projectId);
-
     IRepositoryClient GetRepository(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    ICommitClient GetCommits(int projectId);
 
     ICommitClient GetCommits(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    ICommitStatusClient GetCommitStatus(int projectId);
-
     ICommitStatusClient GetCommitStatus(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IPipelineClient GetPipelines(int projectId);
 
     IPipelineClient GetPipelines(ProjectId projectId);
 
     IPipelineScheduleClient GetPipelineSchedules(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    ITriggerClient GetTriggers(int projectId);
-
     ITriggerClient GetTriggers(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IJobClient GetJobs(int projectId);
-
     IJobClient GetJobs(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IMergeRequestClient GetMergeRequest(int projectId);
 
     IMergeRequestClient GetMergeRequest(ProjectId projectId);
 
     IMergeRequestClient GetGroupMergeRequest(GroupId groupId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IMilestoneClient GetMilestone(int projectId);
-
     IMilestoneClient GetMilestone(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IMilestoneClient GetGroupMilestone(int groupId);
-
     IMilestoneClient GetGroupMilestone(GroupId groupId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IReleaseClient GetReleases(int projectId);
 
     IReleaseClient GetReleases(ProjectId projectId);
 
@@ -116,65 +79,29 @@ public interface IGitLabClient
 
     ISearchClient AdvancedSearch { get; }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IProjectIssueNoteClient GetProjectIssueNoteClient(int projectId);
-
     IProjectIssueNoteClient GetProjectIssueNoteClient(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IEnvironmentClient GetEnvironmentClient(int projectId);
 
     IEnvironmentClient GetEnvironmentClient(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IClusterClient GetClusterClient(int projectId);
-
     IClusterClient GetClusterClient(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IWikiClient GetWikiClient(int projectId);
 
     IWikiClient GetWikiClient(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IProjectBadgeClient GetProjectBadgeClient(int projectId);
-
     IProjectBadgeClient GetProjectBadgeClient(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IGroupBadgeClient GetGroupBadgeClient(int groupId);
 
     IGroupBadgeClient GetGroupBadgeClient(GroupId groupId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IProjectVariableClient GetProjectVariableClient(int projectId);
-
     IProjectVariableClient GetProjectVariableClient(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IGroupVariableClient GetGroupVariableClient(int groupId);
 
     IGroupVariableClient GetGroupVariableClient(GroupId groupId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(int projectId);
-
     IProjectLevelApprovalRulesClient GetProjectLevelApprovalRulesClient(ProjectId projectId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    IProtectedBranchClient GetProtectedBranchClient(int projectId);
 
     IProtectedBranchClient GetProtectedBranchClient(ProjectId projectId);
 
     IProtectedTagClient GetProtectedTagClient(ProjectId projectId);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ISearchClient GetGroupSearchClient(int groupId);
-
     public ISearchClient GetGroupSearchClient(GroupId groupId);
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ISearchClient GetProjectSearchClient(int projectId);
 
     public ISearchClient GetProjectSearchClient(ProjectId projectId);
 

--- a/NGitLab/IGroupBadgeClient.cs
+++ b/NGitLab/IGroupBadgeClient.cs
@@ -7,11 +7,11 @@ public interface IGroupBadgeClient
 {
     IEnumerable<Badge> All { get; }
 
-    Badge this[int id] { get; }
+    Badge this[long id] { get; }
 
     Badge Create(BadgeCreate badge);
 
-    Badge Update(int id, BadgeUpdate badge);
+    Badge Update(long id, BadgeUpdate badge);
 
-    void Delete(int id);
+    void Delete(long id);
 }

--- a/NGitLab/IGroupHooksClient.cs
+++ b/NGitLab/IGroupHooksClient.cs
@@ -7,11 +7,11 @@ public interface IGroupHooksClient
 {
     IEnumerable<GroupHook> All { get; }
 
-    GroupHook this[int hookId] { get; }
+    GroupHook this[long hookId] { get; }
 
     GroupHook Create(GroupHookUpsert hook);
 
-    GroupHook Update(int hookId, GroupHookUpsert hook);
+    GroupHook Update(long hookId, GroupHookUpsert hook);
 
-    void Delete(int hookId);
+    void Delete(long hookId);
 }

--- a/NGitLab/IGroupsClient.cs
+++ b/NGitLab/IGroupsClient.cs
@@ -48,14 +48,14 @@ public interface IGroupsClient
     Task<PagedResponse<Group>> PageAsync(PageQuery<GroupQuery> query, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="GetByIdAsync"/>
-    Group this[int id] { get; }
+    Group this[long id] { get; }
 
     /// <inheritdoc cref="GetByFullPathAsync"/>
     Group this[string fullPath] { get; }
 
     /// <inheritdoc cref="GetGroupAsync"/>
     /// <param name="id">The group's id</param>
-    Task<Group> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Group> GetByIdAsync(long id, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="GetGroupAsync"/>
     /// <param name="fullPath">The group's path</param>
@@ -76,7 +76,7 @@ public interface IGroupsClient
 
     /// <inheritdoc cref="GetSubgroupsAsync"/>
     /// <param name="id">The group's id</param>
-    GitLabCollectionResponse<Group> GetSubgroupsByIdAsync(int id, SubgroupQuery query = null);
+    GitLabCollectionResponse<Group> GetSubgroupsByIdAsync(long id, SubgroupQuery query = null);
 
     /// <inheritdoc cref="GetSubgroupsAsync"/>
     /// <param name="fullPath">The group's path</param>
@@ -126,11 +126,11 @@ public interface IGroupsClient
     /// <param name="id">The group's id.</param>
     /// <param name="search">The search criteria.</param>
     [Obsolete("Use SearchProjectsAsync instead")]
-    IEnumerable<Project> SearchProjects(int groupId, string search);
+    IEnumerable<Project> SearchProjects(long groupId, string search);
 
     /// <inheritdoc cref="SearchProjectsAsync"/>
     /// <param name="id">The group's id.</param>
-    GitLabCollectionResponse<Project> GetProjectsAsync(int groupId, GroupProjectsQuery query);
+    GitLabCollectionResponse<Project> GetProjectsAsync(long groupId, GroupProjectsQuery query);
 
     /// <summary>
     /// Gets a list of projects in this group. When accessed without authentication, only public projects are returned.
@@ -156,7 +156,7 @@ public interface IGroupsClient
     Task<PagedResponse<Project>> PageProjectsAsync(GroupId groupId, PageQuery<GroupProjectsQuery> query, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="DeleteAsync"/>
-    void Delete(int id);
+    void Delete(long id);
 
     /// <summary>
     /// Removes a group.
@@ -164,10 +164,10 @@ public interface IGroupsClient
     /// </summary>
     /// <param name="id">The group's id.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+    Task DeleteAsync(long id, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="UpdateAsync"/>
-    Group Update(int id, GroupUpdate groupUpdate);
+    Group Update(long id, GroupUpdate groupUpdate);
 
     /// <summary>
     /// Updates an existing group.
@@ -176,10 +176,10 @@ public interface IGroupsClient
     /// <param name="id">The group's id.</param>
     /// <param name="groupUpdate">The properties to update.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task<Group> UpdateAsync(int id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default);
+    Task<Group> UpdateAsync(long id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="RestoreAsync"/>
-    void Restore(int id);
+    void Restore(long id);
 
     /// <summary>
     /// Restores a group marked for deletion.
@@ -187,5 +187,5 @@ public interface IGroupsClient
     /// </summary>
     /// <param name="id">The group's id.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task RestoreAsync(int id, CancellationToken cancellationToken = default);
+    Task RestoreAsync(long id, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -15,13 +15,13 @@ public interface IIssueClient
     /// <summary>
     /// Get a list of issues for the specified project.
     /// </summary>
-    IEnumerable<Issue> ForProject(int projectId);
+    IEnumerable<Issue> ForProject(long projectId);
 
-    GitLabCollectionResponse<Issue> ForProjectAsync(int projectId);
+    GitLabCollectionResponse<Issue> ForProjectAsync(long projectId);
 
-    GitLabCollectionResponse<Issue> ForGroupsAsync(int groupId);
+    GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId);
 
-    GitLabCollectionResponse<Issue> ForGroupsAsync(int groupId, IssueQuery query);
+    GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId, IssueQuery query);
 
     /// <summary>
     ///     <para>Return a single issue for a project given project.</para>
@@ -30,9 +30,9 @@ public interface IIssueClient
     /// <param name="projectId"></param>
     /// <param name="issueIid"></param>
     /// <returns>The issue that corresponds to the project id and issue id</returns>
-    Issue Get(int projectId, int issueIid);
+    Issue Get(long projectId, long issueIid);
 
-    Task<Issue> GetAsync(int projectId, int issueIid, CancellationToken cancellationToken = default);
+    Task<Issue> GetAsync(long projectId, long issueIid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Return issues for a given query.
@@ -55,9 +55,9 @@ public interface IIssueClient
     /// <param name="projectId"></param>
     /// <param name="query"></param>
     /// <returns>the query's related issues</returns>
-    IEnumerable<Issue> Get(int projectId, IssueQuery query);
+    IEnumerable<Issue> Get(long projectId, IssueQuery query);
 
-    GitLabCollectionResponse<Issue> GetAsync(int projectId, IssueQuery query);
+    GitLabCollectionResponse<Issue> GetAsync(long projectId, IssueQuery query);
 
     /// <summary>
     ///     <para>Return a single issue, only for administrators.</para>
@@ -65,9 +65,9 @@ public interface IIssueClient
     /// </summary>
     /// <param name="issueId"></param>
     /// <returns>The issue that corresponds to the issue id</returns>
-    Issue GetById(int issueId);
+    Issue GetById(long issueId);
 
-    Task<Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default);
+    Task<Issue> GetByIdAsync(long issueId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add an issue witht he proposed title to the GitLab list for the selected proejct id.
@@ -96,9 +96,9 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>A collection of the resource label events linked to this issue.</returns>
-    IEnumerable<ResourceLabelEvent> ResourceLabelEvents(int projectId, int issueIid);
+    IEnumerable<ResourceLabelEvent> ResourceLabelEvents(long projectId, long issueIid);
 
-    GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int issueIid);
+    GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long issueIid);
 
     /// <summary>
     /// Gets the resource milestone events.
@@ -109,9 +109,9 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>A collection of the resource milestone events linked to this issue.</returns>
-    IEnumerable<ResourceMilestoneEvent> ResourceMilestoneEvents(int projectId, int issueIid);
+    IEnumerable<ResourceMilestoneEvent> ResourceMilestoneEvents(long projectId, long issueIid);
 
-    GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int issueIid);
+    GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long issueIid);
 
     /// <summary>
     /// Gets the resource state events.
@@ -122,9 +122,9 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>A collection of the resource state events linked to this issue.</returns>
-    IEnumerable<ResourceStateEvent> ResourceStateEvents(int projectId, int issueIid);
+    IEnumerable<ResourceStateEvent> ResourceStateEvents(long projectId, long issueIid);
 
-    GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(int projectId, int issueIid);
+    GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(long projectId, long issueIid);
 
     /// <summary>
     /// Get all merge requests that are related to a particular issue.
@@ -132,7 +132,7 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>The list of MR that are related this issue.</returns>
-    IEnumerable<MergeRequest> RelatedTo(int projectId, int issueIid);
+    IEnumerable<MergeRequest> RelatedTo(long projectId, long issueIid);
 
     /// <summary>
     /// Get all Issues that are linked to a particular issue of particular project.
@@ -140,7 +140,7 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueId">The id of the issue in the project's scope.</param>
     /// <returns>The list of Issues linked to this issue.</returns>
-    GitLabCollectionResponse<Issue> LinkedToAsync(int projectId, int issueId);
+    GitLabCollectionResponse<Issue> LinkedToAsync(long projectId, long issueId);
 
     /// <summary>
     /// Create links between Issues.
@@ -149,9 +149,9 @@ public interface IIssueClient
     /// <param name="sourceIssueId">The id of the issue in the project's scope.</param>
     /// <param name="targetProjectId">The target project id.</param>
     /// <param name="targetIssueId">The target id of the issue to link to.</param>
-    bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId);
+    bool CreateLinkBetweenIssues(long sourceProjectId, long sourceIssueId, long targetProjectId, long targetIssueId);
 
-    GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid);
+    GitLabCollectionResponse<MergeRequest> RelatedToAsync(long projectId, long issueIid);
 
     /// <summary>
     /// Get all merge requests that close a particular issue when merged.
@@ -159,9 +159,9 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>The list of MR that closed this issue.</returns>
-    IEnumerable<MergeRequest> ClosedBy(int projectId, int issueIid);
+    IEnumerable<MergeRequest> ClosedBy(long projectId, long issueIid);
 
-    GitLabCollectionResponse<MergeRequest> ClosedByAsync(int projectId, int issueIid);
+    GitLabCollectionResponse<MergeRequest> ClosedByAsync(long projectId, long issueIid);
 
     /// <summary>
     /// Get time tracking statistics
@@ -169,7 +169,7 @@ public interface IIssueClient
     /// <param name="projectId">The project id.</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>The time tracking statistics of the issue.</returns>
-    Task<TimeStats> TimeStatsAsync(int projectId, int issueIid, CancellationToken cancellationToken = default);
+    Task<TimeStats> TimeStatsAsync(long projectId, long issueIid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Clone the issue to given project
@@ -179,7 +179,7 @@ public interface IIssueClient
     /// <param name="issueClone">Destination information</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<Issue> CloneAsync(int projectId, int issueIid, IssueClone issueClone, CancellationToken cancellationToken = default);
+    Task<Issue> CloneAsync(long projectId, long issueIid, IssueClone issueClone, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Participants
@@ -187,7 +187,7 @@ public interface IIssueClient
     /// <param name="projectId">The project id</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>The participants of the issue.</returns>
-    IEnumerable<Participant> GetParticipants(ProjectId projectId, int issueIid);
+    IEnumerable<Participant> GetParticipants(ProjectId projectId, long issueIid);
 
     /// <summary>
     /// Unsubscribe to the issue
@@ -195,5 +195,5 @@ public interface IIssueClient
     /// <param name="projectId">The project id</param>
     /// <param name="issueIid">The id of the issue in the project's scope.</param>
     /// <returns>The issue that corresponds to the project id and issue id</returns>
-    Issue Unsubscribe(ProjectId projectId, int issueIid);
+    Issue Unsubscribe(ProjectId projectId, long issueIid);
 }

--- a/NGitLab/IJobClient.cs
+++ b/NGitLab/IJobClient.cs
@@ -13,21 +13,21 @@ public interface IJobClient
 
     GitLabCollectionResponse<Job> GetJobsAsync(JobQuery query);
 
-    Job RunAction(int jobId, JobAction action);
+    Job RunAction(long jobId, JobAction action);
 
-    Task<Job> RunActionAsync(int jobId, JobAction action, CancellationToken cancellationToken = default);
+    Task<Job> RunActionAsync(long jobId, JobAction action, CancellationToken cancellationToken = default);
 
-    Job Get(int jobId);
+    Job Get(long jobId);
 
-    Task<Job> GetAsync(int jobId, CancellationToken cancellationToken = default);
+    Task<Job> GetAsync(long jobId, CancellationToken cancellationToken = default);
 
-    byte[] GetJobArtifacts(int jobId);
+    byte[] GetJobArtifacts(long jobId);
 
-    byte[] GetJobArtifact(int jobId, string path);
+    byte[] GetJobArtifact(long jobId, string path);
 
     byte[] GetJobArtifact(JobArtifactQuery query);
 
-    string GetTrace(int jobId);
+    string GetTrace(long jobId);
 
-    Task<string> GetTraceAsync(int jobId, CancellationToken cancellationToken = default);
+    Task<string> GetTraceAsync(long jobId, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -11,14 +11,14 @@ public interface ILabelClient
     /// </summary>
     /// <param name="projectId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForProject(int projectId);
+    IEnumerable<Label> ForProject(long projectId);
 
     /// <summary>
     /// Return a list of labels for a group.
     /// </summary>
     /// <param name="groupId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForGroup(int groupId);
+    IEnumerable<Label> ForGroup(long groupId);
 
     /// <summary>
     /// Return a specified label from the project or null;
@@ -26,10 +26,10 @@ public interface ILabelClient
     /// <param name="projectId"></param>
     /// <param name="name"></param>
     /// <returns></returns>
-    Label GetProjectLabel(int projectId, string name);
+    Label GetProjectLabel(long projectId, string name);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    Label GetLabel(int projectId, string name);
+    Label GetLabel(long projectId, string name);
 
     /// <summary>
     /// Return a specified label from the group or null;
@@ -37,7 +37,7 @@ public interface ILabelClient
     /// <param name="groupId"></param>
     /// <param name="name"></param>
     /// <returns></returns>
-    Label GetGroupLabel(int groupId, string name);
+    Label GetGroupLabel(long groupId, string name);
 
     /// <summary>
     /// Create a new label for a project.
@@ -45,7 +45,7 @@ public interface ILabelClient
     /// <param name="projectId"></param>
     /// <param name="label"></param>
     /// <returns></returns>
-    Label CreateProjectLabel(int projectId, ProjectLabelCreate label);
+    Label CreateProjectLabel(long projectId, ProjectLabelCreate label);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     Label Create(LabelCreate label);
@@ -56,7 +56,7 @@ public interface ILabelClient
     /// <param name="groupId"></param>
     /// <param name="label"></param>
     /// <returns></returns>
-    Label CreateGroupLabel(int groupId, GroupLabelCreate label);
+    Label CreateGroupLabel(long groupId, GroupLabelCreate label);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     Label CreateGroupLabel(LabelCreate label);
@@ -67,7 +67,7 @@ public interface ILabelClient
     /// <param name="projectId"></param>
     /// <param name="label"></param>
     /// <returns></returns>
-    Label EditProjectLabel(int projectId, ProjectLabelEdit label);
+    Label EditProjectLabel(long projectId, ProjectLabelEdit label);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     Label Edit(LabelEdit label);
@@ -78,7 +78,7 @@ public interface ILabelClient
     /// <param name="groupId"></param>
     /// <param name="label"></param>
     /// <returns></returns>
-    Label EditGroupLabel(int groupId, GroupLabelEdit label);
+    Label EditGroupLabel(long groupId, GroupLabelEdit label);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     Label EditGroupLabel(LabelEdit label);
@@ -89,7 +89,7 @@ public interface ILabelClient
     /// <param name="projectId"></param>
     /// <param name="label"></param>
     /// <returns>True if "200", the success code for delete, was returned from the service.</returns>
-    Label DeleteProjectLabel(int projectId, ProjectLabelDelete label);
+    Label DeleteProjectLabel(long projectId, ProjectLabelDelete label);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     Label Delete(LabelDelete label);

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -14,57 +14,57 @@ public interface IMergeRequestClient
 
     IEnumerable<MergeRequest> Get(MergeRequestQuery query);
 
-    MergeRequest this[int iid] { get; }
+    MergeRequest this[long iid] { get; }
 
-    Task<MergeRequest> GetByIidAsync(int iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default);
+    Task<MergeRequest> GetByIidAsync(long iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default);
 
     MergeRequest Create(MergeRequestCreate mergeRequest);
 
-    MergeRequest Update(int mergeRequestIid, MergeRequestUpdate mergeRequest);
+    MergeRequest Update(long mergeRequestIid, MergeRequestUpdate mergeRequest);
 
-    MergeRequest Close(int mergeRequestIid);
+    MergeRequest Close(long mergeRequestIid);
 
-    MergeRequest Reopen(int mergeRequestIid);
+    MergeRequest Reopen(long mergeRequestIid);
 
-    void Delete(int mergeRequestIid);
+    void Delete(long mergeRequestIid);
 
-    MergeRequest CancelMergeWhenPipelineSucceeds(int mergeRequestIid);
+    MergeRequest CancelMergeWhenPipelineSucceeds(long mergeRequestIid);
 
     [Obsolete("You should use MergeRequestMerge instead of MergeRequestAccept")]
-    MergeRequest Accept(int mergeRequestIid, MergeRequestAccept message);
+    MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message);
 
-    MergeRequest Accept(int mergeRequestIid, MergeRequestMerge message);
+    MergeRequest Accept(long mergeRequestIid, MergeRequestMerge message);
 
-    MergeRequest Approve(int mergeRequestIid, MergeRequestApprove message);
+    MergeRequest Approve(long mergeRequestIid, MergeRequestApprove message);
 
-    RebaseResult Rebase(int mergeRequestIid);
+    RebaseResult Rebase(long mergeRequestIid);
 
-    Task<RebaseResult> RebaseAsync(int mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default);
+    Task<RebaseResult> RebaseAsync(long mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default);
 
-    IEnumerable<PipelineBasic> GetPipelines(int mergeRequestIid);
+    IEnumerable<PipelineBasic> GetPipelines(long mergeRequestIid);
 
-    IEnumerable<Author> GetParticipants(int mergeRequestIid);
+    IEnumerable<Author> GetParticipants(long mergeRequestIid);
 
-    GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(int mergeRequestIid);
+    GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(long mergeRequestIid);
 
-    IMergeRequestCommentClient Comments(int mergeRequestIid);
+    IMergeRequestCommentClient Comments(long mergeRequestIid);
 
-    IMergeRequestDiscussionClient Discussions(int mergeRequestIid);
+    IMergeRequestDiscussionClient Discussions(long mergeRequestIid);
 
-    IMergeRequestCommitClient Commits(int mergeRequestIid);
+    IMergeRequestCommitClient Commits(long mergeRequestIid);
 
-    IMergeRequestChangeClient Changes(int mergeRequestIid);
+    IMergeRequestChangeClient Changes(long mergeRequestIid);
 
-    IMergeRequestApprovalClient ApprovalClient(int mergeRequestIid);
+    IMergeRequestApprovalClient ApprovalClient(long mergeRequestIid);
 
-    IEnumerable<Issue> ClosesIssues(int mergeRequestIid);
+    IEnumerable<Issue> ClosesIssues(long mergeRequestIid);
 
     /// <summary>
     /// Get time tracking statistics
     /// </summary>
     /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
     /// <returns>The time tracking statistics of the merge request.</returns>
-    Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default);
+    Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the resource label events.
@@ -75,7 +75,7 @@ public interface IMergeRequestClient
     /// <param name="projectId">The project id.</param>
     /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
     /// <returns>A collection of the resource label events linked to this merge request.</returns>
-    GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int mergeRequestIid);
+    GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long mergeRequestIid);
 
     /// <summary>
     /// Gets the resource milestone events.
@@ -86,7 +86,7 @@ public interface IMergeRequestClient
     /// <param name="projectId">The project id.</param>
     /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
     /// <returns>A collection of the resource milestone events linked to this merge request.</returns>
-    GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int mergeRequestIid);
+    GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long mergeRequestIid);
 
     /// <summary>
     /// Gets the resource state events.
@@ -97,5 +97,5 @@ public interface IMergeRequestClient
     /// <param name="projectId">The project id.</param>
     /// <param name="mergeRequestIid">The id of the merge request in the project's scope.</param>
     /// <returns>A collection of the resource state events linked to this merge request.</returns>
-    GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(int projectId, int mergeRequestIid);
+    GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(long projectId, long mergeRequestIid);
 }

--- a/NGitLab/IMilestoneClient.cs
+++ b/NGitLab/IMilestoneClient.cs
@@ -14,17 +14,17 @@ public interface IMilestoneClient
 
     IEnumerable<Milestone> Get(MilestoneQuery query);
 
-    Milestone this[int id] { get; }
+    Milestone this[long id] { get; }
 
     Milestone Create(MilestoneCreate milestone);
 
-    Milestone Update(int milestoneId, MilestoneUpdate milestone);
+    Milestone Update(long milestoneId, MilestoneUpdate milestone);
 
-    void Delete(int milestoneId);
+    void Delete(long milestoneId);
 
-    Milestone Close(int milestoneId);
+    Milestone Close(long milestoneId);
 
-    Milestone Activate(int milestoneId);
+    Milestone Activate(long milestoneId);
 
-    IEnumerable<MergeRequest> GetMergeRequests(int milestoneId);
+    IEnumerable<MergeRequest> GetMergeRequests(long milestoneId);
 }

--- a/NGitLab/INamespacesClient.cs
+++ b/NGitLab/INamespacesClient.cs
@@ -14,7 +14,7 @@ public interface INamespacesClient
     /// </summary>
     IEnumerable<Namespace> Accessible { get; }
 
-    Namespace this[int id] { get; }
+    Namespace this[long id] { get; }
 
     /// <summary>
     /// Returns the project with the provided full path in the form Namespace/Name.

--- a/NGitLab/IPipelineClient.cs
+++ b/NGitLab/IPipelineClient.cs
@@ -18,9 +18,9 @@ public interface IPipelineClient
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    Pipeline this[int id] { get; }
+    Pipeline this[long id] { get; }
 
-    Task<Pipeline> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Pipeline> GetByIdAsync(long id, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get all jobs in a project
@@ -39,7 +39,7 @@ public interface IPipelineClient
     /// <summary>
     /// Returns the jobs of a pipeline.
     /// </summary>
-    Job[] GetJobs(int pipelineId);
+    Job[] GetJobs(long pipelineId);
 
     /// <summary>
     /// Returns the jobs of a pipeline.
@@ -88,27 +88,27 @@ public interface IPipelineClient
     /// Delete a pipeline.
     /// </summary>
     /// <param name="pipelineId">ID of the pipeline</param>
-    void Delete(int pipelineId);
+    void Delete(long pipelineId);
 
     /// <summary>
     /// Get variables for a pipeline.
     /// </summary>
     /// <param name="pipelineId">ID of the pipeline</param>
-    IEnumerable<PipelineVariable> GetVariables(int pipelineId);
+    IEnumerable<PipelineVariable> GetVariables(long pipelineId);
 
-    GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(int pipelineId);
+    GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(long pipelineId);
 
     /// <summary>
     /// Get test reports for a pipeline.
     /// </summary>
     /// <param name="pipelineId">ID of the pipeline</param>
-    TestReport GetTestReports(int pipelineId);
+    TestReport GetTestReports(long pipelineId);
 
     /// <summary>
     /// Get test reports summary for a pipeline.
     /// </summary>
     /// <param name="pipelineId">ID of the pipeline</param>
-    TestReportSummary GetTestReportsSummary(int pipelineId);
+    TestReportSummary GetTestReportsSummary(long pipelineId);
 
     /// <summary>
     /// Returns the bridges of a pipeline.
@@ -116,7 +116,7 @@ public interface IPipelineClient
     /// <param name="query"></param>
     GitLabCollectionResponse<Bridge> GetBridgesAsync(PipelineBridgeQuery query);
 
-    Task<Pipeline> RetryAsync(int pipelineId, CancellationToken cancellationToken = default);
+    Task<Pipeline> RetryAsync(long pipelineId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the metadata for the specified pipeline
@@ -125,5 +125,5 @@ public interface IPipelineClient
     /// <param name="update">The metadata to update</param>
     /// <param name="cancellationToken">The cancellation otken for the operation</param>
     /// <seealso href="https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata" />
-    Task<Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default);
+    Task<Pipeline> UpdateMetadataAsync(long pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default);
 }

--- a/NGitLab/IPipelineScheduleClient.cs
+++ b/NGitLab/IPipelineScheduleClient.cs
@@ -17,7 +17,7 @@ public interface IPipelineScheduleClient
     /// </summary>
     /// <param name="id">Schedule Id</param>
     /// <returns></returns>
-    PipelineSchedule this[int id] { get; }
+    PipelineSchedule this[long id] { get; }
 
     /// <summary>
     /// Gets the details of single schedule
@@ -25,7 +25,7 @@ public interface IPipelineScheduleClient
     /// <param name="id">Schedule Id</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<PipelineSchedule> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<PipelineSchedule> GetByIdAsync(long id, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all the pipeline schedules of the project
@@ -39,5 +39,5 @@ public interface IPipelineScheduleClient
     /// </summary>
     /// <param name="id">Schedule Id</param>
     /// <returns></returns>
-    GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(int id);
+    GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(long id);
 }

--- a/NGitLab/IProjectBadgeClient.cs
+++ b/NGitLab/IProjectBadgeClient.cs
@@ -13,13 +13,13 @@ public interface IProjectBadgeClient
     /// <remarks>Project Badge API returns both Group and Project badges</remarks>
     IEnumerable<Badge> ProjectsOnly { get; }
 
-    Badge this[int id] { get; }
+    Badge this[long id] { get; }
 
     Badge Create(BadgeCreate badge);
 
-    Badge Update(int id, BadgeUpdate badge);
+    Badge Update(long id, BadgeUpdate badge);
 
-    void Delete(int id);
+    void Delete(long id);
 }
 
 public interface IProjectVariableClient

--- a/NGitLab/IProjectClient.cs
+++ b/NGitLab/IProjectClient.cs
@@ -30,7 +30,7 @@ public interface IProjectClient
     /// <inheritdoc cref="Get(ProjectQuery)"/>
     GitLabCollectionResponse<Project> GetAsync(ProjectQuery query);
 
-    Project this[int id] { get; }
+    Project this[long id] { get; }
 
     /// <summary>
     /// Returns the project with the provided full name in the form Namespace/Name.
@@ -46,22 +46,22 @@ public interface IProjectClient
 
     Task<Project> UpdateAsync(ProjectId projectId, ProjectUpdate projectUpdate, CancellationToken cancellationToken = default);
 
-    void Delete(int id);
+    void Delete(long id);
 
     Task DeleteAsync(ProjectId projectId, CancellationToken cancellationToken = default);
 
-    void Archive(int id);
+    void Archive(long id);
 
-    void Unarchive(int id);
+    void Unarchive(long id);
 
     /// <summary>
     /// Uploads a file to the specified project to be used in an issue or merge request description, or a comment.
     /// </summary>
     UploadedProjectFile UploadFile(string id, FormDataContent data);
 
-    Project GetById(int id, SingleProjectQuery query);
+    Project GetById(long id, SingleProjectQuery query);
 
-    Task<Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default);
+    Task<Project> GetByIdAsync(long id, SingleProjectQuery query, CancellationToken cancellationToken = default);
 
     Task<Project> GetByNamespacedPathAsync(string path, SingleProjectQuery query = null, CancellationToken cancellationToken = default);
 

--- a/NGitLab/IProjectHooksClient.cs
+++ b/NGitLab/IProjectHooksClient.cs
@@ -7,11 +7,11 @@ public interface IProjectHooksClient
 {
     IEnumerable<ProjectHook> All { get; }
 
-    ProjectHook this[int hookId] { get; }
+    ProjectHook this[long hookId] { get; }
 
     ProjectHook Create(ProjectHookUpsert hook);
 
-    ProjectHook Update(int hookId, ProjectHookUpsert hook);
+    ProjectHook Update(long hookId, ProjectHookUpsert hook);
 
-    void Delete(int hookId);
+    void Delete(long hookId);
 }

--- a/NGitLab/IProjectIssueNoteClient.cs
+++ b/NGitLab/IProjectIssueNoteClient.cs
@@ -8,7 +8,7 @@ public interface IProjectIssueNoteClient
     /// <summary>
     /// Get a list of issue notes for the specified issue.
     /// </summary>
-    IEnumerable<ProjectIssueNote> ForIssue(int issueId);
+    IEnumerable<ProjectIssueNote> ForIssue(long issueId);
 
     /// <summary>
     /// Return a single issue note for a given.
@@ -19,7 +19,7 @@ public interface IProjectIssueNoteClient
     /// <param name="issueId"></param>
     /// <param name="noteId"></param>
     /// <returns></returns>
-    ProjectIssueNote Get(int issueId, int noteId);
+    ProjectIssueNote Get(long issueId, long noteId);
 
     /// <summary>
     /// Add an project issue note with the specified body to the specified issue.

--- a/NGitLab/IProjectLevelApprovalRulesClient.cs
+++ b/NGitLab/IProjectLevelApprovalRulesClient.cs
@@ -17,7 +17,7 @@ public interface IProjectLevelApprovalRulesClient
     /// <param name="approvalRuleIdToUpdate">The Id of the approval rule to update.</param>
     /// <param name="approvalRuleUpdate">New values of the approval rule.</param>
     /// <returns>The approval rule updated for a project.</returns>
-    ApprovalRule UpdateProjectLevelApprovalRule(int approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate);
+    ApprovalRule UpdateProjectLevelApprovalRule(long approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate);
 
     /// <summary>
     /// Create an approval rule for a project.
@@ -30,5 +30,5 @@ public interface IProjectLevelApprovalRulesClient
     /// Delete an approval rule for a project.
     /// </summary>
     /// <param name="approvalRuleIdToDelete">The Id of the approval rule to delete for a project.</param>
-    void DeleteProjectLevelRule(int approvalRuleIdToDelete);
+    void DeleteProjectLevelRule(long approvalRuleIdToDelete);
 }

--- a/NGitLab/IReleaseLinkClient.cs
+++ b/NGitLab/IReleaseLinkClient.cs
@@ -7,11 +7,11 @@ public interface IReleaseLinkClient
 {
     IEnumerable<ReleaseLink> All { get; }
 
-    ReleaseLink this[int id] { get; }
+    ReleaseLink this[long id] { get; }
 
     ReleaseLink Create(ReleaseLinkCreate data);
 
-    ReleaseLink Update(int id, ReleaseLinkUpdate data);
+    ReleaseLink Update(long id, ReleaseLinkUpdate data);
 
-    void Delete(int id);
+    void Delete(long id);
 }

--- a/NGitLab/IRunnerClient.cs
+++ b/NGitLab/IRunnerClient.cs
@@ -25,7 +25,7 @@ public interface IRunnerClient
     /// <summary>
     /// Get details of a runner
     /// </summary>
-    Runner this[int id] { get; }
+    Runner this[long id] { get; }
 
     /// <summary>
     /// Deletes the specified runner.
@@ -35,47 +35,47 @@ public interface IRunnerClient
     /// <summary>
     /// Deletes the specified runner.
     /// </summary>
-    void Delete(int runnerId);
+    void Delete(long runnerId);
 
     /// <summary>
     /// Updates the tags, description, isActive
     /// </summary>
     /// <returns>The updated runner</returns>
-    Runner Update(int runnerId, RunnerUpdate runnerUpdate);
+    Runner Update(long runnerId, RunnerUpdate runnerUpdate);
 
     /// <summary>
     /// get the list of runners associated with the group
     /// </summary>
     /// <returns>the list of runners associated with the group</returns>
-    IEnumerable<Runner> OfGroup(int groupId);
+    IEnumerable<Runner> OfGroup(long groupId);
 
-    GitLabCollectionResponse<Runner> OfGroupAsync(int groupId);
+    GitLabCollectionResponse<Runner> OfGroupAsync(long groupId);
 
     /// <summary>
     /// get the list of runners associated with the project
     /// </summary>
     /// <returns>the list of runners associated with the project</returns>
-    IEnumerable<Runner> OfProject(int projectId);
+    IEnumerable<Runner> OfProject(long projectId);
 
-    GitLabCollectionResponse<Runner> OfProjectAsync(int projectId);
+    GitLabCollectionResponse<Runner> OfProjectAsync(long projectId);
 
     /// <summary>
     /// List all jobs of the given runner that meet the specified scope
     /// </summary>
     [Obsolete("Use GetJobs(int, JobStatus?) instead")]
-    IEnumerable<Job> GetJobs(int runnerId, JobScope jobScope);
+    IEnumerable<Job> GetJobs(long runnerId, JobScope jobScope);
 
     /// <summary>
     /// List all jobs of the given runner that meet the specified status
     /// </summary>
     [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads", Justification = "Keep compatibility")]
-    IEnumerable<Job> GetJobs(int runnerId, JobStatus? status = null);
+    IEnumerable<Job> GetJobs(long runnerId, JobStatus? status = null);
 
     /// <summary>
     /// List all runners (specific and shared) available in the project. Shared runners are listed if at least one shared runner is defined and shared runners usage is enabled in the project's settings.
     /// </summary>
     /// <param name="projectId"></param>
-    IEnumerable<Runner> GetAvailableRunners(int projectId);
+    IEnumerable<Runner> GetAvailableRunners(long projectId);
 
     /// <summary>
     /// List all runners in the GitLab instance that meet the specified scope
@@ -89,16 +89,16 @@ public interface IRunnerClient
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="runnerId"></param>
-    Runner EnableRunner(int projectId, RunnerId runnerId);
+    Runner EnableRunner(long projectId, RunnerId runnerId);
 
-    Task<Runner> EnableRunnerAsync(int projectId, RunnerId runnerId, CancellationToken cancellationToken = default);
+    Task<Runner> EnableRunnerAsync(long projectId, RunnerId runnerId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disable a specific runner from the project. It works only if the project isn't the only project associated with the specified runner. If so, an error is returned. Use the Remove a runner call instead.
     /// </summary>
     /// <param name="projectId"></param>
     /// <param name="runnerId"></param>
-    void DisableRunner(int projectId, RunnerId runnerId);
+    void DisableRunner(long projectId, RunnerId runnerId);
 
     /// <summary>
     /// Register a new runner for the instance.

--- a/NGitLab/IRunnerClient.cs
+++ b/NGitLab/IRunnerClient.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -60,15 +58,8 @@ public interface IRunnerClient
     GitLabCollectionResponse<Runner> OfProjectAsync(long projectId);
 
     /// <summary>
-    /// List all jobs of the given runner that meet the specified scope
-    /// </summary>
-    [Obsolete("Use GetJobs(int, JobStatus?) instead")]
-    IEnumerable<Job> GetJobs(long runnerId, JobScope jobScope);
-
-    /// <summary>
     /// List all jobs of the given runner that meet the specified status
     /// </summary>
-    [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads", Justification = "Keep compatibility")]
     IEnumerable<Job> GetJobs(long runnerId, JobStatus? status = null);
 
     /// <summary>

--- a/NGitLab/ISnippetClient.cs
+++ b/NGitLab/ISnippetClient.cs
@@ -10,12 +10,12 @@ public interface ISnippetClient
     /// <summary>
     /// Get a list of snippets for the specified project.
     /// </summary>
-    IEnumerable<Snippet> ForProject(int projectId);
+    IEnumerable<Snippet> ForProject(long projectId);
 
     /// <summary>
     /// Return a single snippet for a given project.
     /// </summary>
-    Snippet Get(int projectId, int snippetId);
+    Snippet Get(long projectId, long snippetId);
 
     /// <summary>
     /// Return all snippets of the authenticated user
@@ -47,15 +47,15 @@ public interface ISnippetClient
     /// <summary>
     /// Delete a snippet not linked to a project but only to a user, could delete snippet linked to a project but will return an error 403 in API v4
     /// </summary>
-    void Delete(int snippetId);
+    void Delete(long snippetId);
 
     /// <summary>
     /// Delete a snippet linked to a project
     /// </summary>
-    void Delete(int projectId, int snippetId);
+    void Delete(long projectId, long snippetId);
 
     /// <summary>
     /// Get single snippet's content for a given project
     /// </summary>
-    void GetContent(int projectId, int snippetId, Action<Stream> parser);
+    void GetContent(long projectId, long snippetId, Action<Stream> parser);
 }

--- a/NGitLab/ISshKeyClient.cs
+++ b/NGitLab/ISshKeyClient.cs
@@ -7,9 +7,9 @@ public interface ISshKeyClient
 {
     IEnumerable<SshKey> All { get; }
 
-    SshKey this[int keyId] { get; }
+    SshKey this[long keyId] { get; }
 
     SshKey Add(SshKeyCreate key);
 
-    void Remove(int keyId);
+    void Remove(long keyId);
 }

--- a/NGitLab/ISystemHookClient.cs
+++ b/NGitLab/ISystemHookClient.cs
@@ -7,9 +7,9 @@ public interface ISystemHookClient
 {
     IEnumerable<SystemHook> All { get; }
 
-    SystemHook this[int hookId] { get; }
+    SystemHook this[long hookId] { get; }
 
     SystemHook Create(SystemHookUpsert hook);
 
-    void Delete(int hookId);
+    void Delete(long hookId);
 }

--- a/NGitLab/ITriggerClient.cs
+++ b/NGitLab/ITriggerClient.cs
@@ -10,7 +10,7 @@ public interface ITriggerClient
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    Trigger this[int id] { get; }
+    Trigger this[long id] { get; }
 
     /// <summary>
     /// Get a list of all triggers for project.

--- a/NGitLab/IUserClient.cs
+++ b/NGitLab/IUserClient.cs
@@ -12,9 +12,9 @@ public interface IUserClient
 
     IEnumerable<User> Search(string query);
 
-    User this[int id] { get; }
+    User this[long id] { get; }
 
-    Task<User> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<User> GetByIdAsync(long id, CancellationToken cancellationToken = default);
 
     Task<User> GetByUserNameAsync(string username, CancellationToken cancellationToken = default);
 
@@ -22,7 +22,7 @@ public interface IUserClient
 
     Task<User> CreateAsync(UserUpsert user, CancellationToken cancellationToken = default);
 
-    User Update(int id, UserUpsert user);
+    User Update(long id, UserUpsert user);
 
     /// <summary>
     /// Request a token for user impersonation.
@@ -38,11 +38,11 @@ public interface IUserClient
     /// <inheritdoc cref="CreateTokenAsync(UserTokenCreate, CancellationToken)"/>>
     UserToken CreateToken(UserTokenCreate tokenRequest);
 
-    void Delete(int id);
+    void Delete(long id);
 
-    void Activate(int id);
+    void Activate(long id);
 
-    void Deactivate(int id);
+    void Deactivate(long id);
 
     Session Current { get; }
 
@@ -57,7 +57,7 @@ public interface IUserClient
     /// <summary>
     /// Allows to manipulate the ssh keys of a given user, needs GitLab admin rights.
     /// </summary>
-    ISshKeyClient SShKeys(int userId);
+    ISshKeyClient SShKeys(long userId);
 
     /// <summary>
     /// Get users that match the username

--- a/NGitLab/Impl/BadgeClient.cs
+++ b/NGitLab/Impl/BadgeClient.cs
@@ -17,11 +17,11 @@ internal abstract class BadgeClient
 
     public IEnumerable<Badge> All => _api.Get().GetAll<Badge>(_urlPrefix + "/badges");
 
-    public Badge this[int id] => _api.Get().To<Badge>(_urlPrefix + "/badges/" + id.ToStringInvariant());
+    public Badge this[long id] => _api.Get().To<Badge>(_urlPrefix + "/badges/" + id.ToStringInvariant());
 
     public Badge Create(BadgeCreate badge) => _api.Post().With(badge).To<Badge>(_urlPrefix + "/badges");
 
-    public Badge Update(int id, BadgeUpdate badge) => _api.Put().With(badge).To<Badge>(_urlPrefix + "/badges/" + id.ToStringInvariant());
+    public Badge Update(long id, BadgeUpdate badge) => _api.Put().With(badge).To<Badge>(_urlPrefix + "/badges/" + id.ToStringInvariant());
 
-    public void Delete(int id) => _api.Delete().Execute(_urlPrefix + "/badges/" + id.ToStringInvariant());
+    public void Delete(long id) => _api.Delete().Execute(_urlPrefix + "/badges/" + id.ToStringInvariant());
 }

--- a/NGitLab/Impl/ClusterClient.cs
+++ b/NGitLab/Impl/ClusterClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -8,12 +7,6 @@ public class ClusterClient : IClusterClient
 {
     private readonly API _api;
     private readonly string _environmentsPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ClusterClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public ClusterClient(API api, ProjectId projectId)
     {

--- a/NGitLab/Impl/CommitClient.cs
+++ b/NGitLab/Impl/CommitClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Net;
 using NGitLab.Models;
 
@@ -9,12 +8,6 @@ public class CommitClient : ICommitClient
 {
     private readonly API _api;
     private readonly string _repoPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public CommitClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public CommitClient(API api, ProjectId projectId)
     {

--- a/NGitLab/Impl/CommitStatusClient.cs
+++ b/NGitLab/Impl/CommitStatusClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -9,12 +8,6 @@ public class CommitStatusClient : ICommitStatusClient
     private readonly API _api;
     private readonly string _statusCreatePath;
     private readonly string _statusPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public CommitStatusClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public CommitStatusClient(API api, ProjectId projectId)
     {

--- a/NGitLab/Impl/ContributorClient.cs
+++ b/NGitLab/Impl/ContributorClient.cs
@@ -15,12 +15,6 @@ internal sealed class ContributorClient : IContributorClient
         _contributorPath = repoPath + Contributor.Url;
     }
 
-    [Obsolete("Argument projectId is redundant, please use ContributorClient(API api, string repoPath) instead.")]
-    public ContributorClient(API api, string repoPath, long projectId)
-        : this(api, repoPath)
-    {
-    }
-
     /// <remarks>
     /// HACK: We force the order_by and sort due to a pagination bug from GitLab
     /// </remarks>

--- a/NGitLab/Impl/ContributorClient.cs
+++ b/NGitLab/Impl/ContributorClient.cs
@@ -16,7 +16,7 @@ internal sealed class ContributorClient : IContributorClient
     }
 
     [Obsolete("Argument projectId is redundant, please use ContributorClient(API api, string repoPath) instead.")]
-    public ContributorClient(API api, string repoPath, int projectId)
+    public ContributorClient(API api, string repoPath, long projectId)
         : this(api, repoPath)
     {
     }

--- a/NGitLab/Impl/ContributorClient.cs
+++ b/NGitLab/Impl/ContributorClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using NGitLab.Models;
 

--- a/NGitLab/Impl/DeploymentClient.cs
+++ b/NGitLab/Impl/DeploymentClient.cs
@@ -16,12 +16,12 @@ public class DeploymentClient : IDeploymentClient
         _api = api;
     }
 
-    public IEnumerable<Deployment> Get(int projectId, DeploymentQuery query)
+    public IEnumerable<Deployment> Get(long projectId, DeploymentQuery query)
     {
         return Get(string.Format(ProjectDeploymentsUrl, projectId), query);
     }
 
-    public IEnumerable<MergeRequest> GetMergeRequests(int projectId, int deploymentId)
+    public IEnumerable<MergeRequest> GetMergeRequests(long projectId, long deploymentId)
     {
         return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, DeploymentMergeRequestsUrl, projectId, deploymentId));
     }

--- a/NGitLab/Impl/EnvironmentClient.cs
+++ b/NGitLab/Impl/EnvironmentClient.cs
@@ -13,12 +13,6 @@ public class EnvironmentClient : IEnvironmentClient
     private readonly API _api;
     private readonly string _environmentsPath;
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public EnvironmentClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
-
     public EnvironmentClient(API api, ProjectId projectId)
     {
         _api = api;
@@ -42,10 +36,10 @@ public class EnvironmentClient : IEnvironmentClient
         return _api.Post().To<EnvironmentInfo>(url);
     }
 
-    public EnvironmentInfo Edit(int environmentId, string externalUrl) => Edit(environmentId, null, externalUrl);
+    public EnvironmentInfo Edit(long environmentId, string externalUrl) => Edit(environmentId, null, externalUrl);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public EnvironmentInfo Edit(int environmentId, string name, string externalUrl)
+    public EnvironmentInfo Edit(long environmentId, string name, string externalUrl)
     {
         var url = $"{_environmentsPath}/{environmentId.ToStringInvariant()}";
 
@@ -62,9 +56,9 @@ public class EnvironmentClient : IEnvironmentClient
         return _api.Put().To<EnvironmentInfo>(url);
     }
 
-    public void Delete(int environmentId) => _api.Delete().Execute($"{_environmentsPath}/{environmentId.ToStringInvariant()}");
+    public void Delete(long environmentId) => _api.Delete().Execute($"{_environmentsPath}/{environmentId.ToStringInvariant()}");
 
-    public EnvironmentInfo Stop(int environmentId)
+    public EnvironmentInfo Stop(long environmentId)
     {
         return _api.Post().To<EnvironmentInfo>($"{_environmentsPath}/{environmentId.ToStringInvariant()}/stop");
     }
@@ -80,12 +74,12 @@ public class EnvironmentClient : IEnvironmentClient
         return _api.Get().GetAllAsync<EnvironmentInfo>(url);
     }
 
-    public EnvironmentInfo GetById(int environmentId)
+    public EnvironmentInfo GetById(long environmentId)
     {
         return _api.Get().To<EnvironmentInfo>($"{_environmentsPath}/{environmentId.ToStringInvariant()}");
     }
 
-    public Task<EnvironmentInfo> GetByIdAsync(int environmentId, CancellationToken cancellationToken = default)
+    public Task<EnvironmentInfo> GetByIdAsync(long environmentId, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<EnvironmentInfo>($"{_environmentsPath}/{environmentId.ToStringInvariant()}", cancellationToken);
     }

--- a/NGitLab/Impl/EpicClient.cs
+++ b/NGitLab/Impl/EpicClient.cs
@@ -17,17 +17,17 @@ public class EpicClient : IEpicClient
         _api = api;
     }
 
-    public IEnumerable<Epic> Get(int groupId, EpicQuery query)
+    public IEnumerable<Epic> Get(long groupId, EpicQuery query)
     {
         return Get(string.Format(CultureInfo.InvariantCulture, GroupEpicsUrl, groupId), query);
     }
 
-    public Epic Get(int groupId, int epicId)
+    public Epic Get(long groupId, long epicId)
     {
         return _api.Get().To<Epic>(string.Format(CultureInfo.InvariantCulture, SingleEpiceUrl, groupId, epicId));
     }
 
-    public GitLabCollectionResponse<Issue> GetIssuesAsync(int groupId, int epicId)
+    public GitLabCollectionResponse<Issue> GetIssuesAsync(long groupId, long epicId)
     {
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, GroupEpicIssuesUrl, groupId, epicId));
     }
@@ -47,12 +47,12 @@ public class EpicClient : IEpicClient
         return _api.Get().GetAll<Epic>(url);
     }
 
-    public Epic Create(int groupId, EpicCreate epic)
+    public Epic Create(long groupId, EpicCreate epic)
     {
         return _api.Post().With(epic).To<Epic>(string.Format(CultureInfo.InvariantCulture, GroupEpicsUrl, groupId));
     }
 
-    public Epic Edit(int groupId, EpicEdit epicEdit)
+    public Epic Edit(long groupId, EpicEdit epicEdit)
     {
         return _api.Put().With(epicEdit).To<Epic>(string.Format(CultureInfo.InvariantCulture, SingleEpiceUrl, groupId, epicEdit.EpicId));
     }

--- a/NGitLab/Impl/GroupHooksClient.cs
+++ b/NGitLab/Impl/GroupHooksClient.cs
@@ -17,13 +17,13 @@ public class GroupHooksClient : IGroupHooksClient
 
     public IEnumerable<GroupHook> All => _api.Get().GetAll<GroupHook>(_path);
 
-    public GroupHook this[int hookId] => _api.Get().To<GroupHook>(_path + "/" + hookId.ToStringInvariant());
+    public GroupHook this[long hookId] => _api.Get().To<GroupHook>(_path + "/" + hookId.ToStringInvariant());
 
     public GroupHook Create(GroupHookUpsert hook) => _api.Post().With(hook).To<GroupHook>(_path);
 
-    public GroupHook Update(int hookId, GroupHookUpsert hook) => _api.Put().With(hook).To<GroupHook>(_path + "/" + hookId.ToStringInvariant());
+    public GroupHook Update(long hookId, GroupHookUpsert hook) => _api.Put().With(hook).To<GroupHook>(_path + "/" + hookId.ToStringInvariant());
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         _api.Delete().Execute(_path + "/" + hookId.ToStringInvariant());
     }

--- a/NGitLab/Impl/GroupsClient.cs
+++ b/NGitLab/Impl/GroupsClient.cs
@@ -169,11 +169,11 @@ public class GroupsClient : IGroupsClient
     public GitLabCollectionResponse<Group> SearchAsync(string search) =>
         _api.Get().GetAllAsync<Group>(Utils.AddOrderBy($"{Url}?search={Uri.EscapeDataString(search)}"));
 
-    public Group this[int id] => GetGroup(id);
+    public Group this[long id] => GetGroup(id);
 
     public Group this[string fullPath] => GetGroup(fullPath);
 
-    public Task<Group> GetByIdAsync(int id, CancellationToken cancellationToken = default) =>
+    public Task<Group> GetByIdAsync(long id, CancellationToken cancellationToken = default) =>
         GetGroupAsync(id, cancellationToken);
 
     public Task<Group> GetByFullPathAsync(string fullPath, CancellationToken cancellationToken = default) =>
@@ -185,7 +185,7 @@ public class GroupsClient : IGroupsClient
     public Task<Group> GetGroupAsync(GroupId id, CancellationToken cancellationToken = default) =>
         _api.Get().ToAsync<Group>($"{Url}/{id.ValueAsUriParameter()}", cancellationToken);
 
-    public GitLabCollectionResponse<Group> GetSubgroupsByIdAsync(int id, SubgroupQuery query = null) =>
+    public GitLabCollectionResponse<Group> GetSubgroupsByIdAsync(long id, SubgroupQuery query = null) =>
         GetSubgroupsAsync(id, query);
 
     public GitLabCollectionResponse<Group> GetSubgroupsByFullPathAsync(string fullPath, SubgroupQuery query = null) =>
@@ -203,13 +203,13 @@ public class GroupsClient : IGroupsClient
         return _api.Get().PageAsync<Group>(url, cancellationToken);
     }
 
-    public IEnumerable<Project> SearchProjects(int groupId, string search) =>
+    public IEnumerable<Project> SearchProjects(long groupId, string search) =>
         SearchProjectsAsync(groupId, new GroupProjectsQuery
         {
             Search = search,
         });
 
-    public GitLabCollectionResponse<Project> GetProjectsAsync(int groupId, GroupProjectsQuery query) =>
+    public GitLabCollectionResponse<Project> GetProjectsAsync(long groupId, GroupProjectsQuery query) =>
         SearchProjectsAsync(groupId, query);
 
     public GitLabCollectionResponse<Project> SearchProjectsAsync(GroupId groupId, GroupProjectsQuery query)
@@ -268,21 +268,21 @@ public class GroupsClient : IGroupsClient
     public Task<Group> CreateAsync(GroupCreate group, CancellationToken cancellationToken = default) =>
         _api.Post().With(group).ToAsync<Group>(Url, cancellationToken);
 
-    public void Delete(int id) =>
+    public void Delete(long id) =>
         _api.Delete().Execute($"{Url}/{new GroupId(id).ValueAsUriParameter()}");
 
-    public Task DeleteAsync(int id, CancellationToken cancellationToken = default) =>
+    public Task DeleteAsync(long id, CancellationToken cancellationToken = default) =>
         _api.Delete().ExecuteAsync($"{Url}/{new GroupId(id).ValueAsUriParameter()}", cancellationToken);
 
-    public Group Update(int id, GroupUpdate groupUpdate) =>
+    public Group Update(long id, GroupUpdate groupUpdate) =>
         _api.Put().With(groupUpdate).To<Group>($"{Url}/{new GroupId(id).ValueAsUriParameter()}");
 
-    public Task<Group> UpdateAsync(int id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default) =>
+    public Task<Group> UpdateAsync(long id, GroupUpdate groupUpdate, CancellationToken cancellationToken = default) =>
         _api.Put().With(groupUpdate).ToAsync<Group>($"{Url}/{new GroupId(id).ValueAsUriParameter()}", cancellationToken);
 
-    public void Restore(int id) =>
+    public void Restore(long id) =>
         _api.Post().Execute($"{Url}/{new GroupId(id).ValueAsUriParameter()}/restore");
 
-    public Task RestoreAsync(int id, CancellationToken cancellationToken = default) =>
+    public Task RestoreAsync(long id, CancellationToken cancellationToken = default) =>
         _api.Post().ExecuteAsync($"{Url}/{new GroupId(id).ValueAsUriParameter()}/restore", cancellationToken);
 }

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -35,42 +35,42 @@ public class IssueClient : IIssueClient
 
     public IEnumerable<Issue> Owned => _api.Get().GetAll<Issue>(IssuesUrl);
 
-    public IEnumerable<Issue> ForProject(int projectId)
+    public IEnumerable<Issue> ForProject(long projectId)
     {
         return _api.Get().GetAll<Issue>(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId));
     }
 
-    public GitLabCollectionResponse<Issue> ForProjectAsync(int projectId)
+    public GitLabCollectionResponse<Issue> ForProjectAsync(long projectId)
     {
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId));
     }
 
-    public GitLabCollectionResponse<Issue> ForGroupsAsync(int groupId)
+    public GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId)
     {
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, GroupIssuesUrl, groupId));
     }
 
-    public GitLabCollectionResponse<Issue> ForGroupsAsync(int groupId, IssueQuery query)
+    public GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId, IssueQuery query)
     {
         return Get(string.Format(CultureInfo.InvariantCulture, GroupIssuesUrl, groupId), query);
     }
 
-    public Issue Get(int projectId, int issueIid)
+    public Issue Get(long projectId, long issueIid)
     {
         return _api.Get().To<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueIid));
     }
 
-    public Task<Issue> GetAsync(int projectId, int issueIid, CancellationToken cancellationToken = default)
+    public Task<Issue> GetAsync(long projectId, long issueIid, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, projectId, issueIid), cancellationToken);
     }
 
-    public IEnumerable<Issue> Get(int projectId, IssueQuery query)
+    public IEnumerable<Issue> Get(long projectId, IssueQuery query)
     {
         return Get(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId), query);
     }
 
-    public GitLabCollectionResponse<Issue> GetAsync(int projectId, IssueQuery query)
+    public GitLabCollectionResponse<Issue> GetAsync(long projectId, IssueQuery query)
     {
         return Get(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId), query);
     }
@@ -85,12 +85,12 @@ public class IssueClient : IIssueClient
         return Get(IssuesUrl, query);
     }
 
-    public Issue GetById(int issueId)
+    public Issue GetById(long issueId)
     {
         return _api.Get().To<Issue>(string.Format(CultureInfo.InvariantCulture, IssueByIdUrl, issueId));
     }
 
-    public Task<Issue> GetByIdAsync(int issueId, CancellationToken cancellationToken = default)
+    public Task<Issue> GetByIdAsync(long issueId, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, IssueByIdUrl, issueId), cancellationToken);
     }
@@ -115,48 +115,48 @@ public class IssueClient : IIssueClient
         return _api.Put().With(issueEdit).ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, SingleIssueUrl, issueEdit.ProjectId, issueEdit.IssueId), cancellationToken);
     }
 
-    public IEnumerable<ResourceLabelEvent> ResourceLabelEvents(int projectId, int issueIid)
+    public IEnumerable<ResourceLabelEvent> ResourceLabelEvents(long projectId, long issueIid)
     {
         return _api.Get().GetAll<ResourceLabelEvent>(string.Format(CultureInfo.InvariantCulture, ResourceLabelEventUrl, projectId, issueIid));
     }
 
-    public GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long issueIid)
     {
         return _api.Get().GetAllAsync<ResourceLabelEvent>(string.Format(CultureInfo.InvariantCulture, ResourceLabelEventUrl, projectId, issueIid));
     }
 
-    public IEnumerable<ResourceMilestoneEvent> ResourceMilestoneEvents(int projectId, int issueIid)
+    public IEnumerable<ResourceMilestoneEvent> ResourceMilestoneEvents(long projectId, long issueIid)
     {
         return _api.Get().GetAll<ResourceMilestoneEvent>(string.Format(CultureInfo.InvariantCulture, ResourceMilestoneEventUrl, projectId, issueIid));
     }
 
-    public GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long issueIid)
     {
         return _api.Get().GetAllAsync<ResourceMilestoneEvent>(string.Format(CultureInfo.InvariantCulture, ResourceMilestoneEventUrl, projectId, issueIid));
     }
 
-    public IEnumerable<ResourceStateEvent> ResourceStateEvents(int projectId, int issueIid)
+    public IEnumerable<ResourceStateEvent> ResourceStateEvents(long projectId, long issueIid)
     {
         return _api.Get().GetAll<ResourceStateEvent>(string.Format(CultureInfo.InvariantCulture, ResourceStateEventUrl, projectId, issueIid));
     }
 
-    public GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(long projectId, long issueIid)
     {
         return _api.Get().GetAllAsync<ResourceStateEvent>(string.Format(CultureInfo.InvariantCulture, ResourceStateEventUrl, projectId, issueIid));
     }
 
-    public IEnumerable<MergeRequest> RelatedTo(int projectId, int issueIid)
+    public IEnumerable<MergeRequest> RelatedTo(long projectId, long issueIid)
     {
         return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, RelatedToUrl, projectId, issueIid));
     }
 
-    public GitLabCollectionResponse<Issue> LinkedToAsync(int projectId, int issueId)
+    public GitLabCollectionResponse<Issue> LinkedToAsync(long projectId, long issueId)
     {
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, LinkedIssuesByIdUrl, projectId, issueId));
     }
 
-    public bool CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId,
-        int targetIssueId)
+    public bool CreateLinkBetweenIssues(long sourceProjectId, long sourceIssueId, long targetProjectId,
+        long targetIssueId)
     {
         try
         {
@@ -169,37 +169,37 @@ public class IssueClient : IIssueClient
         }
     }
 
-    public GitLabCollectionResponse<MergeRequest> RelatedToAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<MergeRequest> RelatedToAsync(long projectId, long issueIid)
     {
         return _api.Get().GetAllAsync<MergeRequest>(string.Format(CultureInfo.InvariantCulture, RelatedToUrl, projectId, issueIid));
     }
 
-    public IEnumerable<MergeRequest> ClosedBy(int projectId, int issueIid)
+    public IEnumerable<MergeRequest> ClosedBy(long projectId, long issueIid)
     {
         return _api.Get().GetAll<MergeRequest>(string.Format(CultureInfo.InvariantCulture, ClosedByUrl, projectId, issueIid));
     }
 
-    public GitLabCollectionResponse<MergeRequest> ClosedByAsync(int projectId, int issueIid)
+    public GitLabCollectionResponse<MergeRequest> ClosedByAsync(long projectId, long issueIid)
     {
         return _api.Get().GetAllAsync<MergeRequest>(string.Format(CultureInfo.InvariantCulture, ClosedByUrl, projectId, issueIid));
     }
 
-    public Task<TimeStats> TimeStatsAsync(int projectId, int issueIid, CancellationToken cancellationToken = default)
+    public Task<TimeStats> TimeStatsAsync(long projectId, long issueIid, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<TimeStats>(string.Format(CultureInfo.InvariantCulture, TimeStatsUrl, projectId, issueIid), cancellationToken);
     }
 
-    public Task<Issue> CloneAsync(int projectId, int issueIid, IssueClone issueClone, CancellationToken cancellationToken = default)
+    public Task<Issue> CloneAsync(long projectId, long issueIid, IssueClone issueClone, CancellationToken cancellationToken = default)
     {
         return _api.Post().With(issueClone).ToAsync<Issue>(string.Format(CultureInfo.InvariantCulture, CloneIssueUrl, projectId, issueIid), cancellationToken);
     }
 
-    public IEnumerable<Participant> GetParticipants(ProjectId projectId, int issueIid)
+    public IEnumerable<Participant> GetParticipants(ProjectId projectId, long issueIid)
     {
         return _api.Get().GetAll<Participant>(string.Format(CultureInfo.InvariantCulture, ParticipantsUrl, projectId.ValueAsUriParameter(), issueIid));
     }
 
-    public Issue Unsubscribe(ProjectId projectId, int issueIid)
+    public Issue Unsubscribe(ProjectId projectId, long issueIid)
     {
         return _api.Post().To<Issue>(string.Format(CultureInfo.InvariantCulture, UnsubscribeUrl, projectId.ValueAsUriParameter(), issueIid));
     }

--- a/NGitLab/Impl/JobClient.cs
+++ b/NGitLab/Impl/JobClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,12 +12,6 @@ public class JobClient : IJobClient
 {
     private readonly API _api;
     private readonly string _jobsPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public JobClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public JobClient(API api, ProjectId projectId)
     {
@@ -63,21 +56,21 @@ public class JobClient : IJobClient
         return url;
     }
 
-    public Job RunAction(int jobId, JobAction action) => _api.Post().To<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}/{action.ToString().ToLowerInvariant()}");
+    public Job RunAction(long jobId, JobAction action) => _api.Post().To<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}/{action.ToString().ToLowerInvariant()}");
 
-    public Task<Job> RunActionAsync(int jobId, JobAction action, CancellationToken cancellationToken = default)
+    public Task<Job> RunActionAsync(long jobId, JobAction action, CancellationToken cancellationToken = default)
     {
         return _api.Post().ToAsync<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}/{action.ToString().ToLowerInvariant()}", cancellationToken);
     }
 
-    public Job Get(int jobId) => _api.Get().To<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}");
+    public Job Get(long jobId) => _api.Get().To<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}");
 
-    public Task<Job> GetAsync(int jobId, CancellationToken cancellationToken = default)
+    public Task<Job> GetAsync(long jobId, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<Job>($"{_jobsPath}/{jobId.ToStringInvariant()}", cancellationToken);
     }
 
-    public byte[] GetJobArtifacts(int jobId)
+    public byte[] GetJobArtifacts(long jobId)
     {
         byte[] result = null;
         _api.Get().Stream($"{_jobsPath}/{jobId.ToStringInvariant()}/artifacts", s =>
@@ -89,7 +82,7 @@ public class JobClient : IJobClient
         return result;
     }
 
-    public byte[] GetJobArtifact(int jobId, string path)
+    public byte[] GetJobArtifact(long jobId, string path)
     {
         byte[] result = null;
         _api.Get().Stream($"{_jobsPath}/{jobId.ToStringInvariant()}/artifacts/{path}", s =>
@@ -113,7 +106,7 @@ public class JobClient : IJobClient
         return result;
     }
 
-    public string GetTrace(int jobId)
+    public string GetTrace(long jobId)
     {
         var result = string.Empty;
         _api.Get().Stream($"{_jobsPath}/{jobId.ToStringInvariant()}/trace", s =>
@@ -123,7 +116,7 @@ public class JobClient : IJobClient
         return result;
     }
 
-    public async Task<string> GetTraceAsync(int jobId, CancellationToken cancellationToken = default)
+    public async Task<string> GetTraceAsync(long jobId, CancellationToken cancellationToken = default)
     {
         var result = string.Empty;
         await _api.Get().StreamAsync($"{_jobsPath}/{jobId.ToStringInvariant()}/trace", async s =>

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -19,33 +19,33 @@ public class LabelClient : ILabelClient
         _api = api;
     }
 
-    public IEnumerable<Label> ForProject(int projectId)
+    public IEnumerable<Label> ForProject(long projectId)
     {
         return _api.Get().GetAll<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
 
-    public IEnumerable<Label> ForGroup(int groupId)
+    public IEnumerable<Label> ForGroup(long groupId)
     {
         return _api.Get().GetAll<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
     }
 
-    public Label GetProjectLabel(int projectId, string name)
+    public Label GetProjectLabel(long projectId, string name)
     {
         return ForProject(projectId).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public Label GetLabel(int projectId, string name)
+    public Label GetLabel(long projectId, string name)
     {
         return GetProjectLabel(projectId, name);
     }
 
-    public Label GetGroupLabel(int groupId, string name)
+    public Label GetGroupLabel(long groupId, string name)
     {
         return ForGroup(groupId).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
-    public Label CreateProjectLabel(int projectId, ProjectLabelCreate label)
+    public Label CreateProjectLabel(long projectId, ProjectLabelCreate label)
     {
         return _api.Post().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
@@ -61,7 +61,7 @@ public class LabelClient : ILabelClient
         });
     }
 
-    public Label CreateGroupLabel(int groupId, GroupLabelCreate label)
+    public Label CreateGroupLabel(long groupId, GroupLabelCreate label)
     {
         return _api.Post().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
     }
@@ -77,7 +77,7 @@ public class LabelClient : ILabelClient
         });
     }
 
-    public Label EditProjectLabel(int projectId, ProjectLabelEdit label)
+    public Label EditProjectLabel(long projectId, ProjectLabelEdit label)
     {
         return _api.Put().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
@@ -94,7 +94,7 @@ public class LabelClient : ILabelClient
         });
     }
 
-    public Label EditGroupLabel(int groupId, GroupLabelEdit label)
+    public Label EditGroupLabel(long groupId, GroupLabelEdit label)
     {
         return _api.Put().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
     }
@@ -111,7 +111,7 @@ public class LabelClient : ILabelClient
         });
     }
 
-    public Label DeleteProjectLabel(int projectId, ProjectLabelDelete label)
+    public Label DeleteProjectLabel(long projectId, ProjectLabelDelete label)
     {
         return _api.Delete().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }

--- a/NGitLab/Impl/MergeRequestApprovalClient.cs
+++ b/NGitLab/Impl/MergeRequestApprovalClient.cs
@@ -15,7 +15,7 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
     private readonly string _approvePath;
     private readonly string _resetApprovalsPath;
 
-    public MergeRequestApprovalClient(API api, string projectPath, int mergeRequestIid)
+    public MergeRequestApprovalClient(API api, string projectPath, long mergeRequestIid)
     {
         var iid = mergeRequestIid.ToString(CultureInfo.InvariantCulture);
         _api = api;

--- a/NGitLab/Impl/MergeRequestChangeClient.cs
+++ b/NGitLab/Impl/MergeRequestChangeClient.cs
@@ -13,7 +13,7 @@ public class MergeRequestChangeClient : IMergeRequestChangeClient
     private readonly API _api;
     private readonly string _changesPath;
 
-    public MergeRequestChangeClient(API api, string projectPath, int mergeRequestIid)
+    public MergeRequestChangeClient(API api, string projectPath, long mergeRequestIid)
     {
         var iid = mergeRequestIid.ToString(CultureInfo.InvariantCulture);
         _api = api;

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,12 +15,6 @@ public class MergeRequestClient : IMergeRequestClient
     private const string ResourceStateEventUrl = "/projects/{0}/merge_requests/{1}/resource_state_events";
     private readonly string _path;
     private readonly API _api;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public MergeRequestClient(API api, int projectId)
-        : this(api, projectId: (long)projectId)
-    {
-    }
 
     public MergeRequestClient(API api, ProjectId projectId)
     {
@@ -73,7 +66,7 @@ public class MergeRequestClient : IMergeRequestClient
         return _api.Get().GetAll<MergeRequest>(url);
     }
 
-    public MergeRequest this[int iid]
+    public MergeRequest this[long iid]
     {
         get
         {
@@ -85,7 +78,7 @@ public class MergeRequestClient : IMergeRequestClient
         }
     }
 
-    public Task<MergeRequest> GetByIidAsync(int iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default)
+    public Task<MergeRequest> GetByIidAsync(long iid, SingleMergeRequestQuery options, CancellationToken cancellationToken = default)
     {
         var url = $"{_path}{MergeRequest.Url}/{iid.ToStringInvariant()}";
         if (options != null)
@@ -108,92 +101,92 @@ public class MergeRequestClient : IMergeRequestClient
             .To<MergeRequest>(_path + "/merge_requests");
     }
 
-    public MergeRequest Update(int mergeRequestIid, MergeRequestUpdate mergeRequest) => _api
+    public MergeRequest Update(long mergeRequestIid, MergeRequestUpdate mergeRequest) => _api
         .Put().With(mergeRequest)
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture));
 
-    public MergeRequest Close(int mergeRequestIid) => _api
+    public MergeRequest Close(long mergeRequestIid) => _api
         .Put().With(new MergeRequestUpdateState { NewState = nameof(MergeRequestStateEvent.close) })
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture));
 
-    public MergeRequest Reopen(int mergeRequestIid) => _api
+    public MergeRequest Reopen(long mergeRequestIid) => _api
         .Put().With(new MergeRequestUpdateState { NewState = nameof(MergeRequestStateEvent.reopen) })
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture));
 
-    public void Delete(int mergeRequestIid) => _api
+    public void Delete(long mergeRequestIid) => _api
         .Delete()
         .Execute(_path + "/merge_requests/" + mergeRequestIid.ToStringInvariant());
 
-    public MergeRequest CancelMergeWhenPipelineSucceeds(int mergeRequestIid) => _api
+    public MergeRequest CancelMergeWhenPipelineSucceeds(long mergeRequestIid) => _api
         .Post()
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/cancel_merge_when_pipeline_succeeds");
 
-    public MergeRequest Accept(int mergeRequestIid, MergeRequestAccept message) => _api
+    public MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message) => _api
         .Put().With(message)
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/merge");
 
-    public MergeRequest Accept(int mergeRequestIid, MergeRequestMerge message) => _api
+    public MergeRequest Accept(long mergeRequestIid, MergeRequestMerge message) => _api
         .Put().With(message)
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/merge");
 
-    public MergeRequest Approve(int mergeRequestIid, MergeRequestApprove message) => _api
+    public MergeRequest Approve(long mergeRequestIid, MergeRequestApprove message) => _api
         .Post().With(message)
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/approve");
 
-    public RebaseResult Rebase(int mergeRequestIid) => _api
+    public RebaseResult Rebase(long mergeRequestIid) => _api
         .Put()
         .To<RebaseResult>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/rebase");
 
-    public Task<RebaseResult> RebaseAsync(int mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default) => _api
+    public Task<RebaseResult> RebaseAsync(long mergeRequestIid, MergeRequestRebase options, CancellationToken cancellationToken = default) => _api
         .Put().With(options)
         .ToAsync<RebaseResult>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/rebase", cancellationToken);
 
-    public IEnumerable<PipelineBasic> GetPipelines(int mergeRequestIid)
+    public IEnumerable<PipelineBasic> GetPipelines(long mergeRequestIid)
     {
         return _api.Get().GetAll<PipelineBasic>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/pipelines");
     }
 
-    public IEnumerable<Author> GetParticipants(int mergeRequestIid)
+    public IEnumerable<Author> GetParticipants(long mergeRequestIid)
     {
         return _api.Get().GetAll<Author>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/participants");
     }
 
-    public IEnumerable<Issue> ClosesIssues(int mergeRequestIid)
+    public IEnumerable<Issue> ClosesIssues(long mergeRequestIid)
     {
         return _api.Get().GetAll<Issue>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/closes_issues");
     }
 
-    public GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(int mergeRequestIid)
+    public GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(long mergeRequestIid)
     {
         return _api.Get().GetAllAsync<MergeRequestVersion>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions");
     }
 
-    public Task<TimeStats> TimeStatsAsync(int mergeRequestIid, CancellationToken cancellationToken = default)
+    public Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<TimeStats>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/time_stats", cancellationToken);
     }
 
-    public IMergeRequestCommentClient Comments(int mergeRequestIid) => new MergeRequestCommentClient(_api, _path, mergeRequestIid);
+    public IMergeRequestCommentClient Comments(long mergeRequestIid) => new MergeRequestCommentClient(_api, _path, mergeRequestIid);
 
-    public IMergeRequestDiscussionClient Discussions(int mergeRequestIid) => new MergeRequestDiscussionClient(_api, _path, mergeRequestIid);
+    public IMergeRequestDiscussionClient Discussions(long mergeRequestIid) => new MergeRequestDiscussionClient(_api, _path, mergeRequestIid);
 
-    public IMergeRequestCommitClient Commits(int mergeRequestIid) => new MergeRequestCommitClient(_api, _path, mergeRequestIid);
+    public IMergeRequestCommitClient Commits(long mergeRequestIid) => new MergeRequestCommitClient(_api, _path, mergeRequestIid);
 
-    public IMergeRequestApprovalClient ApprovalClient(int mergeRequestIid) => new MergeRequestApprovalClient(_api, _path, mergeRequestIid);
+    public IMergeRequestApprovalClient ApprovalClient(long mergeRequestIid) => new MergeRequestApprovalClient(_api, _path, mergeRequestIid);
 
-    public IMergeRequestChangeClient Changes(int mergeRequestIid) => new MergeRequestChangeClient(_api, _path, mergeRequestIid);
+    public IMergeRequestChangeClient Changes(long mergeRequestIid) => new MergeRequestChangeClient(_api, _path, mergeRequestIid);
 
-    public GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<ResourceLabelEvent> ResourceLabelEventsAsync(long projectId, long mergeRequestIid)
     {
         return _api.Get().GetAllAsync<ResourceLabelEvent>(string.Format(CultureInfo.InvariantCulture, ResourceLabelEventUrl, projectId, mergeRequestIid));
     }
 
-    public GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<ResourceMilestoneEvent> ResourceMilestoneEventsAsync(long projectId, long mergeRequestIid)
     {
         return _api.Get().GetAllAsync<ResourceMilestoneEvent>(string.Format(CultureInfo.InvariantCulture, ResourceMilestoneEventUrl, projectId, mergeRequestIid));
     }
 
-    public GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(int projectId, int mergeRequestIid)
+    public GitLabCollectionResponse<ResourceStateEvent> ResourceStateEventsAsync(long projectId, long mergeRequestIid)
     {
         return _api.Get().GetAllAsync<ResourceStateEvent>(string.Format(CultureInfo.InvariantCulture, ResourceStateEventUrl, projectId, mergeRequestIid));
     }

--- a/NGitLab/Impl/MergeRequestCommentClient.cs
+++ b/NGitLab/Impl/MergeRequestCommentClient.cs
@@ -10,7 +10,7 @@ public class MergeRequestCommentClient : IMergeRequestCommentClient
     private readonly string _notesPath;
     private readonly string _discussionsPath;
 
-    public MergeRequestCommentClient(API api, string projectPath, int mergeRequestIid)
+    public MergeRequestCommentClient(API api, string projectPath, long mergeRequestIid)
     {
         _api = api;
         _notesPath = projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/notes";

--- a/NGitLab/Impl/MergeRequestCommitClient.cs
+++ b/NGitLab/Impl/MergeRequestCommitClient.cs
@@ -9,7 +9,7 @@ public class MergeRequestCommitClient : IMergeRequestCommitClient
     private readonly API _api;
     private readonly string _commitsPath;
 
-    public MergeRequestCommitClient(API api, string projectPath, int mergeRequestIid)
+    public MergeRequestCommitClient(API api, string projectPath, long mergeRequestIid)
     {
         _api = api;
         _commitsPath = projectPath + "/merge_requests/" + mergeRequestIid.ToStringInvariant() + "/commits?per_page=100";

--- a/NGitLab/Impl/MergeRequestDiscussionClient.cs
+++ b/NGitLab/Impl/MergeRequestDiscussionClient.cs
@@ -11,7 +11,7 @@ public class MergeRequestDiscussionClient : IMergeRequestDiscussionClient
     private readonly API _api;
     private readonly string _discussionsPath;
 
-    public MergeRequestDiscussionClient(API api, string projectPath, int mergeRequestIid)
+    public MergeRequestDiscussionClient(API api, string projectPath, long mergeRequestIid)
     {
         _api = api;
         _discussionsPath = projectPath + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/discussions";

--- a/NGitLab/Impl/MilestoneClient.cs
+++ b/NGitLab/Impl/MilestoneClient.cs
@@ -20,7 +20,7 @@ public class MilestoneClient : IMilestoneClient
     }
 
     [Obsolete("Use GitLabClient.GetMilestone() or GitLabClient.GetGroupMilestone() instead.")]
-    public MilestoneClient(API api, int projectId)
+    public MilestoneClient(API api, long projectId)
         : this(api, MilestoneScope.Projects, (ProjectId)projectId)
     {
     }
@@ -39,28 +39,28 @@ public class MilestoneClient : IMilestoneClient
         return _api.Get().GetAll<Milestone>(url);
     }
 
-    public Milestone this[int id] => _api.Get().To<Milestone>($"{_milestonePath}/{id.ToStringInvariant()}");
+    public Milestone this[long id] => _api.Get().To<Milestone>($"{_milestonePath}/{id.ToStringInvariant()}");
 
     public Milestone Create(MilestoneCreate milestone) => _api
         .Post().With(milestone)
         .To<Milestone>(_milestonePath);
 
-    public Milestone Update(int milestoneId, MilestoneUpdate milestone) => _api
+    public Milestone Update(long milestoneId, MilestoneUpdate milestone) => _api
         .Put().With(milestone)
         .To<Milestone>($"{_milestonePath}/{milestoneId.ToStringInvariant()}");
 
-    public Milestone Close(int milestoneId) => _api
+    public Milestone Close(long milestoneId) => _api
         .Put().With(new MilestoneUpdateState { NewState = nameof(MilestoneStateEvent.close) })
         .To<Milestone>($"{_milestonePath}/{milestoneId.ToStringInvariant()}");
 
-    public Milestone Activate(int milestoneId) => _api
+    public Milestone Activate(long milestoneId) => _api
         .Put().With(new MilestoneUpdateState { NewState = nameof(MilestoneStateEvent.activate) })
         .To<Milestone>($"{_milestonePath}/{milestoneId.ToStringInvariant()}");
 
-    public IEnumerable<MergeRequest> GetMergeRequests(int milestoneId) => _api
+    public IEnumerable<MergeRequest> GetMergeRequests(long milestoneId) => _api
         .Get().GetAll<MergeRequest>($"{_milestonePath}/{milestoneId.ToStringInvariant()}/merge_requests");
 
-    public void Delete(int milestoneId) => _api
+    public void Delete(long milestoneId) => _api
         .Delete()
         .Execute($"{_milestonePath}/{milestoneId.ToStringInvariant()}");
 }

--- a/NGitLab/Impl/NamespacesClient.cs
+++ b/NGitLab/Impl/NamespacesClient.cs
@@ -18,7 +18,7 @@ public class NamespacesClient : INamespacesClient
 
     public IEnumerable<Namespace> Accessible => _api.Get().GetAll<Namespace>(Url);
 
-    public Namespace this[int id] => _api.Get().To<Namespace>(Url + "/" + id.ToStringInvariant());
+    public Namespace this[long id] => _api.Get().To<Namespace>(Url + "/" + id.ToStringInvariant());
 
     public Namespace this[string fullPath] => _api.Get().To<Namespace>(Url + "/" + WebUtility.UrlEncode(fullPath));
 

--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -15,12 +14,6 @@ public class PipelineClient : IPipelineClient
     private readonly API _api;
     private readonly string _projectPath;
     private readonly string _pipelinesPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public PipelineClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public PipelineClient(API api, ProjectId projectId)
     {
@@ -51,14 +44,14 @@ public class PipelineClient : IPipelineClient
         return _api.Get().GetAll<Job>(url);
     }
 
-    public Pipeline this[int id] => _api.Get().To<Pipeline>($"{_pipelinesPath}/{id.ToStringInvariant()}");
+    public Pipeline this[long id] => _api.Get().To<Pipeline>($"{_pipelinesPath}/{id.ToStringInvariant()}");
 
-    public Task<Pipeline> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public Task<Pipeline> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<Pipeline>($"{_pipelinesPath}/{id.ToStringInvariant()}", cancellationToken);
     }
 
-    public Job[] GetJobs(int pipelineId)
+    public Job[] GetJobs(long pipelineId)
     {
         // For some reason GitLab returns the jobs in the reverse order as
         // they appear in their UI. Here we reverse them!
@@ -179,27 +172,27 @@ public class PipelineClient : IPipelineClient
         return url;
     }
 
-    public void Delete(int pipelineId)
+    public void Delete(long pipelineId)
     {
         _api.Delete().Execute($"{_pipelinesPath}/{pipelineId.ToStringInvariant()}");
     }
 
-    public IEnumerable<PipelineVariable> GetVariables(int pipelineId)
+    public IEnumerable<PipelineVariable> GetVariables(long pipelineId)
     {
         return _api.Get().GetAll<PipelineVariable>($"{_projectPath}/pipelines/{pipelineId.ToStringInvariant()}/variables");
     }
 
-    public GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(int pipelineId)
+    public GitLabCollectionResponse<PipelineVariable> GetVariablesAsync(long pipelineId)
     {
         return _api.Get().GetAllAsync<PipelineVariable>($"{_projectPath}/pipelines/{pipelineId.ToStringInvariant()}/variables");
     }
 
-    public TestReport GetTestReports(int pipelineId)
+    public TestReport GetTestReports(long pipelineId)
     {
         return _api.Get().To<TestReport>($"{_projectPath}/pipelines/{pipelineId.ToStringInvariant()}/test_report");
     }
 
-    public TestReportSummary GetTestReportsSummary(int pipelineId)
+    public TestReportSummary GetTestReportsSummary(long pipelineId)
     {
         return _api.Get().To<TestReportSummary>($"{_projectPath}/pipelines/{pipelineId.ToStringInvariant()}/test_report_summary");
     }
@@ -217,13 +210,13 @@ public class PipelineClient : IPipelineClient
         return url;
     }
 
-    public Task<Pipeline> RetryAsync(int pipelineId, CancellationToken cancellationToken = default)
+    public Task<Pipeline> RetryAsync(long pipelineId, CancellationToken cancellationToken = default)
     {
         var url = $"{_pipelinesPath}/{pipelineId.ToStringInvariant()}/retry";
         return _api.Post().ToAsync<Pipeline>(url, cancellationToken);
     }
 
-    public Task<Pipeline> UpdateMetadataAsync(int pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
+    public Task<Pipeline> UpdateMetadataAsync(long pipelineId, PipelineMetadataUpdate update, CancellationToken cancellationToken = default)
     {
         var updatedMetadataValues = new Dictionary<string, string>(StringComparer.Ordinal);
 

--- a/NGitLab/Impl/PipelineScheduleClient.cs
+++ b/NGitLab/Impl/PipelineScheduleClient.cs
@@ -18,16 +18,16 @@ internal class PipelineScheduleClient : IPipelineScheduleClient
         _schedulesPath = $"{projectPath}/pipeline_schedules";
     }
 
-    public PipelineSchedule this[int id] => _api.Get().To<PipelineSchedule>($"{_schedulesPath}/{id.ToStringInvariant()}");
+    public PipelineSchedule this[long id] => _api.Get().To<PipelineSchedule>($"{_schedulesPath}/{id.ToStringInvariant()}");
 
     public IEnumerable<PipelineScheduleBasic> All => _api.Get().GetAll<PipelineScheduleBasic>(_schedulesPath);
 
     public GitLabCollectionResponse<PipelineScheduleBasic> GetAllAsync()
         => _api.Get().GetAllAsync<PipelineScheduleBasic>(_schedulesPath);
 
-    public GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(int id)
+    public GitLabCollectionResponse<PipelineBasic> GetAllSchedulePipelinesAsync(long id)
         => _api.Get().GetAllAsync<PipelineBasic>($"{_schedulesPath}/{id.ToStringInvariant()}/pipelines");
 
-    public Task<PipelineSchedule> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public Task<PipelineSchedule> GetByIdAsync(long id, CancellationToken cancellationToken = default)
         => _api.Get().ToAsync<PipelineSchedule>($"{_schedulesPath}/{id.ToStringInvariant()}", cancellationToken);
 }

--- a/NGitLab/Impl/ProjectClient.cs
+++ b/NGitLab/Impl/ProjectClient.cs
@@ -73,9 +73,6 @@ public class ProjectClient : IProjectClient
             case ProjectQueryScope.Owned:
                 url = Utils.AddParameter(url, "owned", value: true);
                 break;
-#pragma warning disable 618 // Obsolete
-            case ProjectQueryScope.Visible:
-#pragma warning restore 618
             case ProjectQueryScope.All:
                 // This is the default, it returns all visible projects.
                 break;

--- a/NGitLab/Impl/ProjectClient.cs
+++ b/NGitLab/Impl/ProjectClient.cs
@@ -27,7 +27,7 @@ public class ProjectClient : IProjectClient
 
     public IEnumerable<Project> Visible => _api.Get().GetAll<Project>(Utils.AddOrderBy(Project.Url));
 
-    public Project this[int id] => GetById(id, new SingleProjectQuery());
+    public Project this[long id] => GetById(id, new SingleProjectQuery());
 
     public Project Create(ProjectCreate project) => _api.Post().With(project).To<Project>(Project.Url);
 
@@ -36,15 +36,15 @@ public class ProjectClient : IProjectClient
 
     public Project this[string fullName] => _api.Get().To<Project>($"{Project.Url}/{WebUtility.UrlEncode(fullName)}");
 
-    public void Delete(int id) =>
+    public void Delete(long id) =>
         _api.Delete().Execute($"{Project.Url}/{id.ToString(CultureInfo.InvariantCulture)}");
 
     public Task DeleteAsync(ProjectId projectId, CancellationToken cancellationToken = default) =>
         _api.Delete().ExecuteAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}", cancellationToken);
 
-    public void Archive(int id) => _api.Post().Execute($"{Project.Url}/{id.ToString(CultureInfo.InvariantCulture)}/archive");
+    public void Archive(long id) => _api.Post().Execute($"{Project.Url}/{id.ToString(CultureInfo.InvariantCulture)}/archive");
 
-    public void Unarchive(int id) => _api.Post().Execute($"{Project.Url}/{id.ToString(CultureInfo.InvariantCulture)}/unarchive");
+    public void Unarchive(long id) => _api.Post().Execute($"{Project.Url}/{id.ToString(CultureInfo.InvariantCulture)}/unarchive");
 
     private static bool SupportKeysetPagination(ProjectQuery query)
     {
@@ -125,7 +125,7 @@ public class ProjectClient : IProjectClient
         return _api.Get().GetAllAsync<Project>(url);
     }
 
-    public Project GetById(int id, SingleProjectQuery query)
+    public Project GetById(long id, SingleProjectQuery query)
     {
         var url = $"{Project.Url}/{id.ToStringInvariant()}";
         if (query?.Statistics != null)
@@ -136,7 +136,7 @@ public class ProjectClient : IProjectClient
         return _api.Get().To<Project>(url);
     }
 
-    public Task<Project> GetByIdAsync(int id, SingleProjectQuery query, CancellationToken cancellationToken = default) =>
+    public Task<Project> GetByIdAsync(long id, SingleProjectQuery query, CancellationToken cancellationToken = default) =>
         GetAsync(new ProjectId(id), query, cancellationToken);
 
     public Task<Project> GetByNamespacedPathAsync(string path, SingleProjectQuery query = null, CancellationToken cancellationToken = default) =>

--- a/NGitLab/Impl/ProjectHooksClient.cs
+++ b/NGitLab/Impl/ProjectHooksClient.cs
@@ -17,13 +17,13 @@ public class ProjectHooksClient : IProjectHooksClient
 
     public IEnumerable<ProjectHook> All => _api.Get().GetAll<ProjectHook>(_path);
 
-    public ProjectHook this[int hookId] => _api.Get().To<ProjectHook>(_path + "/" + hookId.ToStringInvariant());
+    public ProjectHook this[long hookId] => _api.Get().To<ProjectHook>(_path + "/" + hookId.ToStringInvariant());
 
     public ProjectHook Create(ProjectHookUpsert hook) => _api.Post().With(hook).To<ProjectHook>(_path);
 
-    public ProjectHook Update(int hookId, ProjectHookUpsert hook) => _api.Put().With(hook).To<ProjectHook>(_path + "/" + hookId.ToStringInvariant());
+    public ProjectHook Update(long hookId, ProjectHookUpsert hook) => _api.Put().With(hook).To<ProjectHook>(_path + "/" + hookId.ToStringInvariant());
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         _api.Delete().Execute(_path + "/" + hookId.ToStringInvariant());
     }

--- a/NGitLab/Impl/ProjectIssueNoteClient.cs
+++ b/NGitLab/Impl/ProjectIssueNoteClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -12,24 +11,18 @@ public class ProjectIssueNoteClient : IProjectIssueNoteClient
     private readonly API _api;
     private readonly string _projectId;
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ProjectIssueNoteClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
-
     public ProjectIssueNoteClient(API api, ProjectId projectId)
     {
         _api = api;
         _projectId = projectId.ValueAsUriParameter();
     }
 
-    public IEnumerable<ProjectIssueNote> ForIssue(int issueId)
+    public IEnumerable<ProjectIssueNote> ForIssue(long issueId)
     {
         return _api.Get().GetAll<ProjectIssueNote>(string.Format(IssuesNoteUrl, _projectId, issueId));
     }
 
-    public ProjectIssueNote Get(int issueId, int noteId)
+    public ProjectIssueNote Get(long issueId, long noteId)
     {
         return _api.Get().To<ProjectIssueNote>(string.Format(SingleNoteIssueUrl, _projectId, issueId, noteId));
     }

--- a/NGitLab/Impl/ProjectLevelApprovalRulesClient.cs
+++ b/NGitLab/Impl/ProjectLevelApprovalRulesClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -9,12 +8,6 @@ public class ProjectLevelApprovalRulesClient : IProjectLevelApprovalRulesClient
 {
     private readonly API _api;
     private readonly string _approvalRulesUrl;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public ProjectLevelApprovalRulesClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public ProjectLevelApprovalRulesClient(API api, ProjectId projectId)
     {
@@ -27,7 +20,7 @@ public class ProjectLevelApprovalRulesClient : IProjectLevelApprovalRulesClient
         return _api.Get().To<List<ApprovalRule>>(_approvalRulesUrl);
     }
 
-    public ApprovalRule UpdateProjectLevelApprovalRule(int approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate)
+    public ApprovalRule UpdateProjectLevelApprovalRule(long approvalRuleIdToUpdate, ApprovalRuleUpdate approvalRuleUpdate)
     {
         return _api.Put().With(approvalRuleUpdate).To<ApprovalRule>(_approvalRulesUrl + $"/{approvalRuleIdToUpdate.ToStringInvariant()}");
     }
@@ -37,7 +30,7 @@ public class ProjectLevelApprovalRulesClient : IProjectLevelApprovalRulesClient
         return _api.Post().With(approvalRuleCreate).To<ApprovalRule>(_approvalRulesUrl);
     }
 
-    public void DeleteProjectLevelRule(int approvalRuleIdToDelete)
+    public void DeleteProjectLevelRule(long approvalRuleIdToDelete)
     {
         _api.Delete().Execute(_approvalRulesUrl + $"/{approvalRuleIdToDelete.ToStringInvariant()}");
     }

--- a/NGitLab/Impl/ReleaseLinkClient.cs
+++ b/NGitLab/Impl/ReleaseLinkClient.cs
@@ -20,11 +20,11 @@ internal sealed class ReleaseLinkClient : IReleaseLinkClient
 
     public IEnumerable<ReleaseLink> All => _api.Get().GetAll<ReleaseLink>(_linksPath);
 
-    public ReleaseLink this[int linkId] => _api.Get().To<ReleaseLink>($"{_linksPath}/{linkId.ToString(CultureInfo.InvariantCulture)}");
+    public ReleaseLink this[long linkId] => _api.Get().To<ReleaseLink>($"{_linksPath}/{linkId.ToString(CultureInfo.InvariantCulture)}");
 
     public ReleaseLink Create(ReleaseLinkCreate data) => _api.Post().With(data).To<ReleaseLink>(_linksPath);
 
-    public ReleaseLink Update(int id, ReleaseLinkUpdate data) => _api.Put().With(data).To<ReleaseLink>($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
+    public ReleaseLink Update(long id, ReleaseLinkUpdate data) => _api.Put().With(data).To<ReleaseLink>($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
 
-    public void Delete(int id) => _api.Delete().Execute($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
+    public void Delete(long id) => _api.Delete().Execute($"{_linksPath}/{id.ToString(CultureInfo.InvariantCulture)}");
 }

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,12 +13,6 @@ public class RepositoryClient : IRepositoryClient
     private readonly API _api;
     private readonly string _repoPath;
     private readonly string _projectPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public RepositoryClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public RepositoryClient(API api, ProjectId projectId)
     {

--- a/NGitLab/Impl/RunnerClient.cs
+++ b/NGitLab/Impl/RunnerClient.cs
@@ -21,7 +21,7 @@ public class RunnerClient : IRunnerClient
 
     public IEnumerable<Runner> All => _api.Get().GetAll<Runner>(Runner.Url + "/all");
 
-    public Runner this[int id] => _api.Get().To<Runner>(Runner.Url + "/" + id.ToStringInvariant());
+    public Runner this[long id] => _api.Get().To<Runner>(Runner.Url + "/" + id.ToStringInvariant());
 
     public IEnumerable<Runner> GetAllRunnersWithScope(RunnerScope scope)
     {
@@ -30,41 +30,41 @@ public class RunnerClient : IRunnerClient
         return _api.Get().GetAll<Runner>(url);
     }
 
-    public IEnumerable<Runner> OfProject(int projectId)
+    public IEnumerable<Runner> OfProject(long projectId)
     {
         return _api.Get().GetAll<Runner>(Project.Url + $"/{projectId.ToStringInvariant()}" + Runner.Url);
     }
 
-    public GitLabCollectionResponse<Runner> OfProjectAsync(int projectId)
+    public GitLabCollectionResponse<Runner> OfProjectAsync(long projectId)
     {
         return _api.Get().GetAllAsync<Runner>(Project.Url + $"/{projectId.ToStringInvariant()}" + Runner.Url);
     }
 
-    public IEnumerable<Runner> OfGroup(int groupId)
+    public IEnumerable<Runner> OfGroup(long groupId)
     {
         return _api.Get().GetAll<Runner>(Group.Url + $"/{groupId.ToStringInvariant()}" + Runner.Url);
     }
 
-    public GitLabCollectionResponse<Runner> OfGroupAsync(int groupId)
+    public GitLabCollectionResponse<Runner> OfGroupAsync(long groupId)
     {
         return _api.Get().GetAllAsync<Runner>(Group.Url + $"/{groupId.ToStringInvariant()}" + Runner.Url);
     }
 
     public void Delete(Runner runner) => Delete(runner.Id);
 
-    public void Delete(int runnerId)
+    public void Delete(long runnerId)
     {
         _api.Delete().Execute(Runner.Url + "/" + runnerId.ToStringInvariant());
     }
 
-    public Runner Update(int runnerId, RunnerUpdate runnerUpdate)
+    public Runner Update(long runnerId, RunnerUpdate runnerUpdate)
     {
         var url = $"{Runner.Url}/{runnerId.ToStringInvariant()}";
         return _api.Put().With(runnerUpdate).To<Runner>(url);
     }
 
     [Obsolete("Use GetJobs(int, JobStatus?) instead")]
-    public IEnumerable<Job> GetJobs(int runnerId, JobScope scope)
+    public IEnumerable<Job> GetJobs(long runnerId, JobScope scope)
     {
         var url = $"{Runner.Url}/{runnerId.ToStringInvariant()}/jobs";
 
@@ -77,7 +77,7 @@ public class RunnerClient : IRunnerClient
     }
 
     [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads", Justification = "Keep compatibility")]
-    public IEnumerable<Job> GetJobs(int runnerId, JobStatus? status = null)
+    public IEnumerable<Job> GetJobs(long runnerId, JobStatus? status = null)
     {
         var url = $"{Runner.Url}/{runnerId.ToStringInvariant()}/jobs";
 
@@ -89,19 +89,19 @@ public class RunnerClient : IRunnerClient
         return _api.Get().GetAll<Job>(url);
     }
 
-    IEnumerable<Runner> IRunnerClient.GetAvailableRunners(int projectId)
+    IEnumerable<Runner> IRunnerClient.GetAvailableRunners(long projectId)
     {
         var url = $"{Project.Url}/{projectId.ToStringInvariant()}/runners";
         return _api.Get().GetAll<Runner>(url);
     }
 
-    public Runner EnableRunner(int projectId, RunnerId runnerId)
+    public Runner EnableRunner(long projectId, RunnerId runnerId)
     {
         var url = $"{Project.Url}/{projectId.ToStringInvariant()}/runners";
         return _api.Post().With(runnerId).To<Runner>(url);
     }
 
-    public void DisableRunner(int projectId, RunnerId runnerId)
+    public void DisableRunner(long projectId, RunnerId runnerId)
     {
         var url = $"{Project.Url}/{projectId.ToStringInvariant()}/runners/{runnerId.Id.ToStringInvariant()}";
         _api.Delete().Execute(url);
@@ -112,7 +112,7 @@ public class RunnerClient : IRunnerClient
         return _api.Post().With(request).To<Runner>(Runner.Url);
     }
 
-    public Task<Runner> EnableRunnerAsync(int projectId, RunnerId runnerId, CancellationToken cancellationToken = default)
+    public Task<Runner> EnableRunnerAsync(long projectId, RunnerId runnerId, CancellationToken cancellationToken = default)
     {
         var url = $"{Project.Url}/{projectId.ToStringInvariant()}/runners";
         return _api.Post().With(runnerId).ToAsync<Runner>(url, cancellationToken);

--- a/NGitLab/Impl/RunnerClient.cs
+++ b/NGitLab/Impl/RunnerClient.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Extensions;
@@ -63,20 +61,6 @@ public class RunnerClient : IRunnerClient
         return _api.Put().With(runnerUpdate).To<Runner>(url);
     }
 
-    [Obsolete("Use GetJobs(int, JobStatus?) instead")]
-    public IEnumerable<Job> GetJobs(long runnerId, JobScope scope)
-    {
-        var url = $"{Runner.Url}/{runnerId.ToStringInvariant()}/jobs";
-
-        if (scope != JobScope.All)
-        {
-            url = Utils.AddParameter(url, "status", scope.ToString().ToLowerInvariant());
-        }
-
-        return _api.Get().GetAll<Job>(url);
-    }
-
-    [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads", Justification = "Keep compatibility")]
     public IEnumerable<Job> GetJobs(long runnerId, JobStatus? status = null)
     {
         var url = $"{Runner.Url}/{runnerId.ToStringInvariant()}/jobs";

--- a/NGitLab/Impl/SnippetClient.cs
+++ b/NGitLab/Impl/SnippetClient.cs
@@ -22,12 +22,12 @@ public class SnippetClient : ISnippetClient
 
     public IEnumerable<Snippet> All => _api.Get().GetAll<Snippet>(SnippetUrl + "/public"); // all public snippets
 
-    public IEnumerable<Snippet> ForProject(int projectId)
+    public IEnumerable<Snippet> ForProject(long projectId)
     {
         return _api.Get().GetAll<Snippet>($"{ProjectUrl}/{projectId.ToStringInvariant()}/snippets");
     }
 
-    public Snippet Get(int projectId, int snippetId)
+    public Snippet Get(long projectId, long snippetId)
     {
         return _api.Get().To<Snippet>($"{ProjectUrl}/{projectId.ToStringInvariant()}/snippets/{snippetId.ToStringInvariant()}");
     }
@@ -52,10 +52,10 @@ public class SnippetClient : ISnippetClient
         _api.Put().With(snippet).To<SnippetProjectUpdate>($"{ProjectUrl}/{snippet.ProjectId.ToStringInvariant()}/snippets/{snippet.SnippetId.ToStringInvariant()}");
     }
 
-    public void Delete(int snippetId) => _api.Delete().Execute($"{SnippetUrl}/{snippetId.ToStringInvariant()}");
+    public void Delete(long snippetId) => _api.Delete().Execute($"{SnippetUrl}/{snippetId.ToStringInvariant()}");
 
-    public void Delete(int projectId, int snippetId) => _api.Delete().Execute($"{ProjectUrl}/{projectId.ToStringInvariant()}/snippets/{snippetId.ToStringInvariant()}");
+    public void Delete(long projectId, long snippetId) => _api.Delete().Execute($"{ProjectUrl}/{projectId.ToStringInvariant()}/snippets/{snippetId.ToStringInvariant()}");
 
-    public void GetContent(int projectId, int snippetId, Action<Stream> parser)
+    public void GetContent(long projectId, long snippetId, Action<Stream> parser)
         => _api.Get().Stream($"{ProjectUrl}/{projectId.ToStringInvariant()}/snippets/{snippetId.ToStringInvariant()}/raw", parser);
 }

--- a/NGitLab/Impl/SshKeyClient.cs
+++ b/NGitLab/Impl/SshKeyClient.cs
@@ -9,7 +9,7 @@ public class SshKeyClient : ISshKeyClient
     private readonly API _api;
     private readonly string _url;
 
-    public SshKeyClient(API api, int? userId)
+    public SshKeyClient(API api, long? userId)
     {
         _api = api;
         _url = userId != null ? $"users/{userId.Value.ToStringInvariant()}/keys" : "user/keys";
@@ -17,14 +17,14 @@ public class SshKeyClient : ISshKeyClient
 
     public IEnumerable<SshKey> All => _api.Get().GetAll<SshKey>(_url);
 
-    public SshKey this[int keyId] => _api.Get().To<SshKey>($"{_url}/{keyId.ToStringInvariant()}");
+    public SshKey this[long keyId] => _api.Get().To<SshKey>($"{_url}/{keyId.ToStringInvariant()}");
 
     public SshKey Add(SshKeyCreate key)
     {
         return _api.Post().With(key).To<SshKey>(_url);
     }
 
-    public void Remove(int keyId)
+    public void Remove(long keyId)
     {
         _api.Delete().Execute($"{_url}/{keyId.ToStringInvariant()}");
     }

--- a/NGitLab/Impl/SystemHookClient.cs
+++ b/NGitLab/Impl/SystemHookClient.cs
@@ -17,11 +17,11 @@ public sealed class SystemHookClient : ISystemHookClient
 
     public IEnumerable<SystemHook> All => _api.Get().GetAll<SystemHook>(_path);
 
-    public SystemHook this[int hookId] => _api.Get().To<SystemHook>(_path + "/" + hookId.ToStringInvariant());
+    public SystemHook this[long hookId] => _api.Get().To<SystemHook>(_path + "/" + hookId.ToStringInvariant());
 
     public SystemHook Create(SystemHookUpsert hook) => _api.Post().With(hook).To<SystemHook>(_path);
 
-    public void Delete(int hookId)
+    public void Delete(long hookId)
     {
         _api.Delete().Execute(_path + "/" + hookId.ToStringInvariant());
     }

--- a/NGitLab/Impl/TriggerClient.cs
+++ b/NGitLab/Impl/TriggerClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using NGitLab.Extensions;
 using NGitLab.Models;
 
@@ -10,19 +9,13 @@ public class TriggerClient : ITriggerClient
     private readonly API _api;
     private readonly string _triggersPath;
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public TriggerClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
-
     public TriggerClient(API api, ProjectId projectId)
     {
         _api = api;
         _triggersPath = $"{Project.Url}/{projectId.ValueAsUriParameter()}/triggers";
     }
 
-    public Trigger this[int id] => _api.Get().To<Trigger>(_triggersPath + "/" + id.ToStringInvariant());
+    public Trigger this[long id] => _api.Get().To<Trigger>(_triggersPath + "/" + id.ToStringInvariant());
 
     public IEnumerable<Trigger> All => _api.Get().GetAll<Trigger>(_triggersPath);
 

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -20,9 +20,9 @@ public class UserClient : IUserClient
 
     public IEnumerable<User> Search(string query) => _api.Get().GetAll<User>(User.Url + $"?search={query}");
 
-    public User this[int id] => _api.Get().To<User>(User.Url + "/" + id.ToStringInvariant());
+    public User this[long id] => _api.Get().To<User>(User.Url + "/" + id.ToStringInvariant());
 
-    public Task<User> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public Task<User> GetByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<User>(User.Url + "/" + id.ToStringInvariant(), cancellationToken);
     }
@@ -79,7 +79,7 @@ public class UserClient : IUserClient
     public Task<UserToken> CreateTokenAsync(UserTokenCreate tokenRequest, CancellationToken cancellationToken = default) =>
         _api.Post().With(tokenRequest).ToAsync<UserToken>($"{User.Url}/{tokenRequest.UserId.ToStringInvariant()}/impersonation_tokens", cancellationToken);
 
-    public User Update(int id, UserUpsert user) => _api.Put().With(user).To<User>(User.Url + "/" + id.ToStringInvariant());
+    public User Update(long id, UserUpsert user) => _api.Put().With(user).To<User>(User.Url + "/" + id.ToStringInvariant());
 
     public Session Current => _api.Get().To<Session>("/user");
 
@@ -90,19 +90,19 @@ public class UserClient : IUserClient
 
     public ISshKeyClient CurrentUserSShKeys => new SshKeyClient(_api, userId: null);
 
-    public ISshKeyClient SShKeys(int userId) => new SshKeyClient(_api, userId);
+    public ISshKeyClient SShKeys(long userId) => new SshKeyClient(_api, userId);
 
-    public void Delete(int userId)
+    public void Delete(long userId)
     {
         _api.Delete().Execute(User.Url + "/" + userId.ToStringInvariant());
     }
 
-    public void Activate(int userId)
+    public void Activate(long userId)
     {
         _api.Post().Execute($"{User.Url}/{userId.ToStringInvariant()}/activate");
     }
 
-    public void Deactivate(int userId)
+    public void Deactivate(long userId)
     {
         _api.Post().Execute($"{User.Url}/{userId.ToStringInvariant()}/deactivate");
     }

--- a/NGitLab/Impl/Utils.cs
+++ b/NGitLab/Impl/Utils.cs
@@ -34,10 +34,12 @@ internal static class Utils
 
     public static string AddParameter(string url, string parameterName, int? value)
     {
-        if (!value.HasValue)
-            return url;
+        return !value.HasValue ? url : AddParameterInternal(url, parameterName, value?.ToString(CultureInfo.InvariantCulture));
+    }
 
-        return AddParameterInternal(url, parameterName, value?.ToString(CultureInfo.InvariantCulture));
+    public static string AddParameter(string url, string parameterName, long? value)
+    {
+        return !value.HasValue ? url : AddParameterInternal(url, parameterName, value?.ToString(CultureInfo.InvariantCulture));
     }
 
     public static string AddParameter(string url, string parameterName, DateTime? date)
@@ -45,7 +47,7 @@ internal static class Utils
         return Equals(date, null) ? url : AddParameterInternal(url, parameterName, date.Value.ToString("O"));
     }
 
-    public static string AddParameter(string url, string parameterName, int[] values)
+    public static string AddParameter(string url, string parameterName, long[] values)
     {
         return Equals(values, null) ? url : AddParameterInternal(url, parameterName, string.Join(",", values));
     }

--- a/NGitLab/Impl/Utils.cs
+++ b/NGitLab/Impl/Utils.cs
@@ -44,17 +44,17 @@ internal static class Utils
 
     public static string AddParameter(string url, string parameterName, DateTime? date)
     {
-        return Equals(date, null) ? url : AddParameterInternal(url, parameterName, date.Value.ToString("O"));
+        return !date.HasValue ? url : AddParameterInternal(url, parameterName, date.Value.ToString("O"));
     }
 
     public static string AddParameter(string url, string parameterName, long[] values)
     {
-        return Equals(values, null) ? url : AddParameterInternal(url, parameterName, string.Join(",", values));
+        return values is null ? url : AddParameterInternal(url, parameterName, string.Join(",", values.Select(v => v.ToString(CultureInfo.InvariantCulture))));
     }
 
     public static string AddArrayParameter(string url, string parameterName, string[] values)
     {
-        if (Equals(values, null))
+        if (values is null)
         {
             return url;
         }

--- a/NGitLab/Impl/WikiClient.cs
+++ b/NGitLab/Impl/WikiClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Net;
 using NGitLab.Models;
 
@@ -10,12 +9,6 @@ public class WikiClient : IWikiClient
 {
     private readonly API _api;
     private readonly string _projectPath;
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public WikiClient(API api, int projectId)
-        : this(api, (long)projectId)
-    {
-    }
 
     public WikiClient(API api, ProjectId projectId)
     {

--- a/NGitLab/Models/AccessLevel.cs
+++ b/NGitLab/Models/AccessLevel.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace NGitLab.Models;
+﻿namespace NGitLab.Models;
 
 /// <summary>
 /// The access levels are defined in the GitLab::Access module. Currently, these levels are recognized:

--- a/NGitLab/Models/AccessLevel.cs
+++ b/NGitLab/Models/AccessLevel.cs
@@ -13,9 +13,6 @@ public enum AccessLevel
     Reporter = 20,
     Developer = 30,
     Maintainer = 40,
-    [Obsolete("Use Maintainer instead")]
-    Master = Maintainer,
-
     /// <summary>
     /// Only valid for groups.
     /// </summary>

--- a/NGitLab/Models/ApprovalRule.cs
+++ b/NGitLab/Models/ApprovalRule.cs
@@ -8,7 +8,7 @@ public sealed class ApprovalRule
     /// The rule Id.
     /// </summary>
     [JsonPropertyName("id")]
-    public int RuleId { get; set; }
+    public long RuleId { get; set; }
 
     /// <summary>
     /// The name of the approval rule.

--- a/NGitLab/Models/ApprovalRuleCreate.cs
+++ b/NGitLab/Models/ApprovalRuleCreate.cs
@@ -1,16 +1,10 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public class ApprovalRuleCreate
 {
-    // Unnecessary in the POSTed JSON; the 'Project Id' is actually specified through the endpoint URL.
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int Id { get; set; }
-
     /// <summary>
     /// Type of the rule.
     /// </summary>
@@ -36,17 +30,17 @@ public class ApprovalRuleCreate
     /// The ids of users as approvers.
     /// </summary>
     [JsonPropertyName("user_ids")]
-    public int[] UserIds { get; set; }
+    public long[] UserIds { get; set; }
 
     /// <summary>
     /// The ids of groups as approvers.
     /// </summary>
     [JsonPropertyName("group_ids")]
-    public int[] GroupIds { get; set; }
+    public long[] GroupIds { get; set; }
 
     /// <summary>
     /// The ids of protected branches to scope the rule by.
     /// </summary>
     [JsonPropertyName("protected_branch_ids")]
-    public int[] ProtectedBranchIds { get; set; }
+    public long[] ProtectedBranchIds { get; set; }
 }

--- a/NGitLab/Models/ApprovalRuleUpdate.cs
+++ b/NGitLab/Models/ApprovalRuleUpdate.cs
@@ -1,16 +1,10 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public sealed class ApprovalRuleUpdate
 {
-    // Unnecessary in the PUT JSON; the 'Project Id' is actually specified through the endpoint URL.
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int Id { get; set; }
-
     /// <summary>
     /// The name of the approval rule.
     /// </summary>
@@ -23,7 +17,7 @@ public sealed class ApprovalRuleUpdate
     /// </summary>
     [Required]
     [JsonPropertyName("approval_rule_id")]
-    public int ApprovalRuleId { get; set; }
+    public long ApprovalRuleId { get; set; }
 
     /// <summary>
     /// The number of approvals required.
@@ -36,17 +30,17 @@ public sealed class ApprovalRuleUpdate
     /// The ids of users as approvers.
     /// </summary>
     [JsonPropertyName("user_ids")]
-    public int[] UserIds { get; set; }
+    public long[] UserIds { get; set; }
 
     /// <summary>
     /// The ids of groups as approvers.
     /// </summary>
     [JsonPropertyName("group_ids")]
-    public int[] GroupIds { get; set; }
+    public long[] GroupIds { get; set; }
 
     /// <summary>
     /// The ids of protected branches to scope the rule by.
     /// </summary>
     [JsonPropertyName("protected_branch_ids")]
-    public int[] ProtectedBranchIds { get; set; }
+    public long[] ProtectedBranchIds { get; set; }
 }

--- a/NGitLab/Models/Assignee.cs
+++ b/NGitLab/Models/Assignee.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class Assignee
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("username")]
     public string Username;

--- a/NGitLab/Models/Author.cs
+++ b/NGitLab/Models/Author.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class Author
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("username")]
     public string Username;

--- a/NGitLab/Models/Badge.cs
+++ b/NGitLab/Models/Badge.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class Badge
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("link_url")]
     public string LinkUrl;

--- a/NGitLab/Models/ClusterInfo.cs
+++ b/NGitLab/Models/ClusterInfo.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class ClusterInfo
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;

--- a/NGitLab/Models/CommitCreate.cs
+++ b/NGitLab/Models/CommitCreate.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -7,11 +6,6 @@ namespace NGitLab.Models;
 
 public class CommitCreate
 {
-    // Unnecessary in the POSTed JSON; the 'Project Id' is actually specified through the endpoint URL.
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int ProjectId;
-
     [Required]
     [JsonPropertyName("branch")]
     public string Branch;

--- a/NGitLab/Models/CommitStatus.cs
+++ b/NGitLab/Models/CommitStatus.cs
@@ -1,17 +1,11 @@
-﻿using System.ComponentModel;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public class CommitStatus
 {
-    // This is NOT the 'Project Id', but some kind of (undocumented) 'Commit Status Id'
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int ProjectId;
-
     [JsonPropertyName("id")]
-    public int Id { get => ProjectId; set => ProjectId = value; }
+    public long Id { get; set; }
 
     [JsonPropertyName("sha")]
     public string CommitSha;

--- a/NGitLab/Models/CommitStatusCreate.cs
+++ b/NGitLab/Models/CommitStatusCreate.cs
@@ -1,15 +1,9 @@
-﻿using System.ComponentModel;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public class CommitStatusCreate
 {
-    // Unnecessary in the POSTed JSON; the 'Project Id' is actually specified through the endpoint URL.
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int ProjectId;
-
     [JsonPropertyName("sha")]
     public string CommitSha;
 
@@ -35,5 +29,5 @@ public class CommitStatusCreate
     public int? Coverage;
 
     [JsonPropertyName("pipeline_id")]
-    public int? PipelineId;
+    public long? PipelineId;
 }

--- a/NGitLab/Models/Deployment.cs
+++ b/NGitLab/Models/Deployment.cs
@@ -3,15 +3,13 @@ using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
-#pragma warning disable CA1724  // Type names should not match .NET Framework class library namespaces
 public class Deployment
-#pragma warning restore CA1724  // Type names should not match .NET Framework class library namespaces
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("iid")]
-    public int DeploymentId { get; set; }
+    public long DeploymentId { get; set; }
 
     [JsonPropertyName("ref")]
     public string Ref { get; set; }

--- a/NGitLab/Models/EnvironmentInfo.cs
+++ b/NGitLab/Models/EnvironmentInfo.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class EnvironmentInfo
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;

--- a/NGitLab/Models/EnvironmentLastDeployment.cs
+++ b/NGitLab/Models/EnvironmentLastDeployment.cs
@@ -6,10 +6,10 @@ namespace NGitLab.Models;
 public class EnvironmentLastDeployment
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("iid")]
-    public int IId { get; set; }
+    public long IId { get; set; }
 
     [JsonPropertyName("ref")]
     public string Ref { get; set; }

--- a/NGitLab/Models/Epic.cs
+++ b/NGitLab/Models/Epic.cs
@@ -6,13 +6,13 @@ namespace NGitLab.Models;
 public class Epic
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("iid")]
-    public int EpicIid { get; set; }
+    public long EpicIid { get; set; }
 
     [JsonPropertyName("group_id")]
-    public int GroupId { get; set; }
+    public long GroupId { get; set; }
 
     [JsonPropertyName("title")]
     public string Title { get; set; }

--- a/NGitLab/Models/EpicEdit.cs
+++ b/NGitLab/Models/EpicEdit.cs
@@ -1,19 +1,13 @@
-﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public class EpicEdit
 {
-    // Unnecessary in the PUT JSON
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int Id { get; set; }
-
     [Required]
     [JsonPropertyName("epic_iid")]
-    public int EpicId { get; set; }
+    public long EpicId { get; set; }
 
     [JsonPropertyName("title")]
     public string Title { get; set; }

--- a/NGitLab/Models/Event.cs
+++ b/NGitLab/Models/Event.cs
@@ -10,13 +10,13 @@ namespace NGitLab.Models;
 public class Event
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("title")]
     public string Title { get; set; }
 
     [JsonPropertyName("project_id")]
-    public int ProjectId { get; set; }
+    public long ProjectId { get; set; }
 
     [JsonPropertyName("action_name")]
     public DynamicEnum<EventAction> Action { get; set; }
@@ -34,7 +34,7 @@ public class Event
     public string TargetTitle { get; set; }
 
     [JsonPropertyName("author_id")]
-    public int AuthorId { get; set; }
+    public long AuthorId { get; set; }
 
     [JsonPropertyName("author_username")]
     public string AuthorUserName { get; set; }

--- a/NGitLab/Models/Group.cs
+++ b/NGitLab/Models/Group.cs
@@ -8,7 +8,7 @@ public class Group
     public const string Url = "/groups";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;
@@ -38,7 +38,7 @@ public class Group
     public string FullPath;
 
     [JsonPropertyName("parent_id")]
-    public int? ParentId;
+    public long? ParentId;
 
     [JsonPropertyName("runners_token")]
     public string RunnersToken;

--- a/NGitLab/Models/GroupCreate.cs
+++ b/NGitLab/Models/GroupCreate.cs
@@ -26,7 +26,7 @@ public class GroupCreate
     public bool RequestAccessEnabled;
 
     [JsonPropertyName("parent_id")]
-    public int? ParentId;
+    public long? ParentId;
 
     [JsonPropertyName("shared_runners_minutes_limit")]
     public int? SharedRunnersMinutesLimit { get; set; }

--- a/NGitLab/Models/GroupHook.cs
+++ b/NGitLab/Models/GroupHook.cs
@@ -6,13 +6,13 @@ namespace NGitLab.Models;
 public class GroupHook
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("url")]
     public Uri Url { get; set; }
 
     [JsonPropertyName("group_id")]
-    public int GroupId { get; set; }
+    public long GroupId { get; set; }
 
     [JsonPropertyName("created_at")]
     public DateTime CreatedAt { get; set; }

--- a/NGitLab/Models/GroupId.cs
+++ b/NGitLab/Models/GroupId.cs
@@ -32,18 +32,9 @@ public readonly struct GroupId : IIdOrPathAddressable, IEquatable<Group>, IEquat
         _path = path ?? throw new ArgumentNullException(nameof(path));
     }
 
-    [Obsolete("Use the non-ambiguous GroupId(long id) or GroupId(string path) constructor instead.")]
-    public GroupId(Group group)
-    {
-        _id = group?.Id ?? throw new ArgumentNullException(nameof(group));
-    }
-
     public static implicit operator GroupId(long id) => new(id);
 
     public static implicit operator GroupId(string path) => new(path);
-
-    [Obsolete("Use the non-ambiguous GroupId(long id) or GroupId(string path) operator instead.")]
-    public static implicit operator GroupId(Group group) => new(group);
 
     public override string ToString() => this.ValueAsString();
 

--- a/NGitLab/Models/GroupQuery.cs
+++ b/NGitLab/Models/GroupQuery.cs
@@ -10,7 +10,7 @@ public class GroupQuery
     /// Skip the group IDs passed
     /// (optional)
     /// </summary>
-    public int[] SkipGroups;
+    public long[] SkipGroups;
 
     /// <summary>
     /// Show all the groups you have access to (defaults to false for authenticated users, true for admin); Attributes owned and min_access_level have precedence

--- a/NGitLab/Models/Identity.cs
+++ b/NGitLab/Models/Identity.cs
@@ -11,5 +11,5 @@ public class Identity
     public string ExternUid;
 
     [JsonPropertyName("saml_provider_id")]
-    public int? SamlProviderId;
+    public long? SamlProviderId;
 }

--- a/NGitLab/Models/Issue.cs
+++ b/NGitLab/Models/Issue.cs
@@ -6,13 +6,13 @@ namespace NGitLab.Models;
 public class Issue
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("iid")]
-    public int IssueId;
+    public long IssueId;
 
     [JsonPropertyName("project_id")]
-    public int ProjectId;
+    public long ProjectId;
 
     [JsonPropertyName("title")]
     public string Title;
@@ -72,7 +72,7 @@ public class Issue
     public string IssueType;
 
     [JsonPropertyName("moved_to_id")]
-    public int? MovedToId;
+    public long? MovedToId;
 
     [JsonPropertyName("references")]
     public References References;

--- a/NGitLab/Models/IssueClone.cs
+++ b/NGitLab/Models/IssueClone.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class IssueClone
 {
     [JsonPropertyName("to_project_id")]
-    public int ToProjectId { get; set; }
+    public long ToProjectId { get; set; }
 
     [JsonPropertyName("with_notes")]
     public bool WithNotes { get; set; }

--- a/NGitLab/Models/IssueCreate.cs
+++ b/NGitLab/Models/IssueCreate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using NGitLab.Impl.Json;
@@ -9,11 +8,7 @@ namespace NGitLab.Models;
 public class IssueCreate
 {
     [JsonIgnore]
-    public int ProjectId { get => Id; set => Id = value; }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int Id;
+    public long ProjectId { get; set; }
 
     [Required]
     [JsonPropertyName("title")]
@@ -23,13 +18,13 @@ public class IssueCreate
     public string Description;
 
     [JsonPropertyName("assignee_id")]
-    public int? AssigneeId;
+    public long? AssigneeId;
 
     [JsonPropertyName("assignee_ids")]
-    public int[] AssigneeIds;
+    public long[] AssigneeIds;
 
     [JsonPropertyName("milestone_id")]
-    public int? MileStoneId;
+    public long? MileStoneId;
 
     [JsonPropertyName("labels")]
     public string Labels;
@@ -42,5 +37,5 @@ public class IssueCreate
     public DateTime? DueDate;
 
     [JsonPropertyName("epic_id")]
-    public int? EpicId;
+    public long? EpicId;
 }

--- a/NGitLab/Models/IssueEdit.cs
+++ b/NGitLab/Models/IssueEdit.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using NGitLab.Impl.Json;
@@ -9,15 +8,11 @@ namespace NGitLab.Models;
 public class IssueEdit
 {
     [JsonIgnore]
-    public int ProjectId { get => Id; set => Id = value; }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [JsonIgnore]
-    public int Id;
+    public long ProjectId { get; set; }
 
     [Required]
     [JsonPropertyName("issue_id")]
-    public int IssueId;
+    public long IssueId;
 
     [JsonPropertyName("title")]
     public string Title;
@@ -26,13 +21,13 @@ public class IssueEdit
     public string Description;
 
     [JsonPropertyName("assignee_id")]
-    public int? AssigneeId;
+    public long? AssigneeId;
 
     [JsonPropertyName("assignee_ids")]
-    public int[] AssigneeIds;
+    public long[] AssigneeIds;
 
     [JsonPropertyName("milestone_id")]
-    public int? MilestoneId;
+    public long? MilestoneId;
 
     [JsonPropertyName("labels")]
     public string Labels;
@@ -45,5 +40,5 @@ public class IssueEdit
     public DateTime? DueDate;
 
     [JsonPropertyName("epic_id")]
-    public int? EpicId;
+    public long? EpicId;
 }

--- a/NGitLab/Models/IssueEpic.cs
+++ b/NGitLab/Models/IssueEpic.cs
@@ -5,13 +5,13 @@ namespace NGitLab.Models;
 public class IssueEpic
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("iid")]
-    public int EpicId { get; set; }
+    public long EpicId { get; set; }
 
     [JsonPropertyName("group_id")]
-    public int GroupId { get; set; }
+    public long GroupId { get; set; }
 
     [JsonPropertyName("title")]
     public string Title { get; set; }

--- a/NGitLab/Models/IssueQuery.cs
+++ b/NGitLab/Models/IssueQuery.cs
@@ -70,7 +70,7 @@ public class IssueQuery
     /// <summary>
     /// Returns issues created by the given user id. Combine with scope=all or scope=assigned_to_me
     /// </summary>
-    public int? AuthorId { get; set; }
+    public long? AuthorId { get; set; }
 
     /// <summary>
     /// Returns issues assigned to the given user id

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -16,7 +16,7 @@ public class Job : JobBasic
     public class JobRunner
     {
         [JsonPropertyName("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonPropertyName("name")]
         public string Name { get; set; }
@@ -43,7 +43,7 @@ public class Job : JobBasic
     public class JobProject
     {
         [JsonPropertyName("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonPropertyName("name")]
         public string Name { get; set; }

--- a/NGitLab/Models/JobBasic.cs
+++ b/NGitLab/Models/JobBasic.cs
@@ -9,7 +9,7 @@ public class JobBasic
     public string Name { get; set; }
 
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("ref")]
     public string Ref { get; set; }
@@ -65,10 +65,10 @@ public class JobBasic
     public class JobPipeline
     {
         [JsonPropertyName("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonPropertyName("project_id")]
-        public int ProjectId { get; set; }
+        public long ProjectId { get; set; }
 
         [JsonPropertyName("ref")]
         public string Ref { get; set; }

--- a/NGitLab/Models/LabelCreate.cs
+++ b/NGitLab/Models/LabelCreate.cs
@@ -8,7 +8,7 @@ namespace NGitLab.Models;
 public class LabelCreate
 {
     [JsonIgnore]
-    public int Id;
+    public long Id;
 
     [Required]
     [JsonPropertyName("name")]

--- a/NGitLab/Models/LabelDelete.cs
+++ b/NGitLab/Models/LabelDelete.cs
@@ -7,7 +7,7 @@ public class LabelDelete
 {
     [Required]
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [Required]
     [JsonPropertyName("name")]

--- a/NGitLab/Models/LabelEdit.cs
+++ b/NGitLab/Models/LabelEdit.cs
@@ -7,18 +7,8 @@ namespace NGitLab.Models;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class LabelEdit
 {
-    public LabelEdit()
-    {
-    }
-
-    public LabelEdit(int projectId, Label label)
-    {
-        Id = projectId;
-        Name = label.Name;
-    }
-
     [JsonIgnore]
-    public int Id;
+    public long Id;
 
     [Required]
     [JsonPropertyName("name")]

--- a/NGitLab/Models/Membership.cs
+++ b/NGitLab/Models/Membership.cs
@@ -9,7 +9,7 @@ public class Membership
     /// Example: 3
     /// </summary>
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     /// <summary>
     /// Example john_doe

--- a/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/Models/MergeRequest.cs
@@ -9,10 +9,10 @@ public class MergeRequest
     public const string Url = "/merge_requests";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("iid")]
-    public int Iid;
+    public long Iid;
 
     [JsonPropertyName("state")]
     public string State;
@@ -54,13 +54,13 @@ public class MergeRequest
     public string SourceBranch;
 
     [JsonPropertyName("project_id")]
-    public int ProjectId;
+    public long ProjectId;
 
     [JsonPropertyName("source_project_id")]
-    public int SourceProjectId;
+    public long SourceProjectId;
 
     [JsonPropertyName("target_project_id")]
-    public int TargetProjectId;
+    public long TargetProjectId;
 
     [Obsolete("Deprecated by GitLab. Use Draft instead")]
     [JsonPropertyName("work_in_progress")]

--- a/NGitLab/Models/MergeRequestApprovals.cs
+++ b/NGitLab/Models/MergeRequestApprovals.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
@@ -33,10 +32,10 @@ public class MergeRequestApprovals
 public class MergeRequestApproversChange
 {
     [JsonPropertyName("approver_ids")]
-    public int[] Approvers = Array.Empty<int>();
+    public long[] Approvers = [];
 
     [JsonPropertyName("approver_group_ids")]
-    public int[] ApproverGroups = Array.Empty<int>();
+    public long[] ApproverGroups = [];
 }
 
 public class MergeRequestApproveRequest

--- a/NGitLab/Models/MergeRequestCreate.cs
+++ b/NGitLab/Models/MergeRequestCreate.cs
@@ -11,13 +11,13 @@ public class MergeRequestCreate
     public string TargetBranch;
 
     [JsonPropertyName("assignee_id")]
-    public int? AssigneeId;
+    public long? AssigneeId;
 
     [JsonPropertyName("assignee_ids")]
-    public int[] AssigneeIds;
+    public long[] AssigneeIds;
 
     [JsonPropertyName("reviewer_ids")]
-    public int[] ReviewerIds;
+    public long[] ReviewerIds;
 
     [JsonPropertyName("title")]
     public string Title;
@@ -26,13 +26,13 @@ public class MergeRequestCreate
     public string Description;
 
     [JsonPropertyName("target_project_id")]
-    public int? TargetProjectId;
+    public long? TargetProjectId;
 
     [JsonPropertyName("remove_source_branch")]
     public bool RemoveSourceBranch;
 
     [JsonPropertyName("milestone_id")]
-    public int? MilestoneId { get; set; }
+    public long? MilestoneId { get; set; }
 
     [JsonPropertyName("labels")]
     public string Labels;

--- a/NGitLab/Models/MergeRequestQuery.cs
+++ b/NGitLab/Models/MergeRequestQuery.cs
@@ -65,7 +65,7 @@ public class MergeRequestQuery
     /// <summary>
     /// Returns merge requests created by the given user id. Combine with scope=all or scope=assigned_to_me
     /// </summary>
-    public int? AuthorId { get; set; }
+    public long? AuthorId { get; set; }
 
     /// <summary>
     /// Returns merge requests assigned to the given user id
@@ -81,7 +81,7 @@ public class MergeRequestQuery
     /// Returns merge requests which have specified all the users with the given ids as individual approvers.
     /// None returns merge requests without approvers. Any returns merge requests with an approver.
     /// </summary>
-    public int[] ApproverIds { get; set; }
+    public long[] ApproverIds { get; set; }
 
     /// <summary>
     /// Return merge requests with the given source branch

--- a/NGitLab/Models/MergeRequestUpdate.cs
+++ b/NGitLab/Models/MergeRequestUpdate.cs
@@ -11,13 +11,13 @@ public class MergeRequestUpdate
     public string TargetBranch;
 
     [JsonPropertyName("assignee_id")]
-    public int? AssigneeId;
+    public long? AssigneeId;
 
     [JsonPropertyName("assignee_ids")]
-    public int[] AssigneeIds;
+    public long[] AssigneeIds;
 
     [JsonPropertyName("reviewer_ids")]
-    public int[] ReviewerIds;
+    public long[] ReviewerIds;
 
     [JsonPropertyName("title")]
     public string Title;
@@ -38,7 +38,7 @@ public class MergeRequestUpdate
     public string RemoveLabels;
 
     [JsonPropertyName("milestone_id")]
-    public int? MilestoneId;
+    public long? MilestoneId;
 
     [JsonPropertyName("allow_collaboration")]
     public bool? AllowCollaboration;

--- a/NGitLab/Models/MergeRequestVersion.cs
+++ b/NGitLab/Models/MergeRequestVersion.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class MergeRequestVersion
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("head_commit_sha")]
     public string HeadCommitSha { get; set; }
@@ -21,7 +21,7 @@ public class MergeRequestVersion
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("merge_request_id")]
-    public int MergeRequestId { get; set; }
+    public long MergeRequestId { get; set; }
 
     [JsonPropertyName("state")]
     public string State { get; set; }

--- a/NGitLab/Models/Milestone.cs
+++ b/NGitLab/Models/Milestone.cs
@@ -6,10 +6,10 @@ namespace NGitLab.Models;
 public class Milestone
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("iid")]
-    public int Iid;
+    public long Iid;
 
     [JsonPropertyName("title")]
     public string Title;
@@ -21,10 +21,10 @@ public class Milestone
     public string DueDate;
 
     [JsonPropertyName("group_id")]
-    public int? GroupId;
+    public long? GroupId;
 
     [JsonPropertyName("project_id")]
-    public int? ProjectId;
+    public long? ProjectId;
 
     [JsonPropertyName("start_date")]
     public string StartDate;

--- a/NGitLab/Models/Namespace.cs
+++ b/NGitLab/Models/Namespace.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class Namespace
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;

--- a/NGitLab/Models/Participant.cs
+++ b/NGitLab/Models/Participant.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class Participant
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }

--- a/NGitLab/Models/Pipeline.cs
+++ b/NGitLab/Models/Pipeline.cs
@@ -8,7 +8,7 @@ public class Pipeline
     public const string Url = "/pipelines";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name { get; set; }
@@ -68,5 +68,5 @@ public class Pipeline
     public string Source;
 
     [JsonPropertyName("project_id")]
-    public int ProjectId { get; set; }
+    public long ProjectId { get; set; }
 }

--- a/NGitLab/Models/PipelineBasic.cs
+++ b/NGitLab/Models/PipelineBasic.cs
@@ -8,10 +8,10 @@ public class PipelineBasic
     public const string Url = "/pipelines";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("project_id")]
-    public int ProjectId;
+    public long ProjectId;
 
     [JsonPropertyName("status")]
     public JobStatus Status;

--- a/NGitLab/Models/PipelineBridgeQuery.cs
+++ b/NGitLab/Models/PipelineBridgeQuery.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public class PipelineBridgeQuery
 {
     [Required]
-    public int PipelineId { get; set; }
+    public long PipelineId { get; set; }
 
     public string[] Scope { get; set; }
 }

--- a/NGitLab/Models/PipelineJobQuery.cs
+++ b/NGitLab/Models/PipelineJobQuery.cs
@@ -7,7 +7,7 @@ public class PipelineJobQuery
 {
     [Required]
     [JsonPropertyName("id")]
-    public int PipelineId { get; set; }
+    public long PipelineId { get; set; }
 
     public string[] Scope { get; set; }
 

--- a/NGitLab/Models/PipelineScheduleBasic.cs
+++ b/NGitLab/Models/PipelineScheduleBasic.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class PipelineScheduleBasic
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("description")]
     public string Description { get; set; }

--- a/NGitLab/Models/Project.cs
+++ b/NGitLab/Models/Project.cs
@@ -10,7 +10,7 @@ public class Project
     public const string Url = "/projects";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("avatar_url")]
     public string AvatarUrl;
@@ -105,7 +105,7 @@ public class Project
     public DateTime LastActivityAt;
 
     [JsonPropertyName("creator_id")]
-    public int CreatorId;
+    public long CreatorId;
 
     [JsonPropertyName("ssh_url_to_repo")]
     public string SshUrl;
@@ -202,7 +202,7 @@ public class Project
     public bool Mirror;
 
     [JsonPropertyName("mirror_user_id")]
-    public int MirrorUserId;
+    public long MirrorUserId;
 
     [JsonPropertyName("mirror_trigger_builds")]
     public bool MirrorTriggerBuilds;

--- a/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/Models/ProjectCreate.cs
@@ -12,7 +12,7 @@ public class ProjectCreate
     public string Name;
 
     [JsonPropertyName("namespace_id")]
-    public string NamespaceId;
+    public long? NamespaceId { get; set; }
 
     /// <summary>
     /// The default branch name. Requires <see cref="InitializeWithReadme"/> to be true.

--- a/NGitLab/Models/ProjectGroupsQuery.cs
+++ b/NGitLab/Models/ProjectGroupsQuery.cs
@@ -25,5 +25,5 @@ public sealed class ProjectGroupsQuery
     /// <summary>
     /// Skip the group IDs passed
     /// </summary>
-    public int[] SkipGroups { get; set; }
+    public long[] SkipGroups { get; set; }
 }

--- a/NGitLab/Models/ProjectHook.cs
+++ b/NGitLab/Models/ProjectHook.cs
@@ -6,13 +6,13 @@ namespace NGitLab.Models;
 public class ProjectHook
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("url")]
     public Uri Url;
 
     [JsonPropertyName("project_id")]
-    public int ProjectId;
+    public long ProjectId;
 
     [JsonPropertyName("created_at")]
     public DateTime CreatedAt;

--- a/NGitLab/Models/ProjectId.cs
+++ b/NGitLab/Models/ProjectId.cs
@@ -32,18 +32,9 @@ public readonly struct ProjectId : IIdOrPathAddressable, IEquatable<Project>, IE
         _path = path ?? throw new ArgumentNullException(nameof(path));
     }
 
-    [Obsolete("Use the non-ambiguous ProjectId(long id) or ProjectId(string path) constructor instead.")]
-    public ProjectId(Project project)
-    {
-        _id = project?.Id ?? throw new ArgumentNullException(nameof(project));
-    }
-
     public static implicit operator ProjectId(long id) => new(id);
 
     public static implicit operator ProjectId(string path) => new(path);
-
-    [Obsolete("Use the non-ambiguous ProjectId(long id) or ProjectId(string path) operator instead.")]
-    public static implicit operator ProjectId(Project project) => new(project);
 
     public override string ToString() => this.ValueAsString();
 

--- a/NGitLab/Models/ProjectIssueNote.cs
+++ b/NGitLab/Models/ProjectIssueNote.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class ProjectIssueNote
 {
     [JsonPropertyName("id")]
-    public int NoteId;
+    public long NoteId;
 
     [JsonPropertyName("body")]
     public string Body;
@@ -27,13 +27,13 @@ public class ProjectIssueNote
     public bool System;
 
     [JsonPropertyName("noteable_id")]
-    public int NoteableId;
+    public long NoteableId;
 
     [JsonPropertyName("noteable_type")]
     public string NoteableType;
 
     [JsonPropertyName("noteable_iid")]
-    public int Noteable_Iid;
+    public long Noteable_Iid;
 
     [JsonPropertyName("resolvable")]
     public bool Resolvable;

--- a/NGitLab/Models/ProjectIssueNoteCreate.cs
+++ b/NGitLab/Models/ProjectIssueNoteCreate.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class ProjectIssueNoteCreate
 {
     [JsonIgnore]
-    public int IssueId;
+    public long IssueId;
 
     [Required]
     [JsonPropertyName("body")]

--- a/NGitLab/Models/ProjectIssueNoteEdit.cs
+++ b/NGitLab/Models/ProjectIssueNoteEdit.cs
@@ -6,10 +6,10 @@ namespace NGitLab.Models;
 public class ProjectIssueNoteEdit
 {
     [JsonIgnore]
-    public int IssueId;
+    public long IssueId;
 
     [JsonIgnore]
-    public int NoteId;
+    public long NoteId;
 
     [Required]
     [JsonPropertyName("body")]

--- a/NGitLab/Models/ProjectLabelDelete.cs
+++ b/NGitLab/Models/ProjectLabelDelete.cs
@@ -5,7 +5,7 @@ namespace NGitLab.Models;
 public sealed class ProjectLabelDelete
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }

--- a/NGitLab/Models/ProjectQuery.cs
+++ b/NGitLab/Models/ProjectQuery.cs
@@ -53,7 +53,7 @@ public class ProjectQuery
     /// <summary>
     /// Project visible by user
     /// </summary>
-    public int? UserId;
+    public long? UserId;
 
     /// <summary>
     /// Limit to projects where current user has at least this access level

--- a/NGitLab/Models/ProjectQuery.cs
+++ b/NGitLab/Models/ProjectQuery.cs
@@ -85,13 +85,7 @@ public enum ProjectQueryScope
     Owned,
 
     /// <summary>
-    /// Get a list of projects which the authenticated user can see.
-    /// </summary>
-    [Obsolete("Use All instead which is the same behavior.")]
-    Visible,
-
-    /// <summary>
-    /// Get a list of all GitLab projects.
+    /// Get a list of all projects which the authenticated user can see.
     /// </summary>
     All,
 }

--- a/NGitLab/Models/QueryAssigneeId.cs
+++ b/NGitLab/Models/QueryAssigneeId.cs
@@ -20,7 +20,7 @@ public sealed class QueryAssigneeId
 
     public static QueryAssigneeId None { get; } = new QueryAssigneeId("None");
 
-    public static implicit operator QueryAssigneeId(int id)
+    public static implicit operator QueryAssigneeId(long id)
     {
         if (id == 0)
             return None;

--- a/NGitLab/Models/ReleaseLink.cs
+++ b/NGitLab/Models/ReleaseLink.cs
@@ -19,7 +19,7 @@ public enum ReleaseLinkType
 public class ReleaseLink
 {
     [JsonPropertyName("id")]
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }

--- a/NGitLab/Models/ResourceLabelEvent.cs
+++ b/NGitLab/Models/ResourceLabelEvent.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class ResourceLabelEvent
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("user")]
     public Author User { get; set; }
@@ -15,7 +15,7 @@ public class ResourceLabelEvent
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("resource_id")]
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     [JsonPropertyName("resource_type")]
     public string ResourceType { get; set; }

--- a/NGitLab/Models/ResourceMilestoneEvent.cs
+++ b/NGitLab/Models/ResourceMilestoneEvent.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class ResourceMilestoneEvent
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("user")]
     public Author User { get; set; }
@@ -15,7 +15,7 @@ public class ResourceMilestoneEvent
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("resource_id")]
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     [JsonPropertyName("resource_type")]
     public string ResourceType { get; set; }

--- a/NGitLab/Models/ResourceStateEvent.cs
+++ b/NGitLab/Models/ResourceStateEvent.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class ResourceStateEvent
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("user")]
     public Author User { get; set; }
@@ -15,7 +15,7 @@ public class ResourceStateEvent
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("resource_id")]
-    public int ResourceId { get; set; }
+    public long ResourceId { get; set; }
 
     [JsonPropertyName("resource_type")]
     public string ResourceType { get; set; }

--- a/NGitLab/Models/Runner.cs
+++ b/NGitLab/Models/Runner.cs
@@ -18,10 +18,6 @@ public class Runner
     [JsonPropertyName("paused")]
     public bool Paused;
 
-    [Obsolete("Use Paused field instead")]
-    [JsonPropertyName("active")]
-    public bool Active;
-
     [JsonPropertyName("online")]
     public bool Online;
 

--- a/NGitLab/Models/Runner.cs
+++ b/NGitLab/Models/Runner.cs
@@ -10,7 +10,7 @@ public class Runner
     public const string Url = "/runners";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;

--- a/NGitLab/Models/RunnerId.cs
+++ b/NGitLab/Models/RunnerId.cs
@@ -8,11 +8,11 @@ public class RunnerId
     {
     }
 
-    public RunnerId(int id)
+    public RunnerId(long id)
     {
         Id = id;
     }
 
     [JsonPropertyName("runner_id")]
-    public int Id;
+    public long Id;
 }

--- a/NGitLab/Models/RunnerRegister.cs
+++ b/NGitLab/Models/RunnerRegister.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/RunnerRegister.cs
+++ b/NGitLab/Models/RunnerRegister.cs
@@ -8,10 +8,6 @@ public class RunnerRegister
     [JsonPropertyName("token")]
     public string Token { get; set; }
 
-    [Obsolete("Use Paused property instead")]
-    [JsonPropertyName("active")]
-    public bool? Active { get; set; }
-
     [JsonPropertyName("paused")]
     public bool? Paused { get; set; }
 

--- a/NGitLab/Models/RunnerUpdate.cs
+++ b/NGitLab/Models/RunnerUpdate.cs
@@ -1,14 +1,9 @@
-using System;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
 public class RunnerUpdate
 {
-    [Obsolete("Use Paused field instead")]
-    [JsonPropertyName("active")]
-    public bool? Active;
-
     [JsonPropertyName("description")]
     public string Description;
 

--- a/NGitLab/Models/SearchBlob.cs
+++ b/NGitLab/Models/SearchBlob.cs
@@ -23,5 +23,5 @@ public class SearchBlob
     public int StartLine { get; set; }
 
     [JsonPropertyName("project_id")]
-    public int ProjectId { get; set; }
+    public long ProjectId { get; set; }
 }

--- a/NGitLab/Models/Snippet.cs
+++ b/NGitLab/Models/Snippet.cs
@@ -11,10 +11,6 @@ public class Snippet
     [JsonPropertyName("title")]
     public string Title;
 
-    [JsonPropertyName("file_name")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string FileName;
-
     [JsonPropertyName("description")]
     public string Description;
 

--- a/NGitLab/Models/Snippet.cs
+++ b/NGitLab/Models/Snippet.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class Snippet
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("title")]
     public string Title;

--- a/NGitLab/Models/SnippetCreate.cs
+++ b/NGitLab/Models/SnippetCreate.cs
@@ -10,16 +10,6 @@ public class SnippetCreate
     [JsonPropertyName("title")]
     public string Title;
 
-    [Required]
-    [JsonPropertyName("file_name")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string FileName;
-
-    [Required]
-    [JsonPropertyName("content")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string Content;
-
     [JsonPropertyName("description")]
     public string Description;
 

--- a/NGitLab/Models/SnippetCreate.cs
+++ b/NGitLab/Models/SnippetCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/SnippetProjectCreate.cs
+++ b/NGitLab/Models/SnippetProjectCreate.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 
 public class SnippetProjectCreate
 {
-    public int ProjectId;
+    public long ProjectId;
 
     [Required]
     [JsonPropertyName("title")]

--- a/NGitLab/Models/SnippetProjectCreate.cs
+++ b/NGitLab/Models/SnippetProjectCreate.cs
@@ -12,18 +12,8 @@ public class SnippetProjectCreate
     [JsonPropertyName("title")]
     public string Title;
 
-    [Required]
-    [JsonPropertyName("file_name")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string FileName;
-
     [JsonPropertyName("description")]
     public string Description;
-
-    [Required]
-    [JsonPropertyName("content")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string Code;
 
     [Required]
     [JsonPropertyName("visibility")]

--- a/NGitLab/Models/SnippetProjectCreate.cs
+++ b/NGitLab/Models/SnippetProjectCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/SnippetProjectUpdate.cs
+++ b/NGitLab/Models/SnippetProjectUpdate.cs
@@ -16,18 +16,8 @@ public class SnippetProjectUpdate
     [JsonPropertyName("title")]
     public string Title;
 
-    [Required]
-    [JsonPropertyName("file_name")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string FileName;
-
     [JsonPropertyName("description")]
     public string Description;
-
-    [Required]
-    [JsonPropertyName("content")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string Code;
 
     [Required]
     [JsonPropertyName("visibility")]

--- a/NGitLab/Models/SnippetProjectUpdate.cs
+++ b/NGitLab/Models/SnippetProjectUpdate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/SnippetProjectUpdate.cs
+++ b/NGitLab/Models/SnippetProjectUpdate.cs
@@ -6,11 +6,11 @@ namespace NGitLab.Models;
 
 public class SnippetProjectUpdate
 {
-    public int ProjectId;
+    public long ProjectId;
 
     [Required]
     [JsonPropertyName("id")]
-    public int SnippetId { get; set; }
+    public long SnippetId { get; set; }
 
     [Required]
     [JsonPropertyName("title")]

--- a/NGitLab/Models/SnippetUpdate.cs
+++ b/NGitLab/Models/SnippetUpdate.cs
@@ -8,7 +8,7 @@ public class SnippetUpdate
 {
     [Required]
     [JsonPropertyName("id")]
-    public int SnippetId { get; set; }
+    public long SnippetId { get; set; }
 
     [Required]
     [JsonPropertyName("title")]

--- a/NGitLab/Models/SnippetUpdate.cs
+++ b/NGitLab/Models/SnippetUpdate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/SnippetUpdate.cs
+++ b/NGitLab/Models/SnippetUpdate.cs
@@ -14,16 +14,6 @@ public class SnippetUpdate
     [JsonPropertyName("title")]
     public string Title;
 
-    [Required]
-    [JsonPropertyName("file_name")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string FileName;
-
-    [Required]
-    [JsonPropertyName("content")]
-    [Obsolete("Consider using the Files array that support more than one file.")]
-    public string Content;
-
     [JsonPropertyName("description")]
     public string Description;
 

--- a/NGitLab/Models/SshKey.cs
+++ b/NGitLab/Models/SshKey.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class SshKey
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("title")]
     public string Title;

--- a/NGitLab/Models/SubgroupQuery.cs
+++ b/NGitLab/Models/SubgroupQuery.cs
@@ -16,7 +16,7 @@ public class SubgroupQuery
     /// Skip the group IDs passed
     /// (optional)
     /// </summary>
-    public int[] SkipGroups { get; set; }
+    public long[] SkipGroups { get; set; }
 
     /// <summary>
     /// Show all the groups you have access to (defaults to false for authenticated users, true for admin); Attributes owned and min_access_level have precedence

--- a/NGitLab/Models/SystemHook.cs
+++ b/NGitLab/Models/SystemHook.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public sealed class SystemHook
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("url")]
     public Uri Url { get; set; }

--- a/NGitLab/Models/TagCreate.cs
+++ b/NGitLab/Models/TagCreate.cs
@@ -25,11 +25,4 @@ public class TagCreate
     /// </summary>
     [JsonPropertyName("message")]
     public string Message;
-
-    /// <summary>
-    /// (optional) - Add release notes to the git tag and store it in the GitLab database.
-    /// </summary>
-    [JsonPropertyName("release_description")]
-    [Obsolete("Starting in GitLab 14, releases cannot be made through tags. Use `Repository.Releases.Create` instead", false)]
-    public string ReleaseDescription;
 }

--- a/NGitLab/Models/TagCreate.cs
+++ b/NGitLab/Models/TagCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;

--- a/NGitLab/Models/Trigger.cs
+++ b/NGitLab/Models/Trigger.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class Trigger
 {
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("description")]
     public string Description;

--- a/NGitLab/Models/User.cs
+++ b/NGitLab/Models/User.cs
@@ -10,7 +10,7 @@ public class User
     public const string Url = "/users";
 
     [JsonPropertyName("id")]
-    public int Id;
+    public long Id;
 
     [JsonPropertyName("name")]
     public string Name;
@@ -85,10 +85,10 @@ public class User
     public string Email;
 
     [JsonPropertyName("theme_id")]
-    public int ThemeId;
+    public long ThemeId;
 
     [JsonPropertyName("color_scheme_id")]
-    public int ColorSchemeId;
+    public long ColorSchemeId;
 
     [JsonPropertyName("projects_limit")]
     public int ProjectsLimit;
@@ -148,5 +148,5 @@ public class User
     public bool IsAuditor;
 
     [JsonPropertyName("provisioned_by_group_id")]
-    public int ProvisionedByGroupId;
+    public long ProvisionedByGroupId;
 }

--- a/NGitLab/Models/User.cs
+++ b/NGitLab/Models/User.cs
@@ -99,18 +99,6 @@ public class User
     [JsonPropertyName("identities")]
     public Identity[] Identities;
 
-    [Obsolete("Does not match GitLab's API. Use 'Identities.Provider' instead.")]
-    [JsonIgnore]
-    public string Provider;
-
-    [Obsolete("Does not match GitLab's API. Use 'Identities.ExternUid' instead.")]
-    [JsonIgnore]
-    public string ExternUid;
-
-    [Obsolete("Does not match GitLab's API. Use 'State' instead.")]
-    [JsonIgnore]
-    public bool Blocked;
-
     [JsonPropertyName("can_create_group")]
     public bool CanCreateGroup;
 

--- a/NGitLab/Models/UserToken.cs
+++ b/NGitLab/Models/UserToken.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class UserToken
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public long Id { get; set; }
 
     [JsonPropertyName("revoked")]
     public bool Revoked { get; set; }

--- a/NGitLab/Models/UserTokenCreate.cs
+++ b/NGitLab/Models/UserTokenCreate.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class UserTokenCreate
 {
     [JsonPropertyName("user_id")]
-    public int UserId { get; set; }
+    public long UserId { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }

--- a/NGitLab/Models/Variable.cs
+++ b/NGitLab/Models/Variable.cs
@@ -31,14 +31,6 @@ public class Variable
     [JsonPropertyName("raw")]
     public bool Raw { get; set; }
 
-    [JsonIgnore]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public string Scope
-    {
-        get => EnvironmentScope;
-        set => EnvironmentScope = value;
-    }
-
     /// <summary>
     /// The environment scope of a variable
     /// </summary>

--- a/NGitLab/Models/Variable.cs
+++ b/NGitLab/Models/Variable.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -880,7 +880,6 @@ NGitLab.Impl.RunnerClient.EnableRunner(long projectId, NGitLab.Models.RunnerId r
 NGitLab.Impl.RunnerClient.EnableRunnerAsync(long projectId, NGitLab.Models.RunnerId runnerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.GetAllRunnersWithScope(NGitLab.Models.RunnerScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.GetJobs(long runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.Impl.RunnerClient.GetJobs(long runnerId, NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.RunnerClient.OfGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.OfGroupAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.OfProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
@@ -1112,7 +1111,6 @@ NGitLab.IRunnerClient.EnableRunnerAsync(long projectId, NGitLab.Models.RunnerId 
 NGitLab.IRunnerClient.GetAllRunnersWithScope(NGitLab.Models.RunnerScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.GetAvailableRunners(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.GetJobs(long runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.IRunnerClient.GetJobs(long runnerId, NGitLab.Models.JobScope jobScope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IRunnerClient.OfGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.OfGroupAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.OfProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -48,57 +48,34 @@ NGitLab.GitLabClient
 NGitLab.GitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.GitLabClient.Deployments.get -> NGitLab.IDeploymentClient
 NGitLab.GitLabClient.Epics.get -> NGitLab.IEpicClient
-NGitLab.GitLabClient.GetClusterClient(int projectId) -> NGitLab.IClusterClient
 NGitLab.GitLabClient.GetClusterClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IClusterClient
-NGitLab.GitLabClient.GetCommits(int projectId) -> NGitLab.ICommitClient
 NGitLab.GitLabClient.GetCommits(NGitLab.Models.ProjectId projectId) -> NGitLab.ICommitClient
-NGitLab.GitLabClient.GetCommitStatus(int projectId) -> NGitLab.ICommitStatusClient
 NGitLab.GitLabClient.GetCommitStatus(NGitLab.Models.ProjectId projectId) -> NGitLab.ICommitStatusClient
-NGitLab.GitLabClient.GetEnvironmentClient(int projectId) -> NGitLab.IEnvironmentClient
 NGitLab.GitLabClient.GetEnvironmentClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IEnvironmentClient
 NGitLab.GitLabClient.GetEvents() -> NGitLab.IEventClient
-NGitLab.GitLabClient.GetGroupBadgeClient(int groupId) -> NGitLab.IGroupBadgeClient
 NGitLab.GitLabClient.GetGroupBadgeClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupBadgeClient
 NGitLab.GitLabClient.GetGroupHooksClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupHooksClient
 NGitLab.GitLabClient.GetGroupMergeRequest(NGitLab.Models.GroupId groupId) -> NGitLab.IMergeRequestClient
-NGitLab.GitLabClient.GetGroupMilestone(int groupId) -> NGitLab.IMilestoneClient
 NGitLab.GitLabClient.GetGroupMilestone(NGitLab.Models.GroupId groupId) -> NGitLab.IMilestoneClient
-NGitLab.GitLabClient.GetGroupSearchClient(int groupId) -> NGitLab.ISearchClient
 NGitLab.GitLabClient.GetGroupSearchClient(NGitLab.Models.GroupId groupId) -> NGitLab.ISearchClient
-NGitLab.GitLabClient.GetGroupVariableClient(int groupId) -> NGitLab.IGroupVariableClient
 NGitLab.GitLabClient.GetGroupVariableClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupVariableClient
-NGitLab.GitLabClient.GetJobs(int projectId) -> NGitLab.IJobClient
 NGitLab.GitLabClient.GetJobs(NGitLab.Models.ProjectId projectId) -> NGitLab.IJobClient
-NGitLab.GitLabClient.GetMergeRequest(int projectId) -> NGitLab.IMergeRequestClient
 NGitLab.GitLabClient.GetMergeRequest(NGitLab.Models.ProjectId projectId) -> NGitLab.IMergeRequestClient
-NGitLab.GitLabClient.GetMilestone(int projectId) -> NGitLab.IMilestoneClient
 NGitLab.GitLabClient.GetMilestone(NGitLab.Models.ProjectId projectId) -> NGitLab.IMilestoneClient
-NGitLab.GitLabClient.GetPipelines(int projectId) -> NGitLab.IPipelineClient
 NGitLab.GitLabClient.GetPipelines(NGitLab.Models.ProjectId projectId) -> NGitLab.IPipelineClient
 NGitLab.GitLabClient.GetPipelineSchedules(NGitLab.Models.ProjectId projectId) -> NGitLab.IPipelineScheduleClient
-NGitLab.GitLabClient.GetProjectBadgeClient(int projectId) -> NGitLab.IProjectBadgeClient
 NGitLab.GitLabClient.GetProjectBadgeClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectBadgeClient
-NGitLab.GitLabClient.GetProjectEvents(int projectId) -> NGitLab.IEventClient
 NGitLab.GitLabClient.GetProjectEvents(NGitLab.Models.ProjectId projectId) -> NGitLab.IEventClient
-NGitLab.GitLabClient.GetProjectIssueNoteClient(int projectId) -> NGitLab.IProjectIssueNoteClient
 NGitLab.GitLabClient.GetProjectIssueNoteClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectIssueNoteClient
-NGitLab.GitLabClient.GetProjectLevelApprovalRulesClient(int projectId) -> NGitLab.IProjectLevelApprovalRulesClient
 NGitLab.GitLabClient.GetProjectLevelApprovalRulesClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectLevelApprovalRulesClient
-NGitLab.GitLabClient.GetProjectSearchClient(int projectId) -> NGitLab.ISearchClient
 NGitLab.GitLabClient.GetProjectSearchClient(NGitLab.Models.ProjectId projectId) -> NGitLab.ISearchClient
-NGitLab.GitLabClient.GetProjectVariableClient(int projectId) -> NGitLab.IProjectVariableClient
 NGitLab.GitLabClient.GetProjectVariableClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectVariableClient
-NGitLab.GitLabClient.GetProtectedBranchClient(int projectId) -> NGitLab.IProtectedBranchClient
 NGitLab.GitLabClient.GetProtectedBranchClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProtectedBranchClient
 NGitLab.GitLabClient.GetProtectedTagClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProtectedTagClient
-NGitLab.GitLabClient.GetReleases(int projectId) -> NGitLab.IReleaseClient
 NGitLab.GitLabClient.GetReleases(NGitLab.Models.ProjectId projectId) -> NGitLab.IReleaseClient
-NGitLab.GitLabClient.GetRepository(int projectId) -> NGitLab.IRepositoryClient
 NGitLab.GitLabClient.GetRepository(NGitLab.Models.ProjectId projectId) -> NGitLab.IRepositoryClient
-NGitLab.GitLabClient.GetTriggers(int projectId) -> NGitLab.ITriggerClient
 NGitLab.GitLabClient.GetTriggers(NGitLab.Models.ProjectId projectId) -> NGitLab.ITriggerClient
-NGitLab.GitLabClient.GetUserEvents(int userId) -> NGitLab.IEventClient
-NGitLab.GitLabClient.GetWikiClient(int projectId) -> NGitLab.IWikiClient
+NGitLab.GitLabClient.GetUserEvents(long userId) -> NGitLab.IEventClient
 NGitLab.GitLabClient.GetWikiClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IWikiClient
 NGitLab.GitLabClient.GitLabClient(string hostUrl, string apiToken) -> void
 NGitLab.GitLabClient.GitLabClient(string hostUrl, string apiToken, NGitLab.RequestOptions options) -> void
@@ -161,24 +138,24 @@ NGitLab.ICommitStatusClient.AllBySha(string commitSha) -> System.Collections.Gen
 NGitLab.IContributorClient
 NGitLab.IContributorClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Contributor>
 NGitLab.IDeploymentClient
-NGitLab.IDeploymentClient.Get(int projectId, NGitLab.Models.DeploymentQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Deployment>
-NGitLab.IDeploymentClient.GetMergeRequests(int projectId, int deploymentId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.IDeploymentClient.Get(long projectId, NGitLab.Models.DeploymentQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Deployment>
+NGitLab.IDeploymentClient.GetMergeRequests(long projectId, long deploymentId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IEnvironmentClient
 NGitLab.IEnvironmentClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.EnvironmentInfo>
 NGitLab.IEnvironmentClient.Create(string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.IEnvironmentClient.Delete(int environmentId) -> void
-NGitLab.IEnvironmentClient.Edit(int environmentId, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.IEnvironmentClient.Edit(int environmentId, string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.IEnvironmentClient.GetById(int environmentId) -> NGitLab.Models.EnvironmentInfo
-NGitLab.IEnvironmentClient.GetByIdAsync(int environmentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.EnvironmentInfo>
+NGitLab.IEnvironmentClient.Delete(long environmentId) -> void
+NGitLab.IEnvironmentClient.Edit(long environmentId, string externalUrl) -> NGitLab.Models.EnvironmentInfo
+NGitLab.IEnvironmentClient.Edit(long environmentId, string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
+NGitLab.IEnvironmentClient.GetById(long environmentId) -> NGitLab.Models.EnvironmentInfo
+NGitLab.IEnvironmentClient.GetByIdAsync(long environmentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.EnvironmentInfo>
 NGitLab.IEnvironmentClient.GetEnvironmentsAsync(NGitLab.Models.EnvironmentQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.EnvironmentInfo>
-NGitLab.IEnvironmentClient.Stop(int environmentId) -> NGitLab.Models.EnvironmentInfo
+NGitLab.IEnvironmentClient.Stop(long environmentId) -> NGitLab.Models.EnvironmentInfo
 NGitLab.IEpicClient
-NGitLab.IEpicClient.Create(int groupId, NGitLab.Models.EpicCreate epic) -> NGitLab.Models.Epic
-NGitLab.IEpicClient.Edit(int groupId, NGitLab.Models.EpicEdit epicEdit) -> NGitLab.Models.Epic
-NGitLab.IEpicClient.Get(int groupId, int epicId) -> NGitLab.Models.Epic
-NGitLab.IEpicClient.Get(int groupId, NGitLab.Models.EpicQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Epic>
-NGitLab.IEpicClient.GetIssuesAsync(int groupId, int epicId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IEpicClient.Create(long groupId, NGitLab.Models.EpicCreate epic) -> NGitLab.Models.Epic
+NGitLab.IEpicClient.Edit(long groupId, NGitLab.Models.EpicEdit epicEdit) -> NGitLab.Models.Epic
+NGitLab.IEpicClient.Get(long groupId, long epicId) -> NGitLab.Models.Epic
+NGitLab.IEpicClient.Get(long groupId, NGitLab.Models.EpicQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Epic>
+NGitLab.IEpicClient.GetIssuesAsync(long groupId, long epicId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IEventClient
 NGitLab.IEventClient.Get(NGitLab.Models.EventQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Event>
 NGitLab.IFilesClient
@@ -197,57 +174,34 @@ NGitLab.IGitLabClient
 NGitLab.IGitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.IGitLabClient.Deployments.get -> NGitLab.IDeploymentClient
 NGitLab.IGitLabClient.Epics.get -> NGitLab.IEpicClient
-NGitLab.IGitLabClient.GetClusterClient(int projectId) -> NGitLab.IClusterClient
 NGitLab.IGitLabClient.GetClusterClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IClusterClient
-NGitLab.IGitLabClient.GetCommits(int projectId) -> NGitLab.ICommitClient
 NGitLab.IGitLabClient.GetCommits(NGitLab.Models.ProjectId projectId) -> NGitLab.ICommitClient
-NGitLab.IGitLabClient.GetCommitStatus(int projectId) -> NGitLab.ICommitStatusClient
 NGitLab.IGitLabClient.GetCommitStatus(NGitLab.Models.ProjectId projectId) -> NGitLab.ICommitStatusClient
-NGitLab.IGitLabClient.GetEnvironmentClient(int projectId) -> NGitLab.IEnvironmentClient
 NGitLab.IGitLabClient.GetEnvironmentClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IEnvironmentClient
 NGitLab.IGitLabClient.GetEvents() -> NGitLab.IEventClient
-NGitLab.IGitLabClient.GetGroupBadgeClient(int groupId) -> NGitLab.IGroupBadgeClient
 NGitLab.IGitLabClient.GetGroupBadgeClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupBadgeClient
 NGitLab.IGitLabClient.GetGroupHooksClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupHooksClient
 NGitLab.IGitLabClient.GetGroupMergeRequest(NGitLab.Models.GroupId groupId) -> NGitLab.IMergeRequestClient
-NGitLab.IGitLabClient.GetGroupMilestone(int groupId) -> NGitLab.IMilestoneClient
 NGitLab.IGitLabClient.GetGroupMilestone(NGitLab.Models.GroupId groupId) -> NGitLab.IMilestoneClient
-NGitLab.IGitLabClient.GetGroupSearchClient(int groupId) -> NGitLab.ISearchClient
 NGitLab.IGitLabClient.GetGroupSearchClient(NGitLab.Models.GroupId groupId) -> NGitLab.ISearchClient
-NGitLab.IGitLabClient.GetGroupVariableClient(int groupId) -> NGitLab.IGroupVariableClient
 NGitLab.IGitLabClient.GetGroupVariableClient(NGitLab.Models.GroupId groupId) -> NGitLab.IGroupVariableClient
-NGitLab.IGitLabClient.GetJobs(int projectId) -> NGitLab.IJobClient
 NGitLab.IGitLabClient.GetJobs(NGitLab.Models.ProjectId projectId) -> NGitLab.IJobClient
-NGitLab.IGitLabClient.GetMergeRequest(int projectId) -> NGitLab.IMergeRequestClient
 NGitLab.IGitLabClient.GetMergeRequest(NGitLab.Models.ProjectId projectId) -> NGitLab.IMergeRequestClient
-NGitLab.IGitLabClient.GetMilestone(int projectId) -> NGitLab.IMilestoneClient
 NGitLab.IGitLabClient.GetMilestone(NGitLab.Models.ProjectId projectId) -> NGitLab.IMilestoneClient
-NGitLab.IGitLabClient.GetPipelines(int projectId) -> NGitLab.IPipelineClient
 NGitLab.IGitLabClient.GetPipelines(NGitLab.Models.ProjectId projectId) -> NGitLab.IPipelineClient
 NGitLab.IGitLabClient.GetPipelineSchedules(NGitLab.Models.ProjectId projectId) -> NGitLab.IPipelineScheduleClient
-NGitLab.IGitLabClient.GetProjectBadgeClient(int projectId) -> NGitLab.IProjectBadgeClient
 NGitLab.IGitLabClient.GetProjectBadgeClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectBadgeClient
-NGitLab.IGitLabClient.GetProjectEvents(int projectId) -> NGitLab.IEventClient
 NGitLab.IGitLabClient.GetProjectEvents(NGitLab.Models.ProjectId projectId) -> NGitLab.IEventClient
-NGitLab.IGitLabClient.GetProjectIssueNoteClient(int projectId) -> NGitLab.IProjectIssueNoteClient
 NGitLab.IGitLabClient.GetProjectIssueNoteClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectIssueNoteClient
-NGitLab.IGitLabClient.GetProjectLevelApprovalRulesClient(int projectId) -> NGitLab.IProjectLevelApprovalRulesClient
 NGitLab.IGitLabClient.GetProjectLevelApprovalRulesClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectLevelApprovalRulesClient
-NGitLab.IGitLabClient.GetProjectSearchClient(int projectId) -> NGitLab.ISearchClient
 NGitLab.IGitLabClient.GetProjectSearchClient(NGitLab.Models.ProjectId projectId) -> NGitLab.ISearchClient
-NGitLab.IGitLabClient.GetProjectVariableClient(int projectId) -> NGitLab.IProjectVariableClient
 NGitLab.IGitLabClient.GetProjectVariableClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProjectVariableClient
-NGitLab.IGitLabClient.GetProtectedBranchClient(int projectId) -> NGitLab.IProtectedBranchClient
 NGitLab.IGitLabClient.GetProtectedBranchClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProtectedBranchClient
 NGitLab.IGitLabClient.GetProtectedTagClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IProtectedTagClient
-NGitLab.IGitLabClient.GetReleases(int projectId) -> NGitLab.IReleaseClient
 NGitLab.IGitLabClient.GetReleases(NGitLab.Models.ProjectId projectId) -> NGitLab.IReleaseClient
-NGitLab.IGitLabClient.GetRepository(int projectId) -> NGitLab.IRepositoryClient
 NGitLab.IGitLabClient.GetRepository(NGitLab.Models.ProjectId projectId) -> NGitLab.IRepositoryClient
-NGitLab.IGitLabClient.GetTriggers(int projectId) -> NGitLab.ITriggerClient
 NGitLab.IGitLabClient.GetTriggers(NGitLab.Models.ProjectId projectId) -> NGitLab.ITriggerClient
-NGitLab.IGitLabClient.GetUserEvents(int userId) -> NGitLab.IEventClient
-NGitLab.IGitLabClient.GetWikiClient(int projectId) -> NGitLab.IWikiClient
+NGitLab.IGitLabClient.GetUserEvents(long userId) -> NGitLab.IEventClient
 NGitLab.IGitLabClient.GetWikiClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IWikiClient
 NGitLab.IGitLabClient.GraphQL.get -> NGitLab.IGraphQLClient
 NGitLab.IGitLabClient.Groups.get -> NGitLab.IGroupsClient
@@ -271,44 +225,44 @@ NGitLab.IGraphQLClient.ExecuteAsync<T>(NGitLab.Models.GraphQLQuery query, System
 NGitLab.IGroupBadgeClient
 NGitLab.IGroupBadgeClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Badge>
 NGitLab.IGroupBadgeClient.Create(NGitLab.Models.BadgeCreate badge) -> NGitLab.Models.Badge
-NGitLab.IGroupBadgeClient.Delete(int id) -> void
-NGitLab.IGroupBadgeClient.this[int id].get -> NGitLab.Models.Badge
-NGitLab.IGroupBadgeClient.Update(int id, NGitLab.Models.BadgeUpdate badge) -> NGitLab.Models.Badge
+NGitLab.IGroupBadgeClient.Delete(long id) -> void
+NGitLab.IGroupBadgeClient.this[long id].get -> NGitLab.Models.Badge
+NGitLab.IGroupBadgeClient.Update(long id, NGitLab.Models.BadgeUpdate badge) -> NGitLab.Models.Badge
 NGitLab.IGroupHooksClient
 NGitLab.IGroupHooksClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.GroupHook>
 NGitLab.IGroupHooksClient.Create(NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
-NGitLab.IGroupHooksClient.Delete(int hookId) -> void
-NGitLab.IGroupHooksClient.this[int hookId].get -> NGitLab.Models.GroupHook
-NGitLab.IGroupHooksClient.Update(int hookId, NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
+NGitLab.IGroupHooksClient.Delete(long hookId) -> void
+NGitLab.IGroupHooksClient.this[long hookId].get -> NGitLab.Models.GroupHook
+NGitLab.IGroupHooksClient.Update(long hookId, NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
 NGitLab.IGroupsClient
 NGitLab.IGroupsClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.IGroupsClient.Create(NGitLab.Models.GroupCreate group) -> NGitLab.Models.Group
 NGitLab.IGroupsClient.CreateAsync(NGitLab.Models.GroupCreate group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.IGroupsClient.Delete(int id) -> void
-NGitLab.IGroupsClient.DeleteAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IGroupsClient.Delete(long id) -> void
+NGitLab.IGroupsClient.DeleteAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IGroupsClient.Get(NGitLab.Models.GroupQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.IGroupsClient.GetAsync(NGitLab.Models.GroupQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.IGroupsClient.GetByFullPathAsync(string fullPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.IGroupsClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
+NGitLab.IGroupsClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
 NGitLab.IGroupsClient.GetGroup(NGitLab.Models.GroupId id) -> NGitLab.Models.Group
 NGitLab.IGroupsClient.GetGroupAsync(NGitLab.Models.GroupId groupId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.IGroupsClient.GetProjectsAsync(int groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
+NGitLab.IGroupsClient.GetProjectsAsync(long groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.IGroupsClient.GetSubgroupsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.IGroupsClient.GetSubgroupsByFullPathAsync(string fullPath, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
-NGitLab.IGroupsClient.GetSubgroupsByIdAsync(int id, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
+NGitLab.IGroupsClient.GetSubgroupsByIdAsync(long id, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.IGroupsClient.PageAsync(NGitLab.Models.PageQuery<NGitLab.Models.GroupQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Group>>
 NGitLab.IGroupsClient.PageProjectsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.PageQuery<NGitLab.Models.GroupProjectsQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Project>>
 NGitLab.IGroupsClient.PageSubgroupsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.PageQuery<NGitLab.Models.SubgroupQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Group>>
-NGitLab.IGroupsClient.Restore(int id) -> void
-NGitLab.IGroupsClient.RestoreAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IGroupsClient.Restore(long id) -> void
+NGitLab.IGroupsClient.RestoreAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IGroupsClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.IGroupsClient.SearchAsync(string search) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
-NGitLab.IGroupsClient.SearchProjects(int groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.IGroupsClient.SearchProjects(long groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IGroupsClient.SearchProjectsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
-NGitLab.IGroupsClient.this[int id].get -> NGitLab.Models.Group
+NGitLab.IGroupsClient.this[long id].get -> NGitLab.Models.Group
 NGitLab.IGroupsClient.this[string fullPath].get -> NGitLab.Models.Group
-NGitLab.IGroupsClient.Update(int id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
-NGitLab.IGroupsClient.UpdateAsync(int id, NGitLab.Models.GroupUpdate groupUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
+NGitLab.IGroupsClient.Update(long id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
+NGitLab.IGroupsClient.UpdateAsync(long id, NGitLab.Models.GroupUpdate groupUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
 NGitLab.IGroupVariableClient
 NGitLab.IGroupVariableClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Variable>
 NGitLab.IGroupVariableClient.Create(NGitLab.Models.VariableCreate model) -> NGitLab.Models.Variable
@@ -333,68 +287,68 @@ NGitLab.IHttpRequestor.To<T>(string tailAPIUrl) -> T
 NGitLab.IHttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>
 NGitLab.IHttpRequestor.With(object data) -> NGitLab.IHttpRequestor
 NGitLab.IIssueClient
-NGitLab.IIssueClient.CloneAsync(int projectId, int issueIid, NGitLab.Models.IssueClone issueClone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.ClosedBy(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.IIssueClient.ClosedByAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
+NGitLab.IIssueClient.CloneAsync(long projectId, long issueIid, NGitLab.Models.IssueClone issueClone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ClosedBy(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.IIssueClient.ClosedByAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.IIssueClient.Create(NGitLab.Models.IssueCreate issueCreate) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.CreateAsync(NGitLab.Models.IssueCreate issueCreate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId) -> bool
+NGitLab.IIssueClient.CreateLinkBetweenIssues(long sourceProjectId, long sourceIssueId, long targetProjectId, long targetIssueId) -> bool
 NGitLab.IIssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.ForGroupsAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.IIssueClient.ForGroupsAsync(int groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.IIssueClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.IIssueClient.ForProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.IIssueClient.Get(int projectId, int issueIid) -> NGitLab.Models.Issue
-NGitLab.IIssueClient.Get(int projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ForGroupsAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ForGroupsAsync(long groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ForProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.Get(long projectId, long issueIid) -> NGitLab.Models.Issue
+NGitLab.IIssueClient.Get(long projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.IIssueClient.GetAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetAsync(long projectId, long issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetAsync(long projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.IIssueClient.GetById(int issueId) -> NGitLab.Models.Issue
-NGitLab.IIssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.IIssueClient.GetParticipants(NGitLab.Models.ProjectId projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Participant>
-NGitLab.IIssueClient.LinkedToAsync(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetById(long issueId) -> NGitLab.Models.Issue
+NGitLab.IIssueClient.GetByIdAsync(long issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.IIssueClient.GetParticipants(NGitLab.Models.ProjectId projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Participant>
+NGitLab.IIssueClient.LinkedToAsync(long projectId, long issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.IIssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.IIssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
-NGitLab.IIssueClient.ResourceLabelEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceLabelEvent>
-NGitLab.IIssueClient.ResourceLabelEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
-NGitLab.IIssueClient.ResourceMilestoneEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.IIssueClient.ResourceMilestoneEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.IIssueClient.ResourceStateEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceStateEvent>
-NGitLab.IIssueClient.ResourceStateEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
-NGitLab.IIssueClient.TimeStatsAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
-NGitLab.IIssueClient.Unsubscribe(NGitLab.Models.ProjectId projectId, int issueIid) -> NGitLab.Models.Issue
+NGitLab.IIssueClient.RelatedTo(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.IIssueClient.RelatedToAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
+NGitLab.IIssueClient.ResourceLabelEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceLabelEvent>
+NGitLab.IIssueClient.ResourceLabelEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
+NGitLab.IIssueClient.ResourceMilestoneEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.IIssueClient.ResourceMilestoneEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.IIssueClient.ResourceStateEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceStateEvent>
+NGitLab.IIssueClient.ResourceStateEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
+NGitLab.IIssueClient.TimeStatsAsync(long projectId, long issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.IIssueClient.Unsubscribe(NGitLab.Models.ProjectId projectId, long issueIid) -> NGitLab.Models.Issue
 NGitLab.IJobClient
-NGitLab.IJobClient.Get(int jobId) -> NGitLab.Models.Job
-NGitLab.IJobClient.GetAsync(int jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
-NGitLab.IJobClient.GetJobArtifact(int jobId, string path) -> byte[]
+NGitLab.IJobClient.Get(long jobId) -> NGitLab.Models.Job
+NGitLab.IJobClient.GetAsync(long jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
+NGitLab.IJobClient.GetJobArtifact(long jobId, string path) -> byte[]
 NGitLab.IJobClient.GetJobArtifact(NGitLab.Models.JobArtifactQuery query) -> byte[]
-NGitLab.IJobClient.GetJobArtifacts(int jobId) -> byte[]
+NGitLab.IJobClient.GetJobArtifacts(long jobId) -> byte[]
 NGitLab.IJobClient.GetJobs(NGitLab.Models.JobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IJobClient.GetJobs(NGitLab.Models.JobScopeMask scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IJobClient.GetJobsAsync(NGitLab.Models.JobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.IJobClient.GetTrace(int jobId) -> string
-NGitLab.IJobClient.GetTraceAsync(int jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-NGitLab.IJobClient.RunAction(int jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
-NGitLab.IJobClient.RunActionAsync(int jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
+NGitLab.IJobClient.GetTrace(long jobId) -> string
+NGitLab.IJobClient.GetTraceAsync(long jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+NGitLab.IJobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
+NGitLab.IJobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.ILabelClient
 NGitLab.ILabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.CreateGroupLabel(int groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.CreateProjectLabel(int projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.DeleteProjectLabel(int projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.EditGroupLabel(int groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.EditProjectLabel(int projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.ForGroup(int groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.ILabelClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.ILabelClient.GetGroupLabel(int groupId, string name) -> NGitLab.Models.Label
-NGitLab.ILabelClient.GetLabel(int projectId, string name) -> NGitLab.Models.Label
-NGitLab.ILabelClient.GetProjectLabel(int projectId, string name) -> NGitLab.Models.Label
+NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
+NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
+NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILintClient
 NGitLab.ILintClient.ValidateCIYamlContentAsync(string projectId, string yamlContent, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
 NGitLab.ILintClient.ValidateProjectCIConfigurationAsync(string projectId, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
@@ -430,35 +384,35 @@ NGitLab.IMergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.IMergeRequestChangeClient
 NGitLab.IMergeRequestChangeClient.MergeRequestChange.get -> NGitLab.Models.MergeRequestChange
 NGitLab.IMergeRequestClient
-NGitLab.IMergeRequestClient.Accept(int mergeRequestIid, NGitLab.Models.MergeRequestAccept message) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.Accept(int mergeRequestIid, NGitLab.Models.MergeRequestMerge message) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.Accept(long mergeRequestIid, NGitLab.Models.MergeRequestAccept message) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.Accept(long mergeRequestIid, NGitLab.Models.MergeRequestMerge message) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.AllInState(NGitLab.Models.MergeRequestState state) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.IMergeRequestClient.ApprovalClient(int mergeRequestIid) -> NGitLab.IMergeRequestApprovalClient
-NGitLab.IMergeRequestClient.Approve(int mergeRequestIid, NGitLab.Models.MergeRequestApprove message) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.CancelMergeWhenPipelineSucceeds(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.Changes(int mergeRequestIid) -> NGitLab.IMergeRequestChangeClient
-NGitLab.IMergeRequestClient.Close(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.ClosesIssues(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.IMergeRequestClient.Comments(int mergeRequestIid) -> NGitLab.IMergeRequestCommentClient
-NGitLab.IMergeRequestClient.Commits(int mergeRequestIid) -> NGitLab.IMergeRequestCommitClient
+NGitLab.IMergeRequestClient.ApprovalClient(long mergeRequestIid) -> NGitLab.IMergeRequestApprovalClient
+NGitLab.IMergeRequestClient.Approve(long mergeRequestIid, NGitLab.Models.MergeRequestApprove message) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.CancelMergeWhenPipelineSucceeds(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.Changes(long mergeRequestIid) -> NGitLab.IMergeRequestChangeClient
+NGitLab.IMergeRequestClient.Close(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.ClosesIssues(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.IMergeRequestClient.Comments(long mergeRequestIid) -> NGitLab.IMergeRequestCommentClient
+NGitLab.IMergeRequestClient.Commits(long mergeRequestIid) -> NGitLab.IMergeRequestCommitClient
 NGitLab.IMergeRequestClient.Create(NGitLab.Models.MergeRequestCreate mergeRequest) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.Delete(int mergeRequestIid) -> void
-NGitLab.IMergeRequestClient.Discussions(int mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
+NGitLab.IMergeRequestClient.Delete(long mergeRequestIid) -> void
+NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.IMergeRequestClient.GetByIidAsync(int iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
-NGitLab.IMergeRequestClient.GetParticipants(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
-NGitLab.IMergeRequestClient.GetPipelines(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
-NGitLab.IMergeRequestClient.GetVersionsAsync(int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
-NGitLab.IMergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.RebaseResult
-NGitLab.IMergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
-NGitLab.IMergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.ResourceLabelEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
-NGitLab.IMergeRequestClient.ResourceMilestoneEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.IMergeRequestClient.ResourceStateEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
-NGitLab.IMergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
-NGitLab.IMergeRequestClient.TimeStatsAsync(int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
-NGitLab.IMergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
+NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
+NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
+NGitLab.IMergeRequestClient.Rebase(long mergeRequestIid) -> NGitLab.Models.RebaseResult
+NGitLab.IMergeRequestClient.RebaseAsync(long mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
+NGitLab.IMergeRequestClient.Reopen(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.ResourceLabelEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
+NGitLab.IMergeRequestClient.ResourceMilestoneEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.IMergeRequestClient.ResourceStateEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
+NGitLab.IMergeRequestClient.this[long iid].get -> NGitLab.Models.MergeRequest
+NGitLab.IMergeRequestClient.TimeStatsAsync(long mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.IMergeRequestClient.Update(long mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.IMergeRequestCommentClient
 NGitLab.IMergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment
 NGitLab.IMergeRequestCommentClient.Add(NGitLab.Models.MergeRequestCommentCreate comment) -> NGitLab.Models.MergeRequestComment
@@ -478,17 +432,17 @@ NGitLab.IMergeRequestDiscussionClient.Get(string id) -> NGitLab.Models.MergeRequ
 NGitLab.IMergeRequestDiscussionClient.GetAsync(string id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequestDiscussion>
 NGitLab.IMergeRequestDiscussionClient.Resolve(NGitLab.Models.MergeRequestDiscussionResolve resolve) -> NGitLab.Models.MergeRequestDiscussion
 NGitLab.IMilestoneClient
-NGitLab.IMilestoneClient.Activate(int milestoneId) -> NGitLab.Models.Milestone
+NGitLab.IMilestoneClient.Activate(long milestoneId) -> NGitLab.Models.Milestone
 NGitLab.IMilestoneClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
 NGitLab.IMilestoneClient.AllInState(NGitLab.Models.MilestoneState state) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
-NGitLab.IMilestoneClient.Close(int milestoneId) -> NGitLab.Models.Milestone
+NGitLab.IMilestoneClient.Close(long milestoneId) -> NGitLab.Models.Milestone
 NGitLab.IMilestoneClient.Create(NGitLab.Models.MilestoneCreate milestone) -> NGitLab.Models.Milestone
-NGitLab.IMilestoneClient.Delete(int milestoneId) -> void
+NGitLab.IMilestoneClient.Delete(long milestoneId) -> void
 NGitLab.IMilestoneClient.Get(NGitLab.Models.MilestoneQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
-NGitLab.IMilestoneClient.GetMergeRequests(int milestoneId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.IMilestoneClient.GetMergeRequests(long milestoneId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMilestoneClient.Scope.get -> NGitLab.Impl.MilestoneScope
-NGitLab.IMilestoneClient.this[int id].get -> NGitLab.Models.Milestone
-NGitLab.IMilestoneClient.Update(int milestoneId, NGitLab.Models.MilestoneUpdate milestone) -> NGitLab.Models.Milestone
+NGitLab.IMilestoneClient.this[long id].get -> NGitLab.Models.Milestone
+NGitLab.IMilestoneClient.Update(long milestoneId, NGitLab.Models.MilestoneUpdate milestone) -> NGitLab.Models.Milestone
 NGitLab.Impl.API
 NGitLab.Impl.API.API(NGitLab.Impl.GitLabCredentials credentials) -> void
 NGitLab.Impl.API.API(NGitLab.Impl.GitLabCredentials credentials, NGitLab.RequestOptions options) -> void
@@ -513,11 +467,9 @@ NGitLab.Impl.BranchClient.this[string name].get -> NGitLab.Models.Branch
 NGitLab.Impl.BranchClient.Unprotect(string name) -> NGitLab.Models.Branch
 NGitLab.Impl.ClusterClient
 NGitLab.Impl.ClusterClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.ClusterInfo>
-NGitLab.Impl.ClusterClient.ClusterClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.ClusterClient.ClusterClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitClient
 NGitLab.Impl.CommitClient.CherryPick(NGitLab.Models.CommitCherryPick cherryPick) -> NGitLab.Models.Commit
-NGitLab.Impl.CommitClient.CommitClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.CommitClient.CommitClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitClient.Create(NGitLab.Models.CommitCreate commit) -> NGitLab.Models.Commit
 NGitLab.Impl.CommitClient.GetCommit(string ref) -> NGitLab.Models.Commit
@@ -526,12 +478,11 @@ NGitLab.Impl.CommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMer
 NGitLab.Impl.CommitStatusClient
 NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
 NGitLab.Impl.CommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
-NGitLab.Impl.CommitStatusClient.CommitStatusClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.CommitStatusClient.CommitStatusClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.DeploymentClient
 NGitLab.Impl.DeploymentClient.DeploymentClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.DeploymentClient.Get(int projectId, NGitLab.Models.DeploymentQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Deployment>
-NGitLab.Impl.DeploymentClient.GetMergeRequests(int projectId, int deploymentId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.Impl.DeploymentClient.Get(long projectId, NGitLab.Models.DeploymentQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Deployment>
+NGitLab.Impl.DeploymentClient.GetMergeRequests(long projectId, long deploymentId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.DiffStats
 NGitLab.Impl.DiffStats.AddedLines.get -> int
 NGitLab.Impl.DiffStats.AddedLines.set -> void
@@ -541,22 +492,21 @@ NGitLab.Impl.DiffStats.DiffStats() -> void
 NGitLab.Impl.EnvironmentClient
 NGitLab.Impl.EnvironmentClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.EnvironmentInfo>
 NGitLab.Impl.EnvironmentClient.Create(string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.Impl.EnvironmentClient.Delete(int environmentId) -> void
-NGitLab.Impl.EnvironmentClient.Edit(int environmentId, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.Impl.EnvironmentClient.Edit(int environmentId, string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
-NGitLab.Impl.EnvironmentClient.EnvironmentClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.EnvironmentClient.Delete(long environmentId) -> void
+NGitLab.Impl.EnvironmentClient.Edit(long environmentId, string externalUrl) -> NGitLab.Models.EnvironmentInfo
+NGitLab.Impl.EnvironmentClient.Edit(long environmentId, string name, string externalUrl) -> NGitLab.Models.EnvironmentInfo
 NGitLab.Impl.EnvironmentClient.EnvironmentClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
-NGitLab.Impl.EnvironmentClient.GetById(int environmentId) -> NGitLab.Models.EnvironmentInfo
-NGitLab.Impl.EnvironmentClient.GetByIdAsync(int environmentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.EnvironmentInfo>
+NGitLab.Impl.EnvironmentClient.GetById(long environmentId) -> NGitLab.Models.EnvironmentInfo
+NGitLab.Impl.EnvironmentClient.GetByIdAsync(long environmentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.EnvironmentInfo>
 NGitLab.Impl.EnvironmentClient.GetEnvironmentsAsync(NGitLab.Models.EnvironmentQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.EnvironmentInfo>
-NGitLab.Impl.EnvironmentClient.Stop(int environmentId) -> NGitLab.Models.EnvironmentInfo
+NGitLab.Impl.EnvironmentClient.Stop(long environmentId) -> NGitLab.Models.EnvironmentInfo
 NGitLab.Impl.EpicClient
-NGitLab.Impl.EpicClient.Create(int groupId, NGitLab.Models.EpicCreate epic) -> NGitLab.Models.Epic
-NGitLab.Impl.EpicClient.Edit(int groupId, NGitLab.Models.EpicEdit epicEdit) -> NGitLab.Models.Epic
+NGitLab.Impl.EpicClient.Create(long groupId, NGitLab.Models.EpicCreate epic) -> NGitLab.Models.Epic
+NGitLab.Impl.EpicClient.Edit(long groupId, NGitLab.Models.EpicEdit epicEdit) -> NGitLab.Models.Epic
 NGitLab.Impl.EpicClient.EpicClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.EpicClient.Get(int groupId, int epicId) -> NGitLab.Models.Epic
-NGitLab.Impl.EpicClient.Get(int groupId, NGitLab.Models.EpicQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Epic>
-NGitLab.Impl.EpicClient.GetIssuesAsync(int groupId, int epicId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.EpicClient.Get(long groupId, long epicId) -> NGitLab.Models.Epic
+NGitLab.Impl.EpicClient.Get(long groupId, NGitLab.Models.EpicQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Epic>
+NGitLab.Impl.EpicClient.GetIssuesAsync(long groupId, long epicId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.EventClient
 NGitLab.Impl.EventClient.EventClient(NGitLab.Impl.API api, string baseUrl) -> void
 NGitLab.Impl.EventClient.Get(NGitLab.Models.EventQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Event>
@@ -589,40 +539,40 @@ NGitLab.Impl.GitLabCredentials.UserName.set -> void
 NGitLab.Impl.GroupHooksClient
 NGitLab.Impl.GroupHooksClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.GroupHook>
 NGitLab.Impl.GroupHooksClient.Create(NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
-NGitLab.Impl.GroupHooksClient.Delete(int hookId) -> void
+NGitLab.Impl.GroupHooksClient.Delete(long hookId) -> void
 NGitLab.Impl.GroupHooksClient.GroupHooksClient(NGitLab.Impl.API api, NGitLab.Models.GroupId groupId) -> void
-NGitLab.Impl.GroupHooksClient.this[int hookId].get -> NGitLab.Models.GroupHook
-NGitLab.Impl.GroupHooksClient.Update(int hookId, NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
+NGitLab.Impl.GroupHooksClient.this[long hookId].get -> NGitLab.Models.GroupHook
+NGitLab.Impl.GroupHooksClient.Update(long hookId, NGitLab.Models.GroupHookUpsert hook) -> NGitLab.Models.GroupHook
 NGitLab.Impl.GroupsClient
 NGitLab.Impl.GroupsClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.Create(NGitLab.Models.GroupCreate group) -> NGitLab.Models.Group
 NGitLab.Impl.GroupsClient.CreateAsync(NGitLab.Models.GroupCreate group, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.Impl.GroupsClient.Delete(int id) -> void
-NGitLab.Impl.GroupsClient.DeleteAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.GroupsClient.Delete(long id) -> void
+NGitLab.Impl.GroupsClient.DeleteAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.GroupsClient.Get(NGitLab.Models.GroupQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.GetAsync(NGitLab.Models.GroupQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.GetByFullPathAsync(string fullPath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.Impl.GroupsClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
+NGitLab.Impl.GroupsClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.GetGroup(NGitLab.Models.GroupId id) -> NGitLab.Models.Group
 NGitLab.Impl.GroupsClient.GetGroupAsync(NGitLab.Models.GroupId id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
-NGitLab.Impl.GroupsClient.GetProjectsAsync(int groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
+NGitLab.Impl.GroupsClient.GetProjectsAsync(long groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.Impl.GroupsClient.GetSubgroupsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.GetSubgroupsByFullPathAsync(string fullPath, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
-NGitLab.Impl.GroupsClient.GetSubgroupsByIdAsync(int id, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
+NGitLab.Impl.GroupsClient.GetSubgroupsByIdAsync(long id, NGitLab.Models.SubgroupQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.GroupsClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.GroupsClient.PageAsync(NGitLab.Models.PageQuery<NGitLab.Models.GroupQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Group>>
 NGitLab.Impl.GroupsClient.PageProjectsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.PageQuery<NGitLab.Models.GroupProjectsQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Project>>
 NGitLab.Impl.GroupsClient.PageSubgroupsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.PageQuery<NGitLab.Models.SubgroupQuery> query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<NGitLab.Models.Group>>
-NGitLab.Impl.GroupsClient.Restore(int id) -> void
-NGitLab.Impl.GroupsClient.RestoreAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.GroupsClient.Restore(long id) -> void
+NGitLab.Impl.GroupsClient.RestoreAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.GroupsClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Group>
 NGitLab.Impl.GroupsClient.SearchAsync(string search) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
-NGitLab.Impl.GroupsClient.SearchProjects(int groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
+NGitLab.Impl.GroupsClient.SearchProjects(long groupId, string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.GroupsClient.SearchProjectsAsync(NGitLab.Models.GroupId groupId, NGitLab.Models.GroupProjectsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
-NGitLab.Impl.GroupsClient.this[int id].get -> NGitLab.Models.Group
+NGitLab.Impl.GroupsClient.this[long id].get -> NGitLab.Models.Group
 NGitLab.Impl.GroupsClient.this[string fullPath].get -> NGitLab.Models.Group
-NGitLab.Impl.GroupsClient.Update(int id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
-NGitLab.Impl.GroupsClient.UpdateAsync(int id, NGitLab.Models.GroupUpdate groupUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
+NGitLab.Impl.GroupsClient.Update(long id, NGitLab.Models.GroupUpdate groupUpdate) -> NGitLab.Models.Group
+NGitLab.Impl.GroupsClient.UpdateAsync(long id, NGitLab.Models.GroupUpdate groupUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
 NGitLab.Impl.HttpRequestor
 NGitLab.Impl.HttpRequestor.GetAPIUrl(string tailAPIUrl) -> System.Uri
 NGitLab.Impl.HttpRequestor.GetUrl(string tailAPIUrl) -> System.Uri
@@ -632,71 +582,70 @@ NGitLab.Impl.HttpRequestor.With(object data) -> NGitLab.IHttpRequestor
 NGitLab.Impl.IGitDiffChangeCounter
 NGitLab.Impl.IGitDiffChangeCounter.Compute(NGitLab.Models.MergeRequestChange mergeRequestChange) -> NGitLab.Impl.DiffStats
 NGitLab.Impl.IssueClient
-NGitLab.Impl.IssueClient.CloneAsync(int projectId, int issueIid, NGitLab.Models.IssueClone issueClone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.ClosedBy(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.Impl.IssueClient.ClosedByAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
+NGitLab.Impl.IssueClient.CloneAsync(long projectId, long issueIid, NGitLab.Models.IssueClone issueClone, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ClosedBy(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.Impl.IssueClient.ClosedByAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.IssueClient.Create(NGitLab.Models.IssueCreate issueCreate) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.CreateAsync(NGitLab.Models.IssueCreate issueCreate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.CreateLinkBetweenIssues(int sourceProjectId, int sourceIssueId, int targetProjectId, int targetIssueId) -> bool
+NGitLab.Impl.IssueClient.CreateLinkBetweenIssues(long sourceProjectId, long sourceIssueId, long targetProjectId, long targetIssueId) -> bool
 NGitLab.Impl.IssueClient.Edit(NGitLab.Models.IssueEdit issueEdit) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.EditAsync(NGitLab.Models.IssueEdit issueEdit, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.ForGroupsAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.ForGroupsAsync(int groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.ForProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.Get(int projectId, int issueIid) -> NGitLab.Models.Issue
-NGitLab.Impl.IssueClient.Get(int projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ForGroupsAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ForGroupsAsync(long groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ForProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.Get(long projectId, long issueIid) -> NGitLab.Models.Issue
+NGitLab.Impl.IssueClient.Get(long projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.GetAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.GetAsync(int projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.GetAsync(long projectId, long issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.GetAsync(long projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.GetAsync(NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.GetById(int issueId) -> NGitLab.Models.Issue
-NGitLab.Impl.IssueClient.GetByIdAsync(int issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.GetParticipants(NGitLab.Models.ProjectId projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Participant>
+NGitLab.Impl.IssueClient.GetById(long issueId) -> NGitLab.Models.Issue
+NGitLab.Impl.IssueClient.GetByIdAsync(long issueId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.GetParticipants(NGitLab.Models.ProjectId projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Participant>
 NGitLab.Impl.IssueClient.IssueClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.IssueClient.LinkedToAsync(int projectId, int issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.LinkedToAsync(long projectId, long issueId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.Impl.IssueClient.RelatedTo(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.Impl.IssueClient.RelatedToAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
-NGitLab.Impl.IssueClient.ResourceLabelEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceLabelEvent>
-NGitLab.Impl.IssueClient.ResourceLabelEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
-NGitLab.Impl.IssueClient.ResourceMilestoneEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.Impl.IssueClient.ResourceMilestoneEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.Impl.IssueClient.ResourceStateEvents(int projectId, int issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceStateEvent>
-NGitLab.Impl.IssueClient.ResourceStateEventsAsync(int projectId, int issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
-NGitLab.Impl.IssueClient.TimeStatsAsync(int projectId, int issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
-NGitLab.Impl.IssueClient.Unsubscribe(NGitLab.Models.ProjectId projectId, int issueIid) -> NGitLab.Models.Issue
+NGitLab.Impl.IssueClient.RelatedTo(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.Impl.IssueClient.RelatedToAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
+NGitLab.Impl.IssueClient.ResourceLabelEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceLabelEvent>
+NGitLab.Impl.IssueClient.ResourceLabelEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
+NGitLab.Impl.IssueClient.ResourceMilestoneEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.Impl.IssueClient.ResourceMilestoneEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.Impl.IssueClient.ResourceStateEvents(long projectId, long issueIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ResourceStateEvent>
+NGitLab.Impl.IssueClient.ResourceStateEventsAsync(long projectId, long issueIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
+NGitLab.Impl.IssueClient.TimeStatsAsync(long projectId, long issueIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.Impl.IssueClient.Unsubscribe(NGitLab.Models.ProjectId projectId, long issueIid) -> NGitLab.Models.Issue
 NGitLab.Impl.JobClient
-NGitLab.Impl.JobClient.Get(int jobId) -> NGitLab.Models.Job
-NGitLab.Impl.JobClient.GetAsync(int jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
-NGitLab.Impl.JobClient.GetJobArtifact(int jobId, string path) -> byte[]
+NGitLab.Impl.JobClient.Get(long jobId) -> NGitLab.Models.Job
+NGitLab.Impl.JobClient.GetAsync(long jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
+NGitLab.Impl.JobClient.GetJobArtifact(long jobId, string path) -> byte[]
 NGitLab.Impl.JobClient.GetJobArtifact(NGitLab.Models.JobArtifactQuery query) -> byte[]
-NGitLab.Impl.JobClient.GetJobArtifacts(int jobId) -> byte[]
+NGitLab.Impl.JobClient.GetJobArtifacts(long jobId) -> byte[]
 NGitLab.Impl.JobClient.GetJobs(NGitLab.Models.JobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.JobClient.GetJobs(NGitLab.Models.JobScopeMask scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.JobClient.GetJobsAsync(NGitLab.Models.JobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.Impl.JobClient.GetTrace(int jobId) -> string
-NGitLab.Impl.JobClient.GetTraceAsync(int jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
-NGitLab.Impl.JobClient.JobClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.JobClient.GetTrace(long jobId) -> string
+NGitLab.Impl.JobClient.GetTraceAsync(long jobId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
 NGitLab.Impl.JobClient.JobClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
-NGitLab.Impl.JobClient.RunAction(int jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
-NGitLab.Impl.JobClient.RunActionAsync(int jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
+NGitLab.Impl.JobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
+NGitLab.Impl.JobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.Impl.LabelClient
 NGitLab.Impl.LabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.CreateGroupLabel(int groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.CreateProjectLabel(int projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.DeleteProjectLabel(int projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.EditGroupLabel(int groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.EditProjectLabel(int projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.ForGroup(int groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.Impl.LabelClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.Impl.LabelClient.GetGroupLabel(int groupId, string name) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.GetLabel(int projectId, string name) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.GetProjectLabel(int projectId, string name) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.LabelClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.LintClient
 NGitLab.Impl.LintClient.LintClient(NGitLab.Impl.API api) -> void
@@ -731,42 +680,41 @@ NGitLab.Impl.MergeRequestApprovalClient
 NGitLab.Impl.MergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
-NGitLab.Impl.MergeRequestApprovalClient.MergeRequestApprovalClient(NGitLab.Impl.API api, string projectPath, int mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestApprovalClient.MergeRequestApprovalClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.Impl.MergeRequestClient
-NGitLab.Impl.MergeRequestClient.Accept(int mergeRequestIid, NGitLab.Models.MergeRequestAccept message) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.Accept(int mergeRequestIid, NGitLab.Models.MergeRequestMerge message) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.Accept(long mergeRequestIid, NGitLab.Models.MergeRequestAccept message) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.Accept(long mergeRequestIid, NGitLab.Models.MergeRequestMerge message) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.AllInState(NGitLab.Models.MergeRequestState state) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.Impl.MergeRequestClient.ApprovalClient(int mergeRequestIid) -> NGitLab.IMergeRequestApprovalClient
-NGitLab.Impl.MergeRequestClient.Approve(int mergeRequestIid, NGitLab.Models.MergeRequestApprove message) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.CancelMergeWhenPipelineSucceeds(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.Changes(int mergeRequestIid) -> NGitLab.IMergeRequestChangeClient
-NGitLab.Impl.MergeRequestClient.Close(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.ClosesIssues(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
-NGitLab.Impl.MergeRequestClient.Comments(int mergeRequestIid) -> NGitLab.IMergeRequestCommentClient
-NGitLab.Impl.MergeRequestClient.Commits(int mergeRequestIid) -> NGitLab.IMergeRequestCommitClient
+NGitLab.Impl.MergeRequestClient.ApprovalClient(long mergeRequestIid) -> NGitLab.IMergeRequestApprovalClient
+NGitLab.Impl.MergeRequestClient.Approve(long mergeRequestIid, NGitLab.Models.MergeRequestApprove message) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.CancelMergeWhenPipelineSucceeds(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.Changes(long mergeRequestIid) -> NGitLab.IMergeRequestChangeClient
+NGitLab.Impl.MergeRequestClient.Close(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.ClosesIssues(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
+NGitLab.Impl.MergeRequestClient.Comments(long mergeRequestIid) -> NGitLab.IMergeRequestCommentClient
+NGitLab.Impl.MergeRequestClient.Commits(long mergeRequestIid) -> NGitLab.IMergeRequestCommitClient
 NGitLab.Impl.MergeRequestClient.Create(NGitLab.Models.MergeRequestCreate mergeRequest) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.Delete(int mergeRequestIid) -> void
-NGitLab.Impl.MergeRequestClient.Discussions(int mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
+NGitLab.Impl.MergeRequestClient.Delete(long mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.Impl.MergeRequestClient.GetByIidAsync(int iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
-NGitLab.Impl.MergeRequestClient.GetParticipants(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
-NGitLab.Impl.MergeRequestClient.GetPipelines(int mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
-NGitLab.Impl.MergeRequestClient.GetVersionsAsync(int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
+NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
+NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
+NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
 NGitLab.Impl.MergeRequestClient.MergeRequestClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.MergeRequestClient.MergeRequestClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.MergeRequestClient.MergeRequestClient(NGitLab.Impl.API api, NGitLab.Models.GroupId groupId) -> void
 NGitLab.Impl.MergeRequestClient.MergeRequestClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
-NGitLab.Impl.MergeRequestClient.Rebase(int mergeRequestIid) -> NGitLab.Models.RebaseResult
-NGitLab.Impl.MergeRequestClient.RebaseAsync(int mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
-NGitLab.Impl.MergeRequestClient.Reopen(int mergeRequestIid) -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.ResourceLabelEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
-NGitLab.Impl.MergeRequestClient.ResourceMilestoneEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
-NGitLab.Impl.MergeRequestClient.ResourceStateEventsAsync(int projectId, int mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
-NGitLab.Impl.MergeRequestClient.this[int iid].get -> NGitLab.Models.MergeRequest
-NGitLab.Impl.MergeRequestClient.TimeStatsAsync(int mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
-NGitLab.Impl.MergeRequestClient.Update(int mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.Rebase(long mergeRequestIid) -> NGitLab.Models.RebaseResult
+NGitLab.Impl.MergeRequestClient.RebaseAsync(long mergeRequestIid, NGitLab.Models.MergeRequestRebase options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.RebaseResult>
+NGitLab.Impl.MergeRequestClient.Reopen(long mergeRequestIid) -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.ResourceLabelEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceLabelEvent>
+NGitLab.Impl.MergeRequestClient.ResourceMilestoneEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceMilestoneEvent>
+NGitLab.Impl.MergeRequestClient.ResourceStateEventsAsync(long projectId, long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ResourceStateEvent>
+NGitLab.Impl.MergeRequestClient.this[long iid].get -> NGitLab.Models.MergeRequest
+NGitLab.Impl.MergeRequestClient.TimeStatsAsync(long mergeRequestIid, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.TimeStats>
+NGitLab.Impl.MergeRequestClient.Update(long mergeRequestIid, NGitLab.Models.MergeRequestUpdate mergeRequest) -> NGitLab.Models.MergeRequest
 NGitLab.Impl.MergeRequestCommentClient
 NGitLab.Impl.MergeRequestCommentClient.Add(NGitLab.Models.MergeRequestComment comment) -> NGitLab.Models.MergeRequestComment
 NGitLab.Impl.MergeRequestCommentClient.Add(NGitLab.Models.MergeRequestCommentCreate comment) -> NGitLab.Models.MergeRequestComment
@@ -776,17 +724,17 @@ NGitLab.Impl.MergeRequestCommentClient.Delete(long id) -> void
 NGitLab.Impl.MergeRequestCommentClient.Discussions.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequestDiscussion>
 NGitLab.Impl.MergeRequestCommentClient.Edit(long id, NGitLab.Models.MergeRequestCommentEdit comment) -> NGitLab.Models.MergeRequestComment
 NGitLab.Impl.MergeRequestCommentClient.Get(NGitLab.Models.MergeRequestCommentQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequestComment>
-NGitLab.Impl.MergeRequestCommentClient.MergeRequestCommentClient(NGitLab.Impl.API api, string projectPath, int mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestCommentClient.MergeRequestCommentClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestCommitClient
 NGitLab.Impl.MergeRequestCommitClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
-NGitLab.Impl.MergeRequestCommitClient.MergeRequestCommitClient(NGitLab.Impl.API api, string projectPath, int mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestCommitClient.MergeRequestCommitClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestDiscussionClient
 NGitLab.Impl.MergeRequestDiscussionClient.Add(NGitLab.Models.MergeRequestDiscussionCreate comment) -> NGitLab.Models.MergeRequestDiscussion
 NGitLab.Impl.MergeRequestDiscussionClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequestDiscussion>
 NGitLab.Impl.MergeRequestDiscussionClient.Delete(string discussionId, long commentId) -> void
 NGitLab.Impl.MergeRequestDiscussionClient.Get(string id) -> NGitLab.Models.MergeRequestDiscussion
 NGitLab.Impl.MergeRequestDiscussionClient.GetAsync(string id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequestDiscussion>
-NGitLab.Impl.MergeRequestDiscussionClient.MergeRequestDiscussionClient(NGitLab.Impl.API api, string projectPath, int mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestDiscussionClient.MergeRequestDiscussionClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestDiscussionClient.Resolve(NGitLab.Models.MergeRequestDiscussionResolve resolve) -> NGitLab.Models.MergeRequestDiscussion
 NGitLab.Impl.MethodType
 NGitLab.Impl.MethodType.Delete = 4 -> NGitLab.Impl.MethodType
@@ -798,18 +746,18 @@ NGitLab.Impl.MethodType.Post = 2 -> NGitLab.Impl.MethodType
 NGitLab.Impl.MethodType.Put = 1 -> NGitLab.Impl.MethodType
 NGitLab.Impl.MethodType.Trace = 7 -> NGitLab.Impl.MethodType
 NGitLab.Impl.MilestoneClient
-NGitLab.Impl.MilestoneClient.Activate(int milestoneId) -> NGitLab.Models.Milestone
+NGitLab.Impl.MilestoneClient.Activate(long milestoneId) -> NGitLab.Models.Milestone
 NGitLab.Impl.MilestoneClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
 NGitLab.Impl.MilestoneClient.AllInState(NGitLab.Models.MilestoneState state) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
-NGitLab.Impl.MilestoneClient.Close(int milestoneId) -> NGitLab.Models.Milestone
+NGitLab.Impl.MilestoneClient.Close(long milestoneId) -> NGitLab.Models.Milestone
 NGitLab.Impl.MilestoneClient.Create(NGitLab.Models.MilestoneCreate milestone) -> NGitLab.Models.Milestone
-NGitLab.Impl.MilestoneClient.Delete(int milestoneId) -> void
+NGitLab.Impl.MilestoneClient.Delete(long milestoneId) -> void
 NGitLab.Impl.MilestoneClient.Get(NGitLab.Models.MilestoneQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Milestone>
-NGitLab.Impl.MilestoneClient.GetMergeRequests(int milestoneId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
-NGitLab.Impl.MilestoneClient.MilestoneClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.MilestoneClient.GetMergeRequests(long milestoneId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
+NGitLab.Impl.MilestoneClient.MilestoneClient(NGitLab.Impl.API api, long projectId) -> void
 NGitLab.Impl.MilestoneClient.Scope.get -> NGitLab.Impl.MilestoneScope
-NGitLab.Impl.MilestoneClient.this[int id].get -> NGitLab.Models.Milestone
-NGitLab.Impl.MilestoneClient.Update(int milestoneId, NGitLab.Models.MilestoneUpdate milestone) -> NGitLab.Models.Milestone
+NGitLab.Impl.MilestoneClient.this[long id].get -> NGitLab.Models.Milestone
+NGitLab.Impl.MilestoneClient.Update(long milestoneId, NGitLab.Models.MilestoneUpdate milestone) -> NGitLab.Models.Milestone
 NGitLab.Impl.MilestoneScope
 NGitLab.Impl.MilestoneScope.Groups = 1 -> NGitLab.Impl.MilestoneScope
 NGitLab.Impl.MilestoneScope.Projects = 0 -> NGitLab.Impl.MilestoneScope
@@ -817,7 +765,7 @@ NGitLab.Impl.NamespacesClient
 NGitLab.Impl.NamespacesClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Namespace>
 NGitLab.Impl.NamespacesClient.NamespacesClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.NamespacesClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Namespace>
-NGitLab.Impl.NamespacesClient.this[int id].get -> NGitLab.Models.Namespace
+NGitLab.Impl.NamespacesClient.this[long id].get -> NGitLab.Models.Namespace
 NGitLab.Impl.NamespacesClient.this[string fullPath].get -> NGitLab.Models.Namespace
 NGitLab.Impl.PipelineClient
 NGitLab.Impl.PipelineClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
@@ -826,39 +774,38 @@ NGitLab.Impl.PipelineClient.Create(NGitLab.Models.PipelineCreate createOptions) 
 NGitLab.Impl.PipelineClient.Create(string ref) -> NGitLab.Models.Pipeline
 NGitLab.Impl.PipelineClient.CreateAsync(NGitLab.Models.PipelineCreate createOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.Impl.PipelineClient.CreatePipelineWithTrigger(string token, string ref, System.Collections.Generic.Dictionary<string, string> variables) -> NGitLab.Models.Pipeline
-NGitLab.Impl.PipelineClient.Delete(int pipelineId) -> void
+NGitLab.Impl.PipelineClient.Delete(long pipelineId) -> void
 NGitLab.Impl.PipelineClient.GetAllJobsAsync() -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetBridgesAsync(NGitLab.Models.PipelineBridgeQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Bridge>
-NGitLab.Impl.PipelineClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
-NGitLab.Impl.PipelineClient.GetJobs(int pipelineId) -> NGitLab.Models.Job[]
+NGitLab.Impl.PipelineClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.Impl.PipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.Impl.PipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.Impl.PipelineClient.GetTestReports(int pipelineId) -> NGitLab.Models.TestReport
-NGitLab.Impl.PipelineClient.GetTestReportsSummary(int pipelineId) -> NGitLab.Models.TestReportSummary
-NGitLab.Impl.PipelineClient.GetVariables(int pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
-NGitLab.Impl.PipelineClient.GetVariablesAsync(int pipelineId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineVariable>
-NGitLab.Impl.PipelineClient.PipelineClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.PipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
+NGitLab.Impl.PipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
+NGitLab.Impl.PipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
+NGitLab.Impl.PipelineClient.GetVariablesAsync(long pipelineId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineVariable>
 NGitLab.Impl.PipelineClient.PipelineClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
-NGitLab.Impl.PipelineClient.RetryAsync(int pipelineId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.Impl.PipelineClient.RetryAsync(long pipelineId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.Impl.PipelineClient.Search(NGitLab.Models.PipelineQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.PipelineClient.SearchAsync(NGitLab.Models.PipelineQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
-NGitLab.Impl.PipelineClient.this[int id].get -> NGitLab.Models.Pipeline
-NGitLab.Impl.PipelineClient.UpdateMetadataAsync(int pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.Impl.PipelineClient.this[long id].get -> NGitLab.Models.Pipeline
+NGitLab.Impl.PipelineClient.UpdateMetadataAsync(long pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.Impl.ProjectClient
 NGitLab.Impl.ProjectClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
-NGitLab.Impl.ProjectClient.Archive(int id) -> void
+NGitLab.Impl.ProjectClient.Archive(long id) -> void
 NGitLab.Impl.ProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.CreateAsync(NGitLab.Models.ProjectCreate project, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
-NGitLab.Impl.ProjectClient.Delete(int id) -> void
+NGitLab.Impl.ProjectClient.Delete(long id) -> void
 NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.ProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.ForkAsync(string id, NGitLab.Models.ForkProject forkProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
-NGitLab.Impl.ProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
-NGitLab.Impl.ProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
+NGitLab.Impl.ProjectClient.GetById(long id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
+NGitLab.Impl.ProjectClient.GetByIdAsync(long id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetByNamespacedPathAsync(string path, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetForks(string id, NGitLab.Models.ForkedProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.GetForksAsync(string id, NGitLab.Models.ForkedProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
@@ -866,9 +813,9 @@ NGitLab.Impl.ProjectClient.GetGroupsAsync(NGitLab.Models.ProjectId id, NGitLab.M
 NGitLab.Impl.ProjectClient.GetLanguages(string id) -> System.Collections.Generic.Dictionary<string, double>
 NGitLab.Impl.ProjectClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.ProjectClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.ProjectClient.this[int id].get -> NGitLab.Models.Project
+NGitLab.Impl.ProjectClient.this[long id].get -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.this[string fullName].get -> NGitLab.Models.Project
-NGitLab.Impl.ProjectClient.Unarchive(int id) -> void
+NGitLab.Impl.ProjectClient.Unarchive(long id) -> void
 NGitLab.Impl.ProjectClient.Update(string id, NGitLab.Models.ProjectUpdate projectUpdate) -> NGitLab.Models.Project
 NGitLab.Impl.ProjectClient.UpdateAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectUpdate projectUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.Impl.ProjectClient.UploadFile(string id, NGitLab.Models.FormDataContent data) -> NGitLab.Models.UploadedProjectFile
@@ -876,24 +823,22 @@ NGitLab.Impl.ProjectClient.Visible.get -> System.Collections.Generic.IEnumerable
 NGitLab.Impl.ProjectHooksClient
 NGitLab.Impl.ProjectHooksClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectHook>
 NGitLab.Impl.ProjectHooksClient.Create(NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
-NGitLab.Impl.ProjectHooksClient.Delete(int hookId) -> void
+NGitLab.Impl.ProjectHooksClient.Delete(long hookId) -> void
 NGitLab.Impl.ProjectHooksClient.ProjectHooksClient(NGitLab.Impl.API api, string projectPath) -> void
-NGitLab.Impl.ProjectHooksClient.this[int hookId].get -> NGitLab.Models.ProjectHook
-NGitLab.Impl.ProjectHooksClient.Update(int hookId, NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
+NGitLab.Impl.ProjectHooksClient.this[long hookId].get -> NGitLab.Models.ProjectHook
+NGitLab.Impl.ProjectHooksClient.Update(long hookId, NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
 NGitLab.Impl.ProjectIssueNoteClient
 NGitLab.Impl.ProjectIssueNoteClient.Create(NGitLab.Models.ProjectIssueNoteCreate create) -> NGitLab.Models.ProjectIssueNote
 NGitLab.Impl.ProjectIssueNoteClient.Edit(NGitLab.Models.ProjectIssueNoteEdit edit) -> NGitLab.Models.ProjectIssueNote
-NGitLab.Impl.ProjectIssueNoteClient.ForIssue(int issueId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectIssueNote>
-NGitLab.Impl.ProjectIssueNoteClient.Get(int issueId, int noteId) -> NGitLab.Models.ProjectIssueNote
-NGitLab.Impl.ProjectIssueNoteClient.ProjectIssueNoteClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.ProjectIssueNoteClient.ForIssue(long issueId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectIssueNote>
+NGitLab.Impl.ProjectIssueNoteClient.Get(long issueId, long noteId) -> NGitLab.Models.ProjectIssueNote
 NGitLab.Impl.ProjectIssueNoteClient.ProjectIssueNoteClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.ProjectLevelApprovalRulesClient
 NGitLab.Impl.ProjectLevelApprovalRulesClient.CreateProjectLevelRule(NGitLab.Models.ApprovalRuleCreate approvalRuleCreate) -> NGitLab.Models.ApprovalRule
-NGitLab.Impl.ProjectLevelApprovalRulesClient.DeleteProjectLevelRule(int approvalRuleIdToDelete) -> void
+NGitLab.Impl.ProjectLevelApprovalRulesClient.DeleteProjectLevelRule(long approvalRuleIdToDelete) -> void
 NGitLab.Impl.ProjectLevelApprovalRulesClient.GetProjectLevelApprovalRules() -> System.Collections.Generic.List<NGitLab.Models.ApprovalRule>
-NGitLab.Impl.ProjectLevelApprovalRulesClient.ProjectLevelApprovalRulesClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.ProjectLevelApprovalRulesClient.ProjectLevelApprovalRulesClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
-NGitLab.Impl.ProjectLevelApprovalRulesClient.UpdateProjectLevelApprovalRule(int approvalRuleIdToUpdate, NGitLab.Models.ApprovalRuleUpdate approvalRuleUpdate) -> NGitLab.Models.ApprovalRule
+NGitLab.Impl.ProjectLevelApprovalRulesClient.UpdateProjectLevelApprovalRule(long approvalRuleIdToUpdate, NGitLab.Models.ApprovalRuleUpdate approvalRuleUpdate) -> NGitLab.Models.ApprovalRule
 NGitLab.Impl.ProtectedTagClient
 NGitLab.Impl.ProtectedTagClient.GetProtectedTag(string name) -> NGitLab.Models.ProtectedTag
 NGitLab.Impl.ProtectedTagClient.GetProtectedTagAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.ProtectedTag>
@@ -922,38 +867,37 @@ NGitLab.Impl.RepositoryClient.GetTree(string path) -> System.Collections.Generic
 NGitLab.Impl.RepositoryClient.GetTree(string path, string ref, bool recursive) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.GetTreeAsync(NGitLab.Models.RepositoryGetTreeOptions options) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.ProjectHooks.get -> NGitLab.IProjectHooksClient
-NGitLab.Impl.RepositoryClient.RepositoryClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.RepositoryClient.RepositoryClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.RepositoryClient.Tags.get -> NGitLab.ITagClient
 NGitLab.Impl.RepositoryClient.Tree.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RunnerClient
 NGitLab.Impl.RunnerClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.Impl.RunnerClient.Delete(int runnerId) -> void
+NGitLab.Impl.RunnerClient.Delete(long runnerId) -> void
 NGitLab.Impl.RunnerClient.Delete(NGitLab.Models.Runner runner) -> void
-NGitLab.Impl.RunnerClient.DisableRunner(int projectId, NGitLab.Models.RunnerId runnerId) -> void
-NGitLab.Impl.RunnerClient.EnableRunner(int projectId, NGitLab.Models.RunnerId runnerId) -> NGitLab.Models.Runner
-NGitLab.Impl.RunnerClient.EnableRunnerAsync(int projectId, NGitLab.Models.RunnerId runnerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Runner>
+NGitLab.Impl.RunnerClient.DisableRunner(long projectId, NGitLab.Models.RunnerId runnerId) -> void
+NGitLab.Impl.RunnerClient.EnableRunner(long projectId, NGitLab.Models.RunnerId runnerId) -> NGitLab.Models.Runner
+NGitLab.Impl.RunnerClient.EnableRunnerAsync(long projectId, NGitLab.Models.RunnerId runnerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.GetAllRunnersWithScope(NGitLab.Models.RunnerScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.Impl.RunnerClient.GetJobs(int runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.Impl.RunnerClient.GetJobs(int runnerId, NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.Impl.RunnerClient.OfGroup(int groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.Impl.RunnerClient.OfGroupAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
-NGitLab.Impl.RunnerClient.OfProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.Impl.RunnerClient.OfProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
+NGitLab.Impl.RunnerClient.GetJobs(long runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
+NGitLab.Impl.RunnerClient.GetJobs(long runnerId, NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
+NGitLab.Impl.RunnerClient.OfGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
+NGitLab.Impl.RunnerClient.OfGroupAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
+NGitLab.Impl.RunnerClient.OfProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
+NGitLab.Impl.RunnerClient.OfProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
 NGitLab.Impl.RunnerClient.Register(NGitLab.Models.RunnerRegister request) -> NGitLab.Models.Runner
 NGitLab.Impl.RunnerClient.RunnerClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.RunnerClient.this[int id].get -> NGitLab.Models.Runner
-NGitLab.Impl.RunnerClient.Update(int runnerId, NGitLab.Models.RunnerUpdate runnerUpdate) -> NGitLab.Models.Runner
+NGitLab.Impl.RunnerClient.this[long id].get -> NGitLab.Models.Runner
+NGitLab.Impl.RunnerClient.Update(long runnerId, NGitLab.Models.RunnerUpdate runnerUpdate) -> NGitLab.Models.Runner
 NGitLab.Impl.SnippetClient
 NGitLab.Impl.SnippetClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
 NGitLab.Impl.SnippetClient.Create(NGitLab.Models.SnippetCreate snippet) -> void
 NGitLab.Impl.SnippetClient.Create(NGitLab.Models.SnippetProjectCreate snippet) -> void
-NGitLab.Impl.SnippetClient.Delete(int projectId, int snippetId) -> void
-NGitLab.Impl.SnippetClient.Delete(int snippetId) -> void
-NGitLab.Impl.SnippetClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
-NGitLab.Impl.SnippetClient.Get(int projectId, int snippetId) -> NGitLab.Models.Snippet
-NGitLab.Impl.SnippetClient.GetContent(int projectId, int snippetId, System.Action<System.IO.Stream> parser) -> void
+NGitLab.Impl.SnippetClient.Delete(long projectId, long snippetId) -> void
+NGitLab.Impl.SnippetClient.Delete(long snippetId) -> void
+NGitLab.Impl.SnippetClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
+NGitLab.Impl.SnippetClient.Get(long projectId, long snippetId) -> NGitLab.Models.Snippet
+NGitLab.Impl.SnippetClient.GetContent(long projectId, long snippetId, System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.SnippetClient.SnippetClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.SnippetClient.Update(NGitLab.Models.SnippetProjectUpdate snippet) -> void
 NGitLab.Impl.SnippetClient.Update(NGitLab.Models.SnippetUpdate snippet) -> void
@@ -961,15 +905,15 @@ NGitLab.Impl.SnippetClient.User.get -> System.Collections.Generic.IEnumerable<NG
 NGitLab.Impl.SshKeyClient
 NGitLab.Impl.SshKeyClient.Add(NGitLab.Models.SshKeyCreate key) -> NGitLab.Models.SshKey
 NGitLab.Impl.SshKeyClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.SshKey>
-NGitLab.Impl.SshKeyClient.Remove(int keyId) -> void
-NGitLab.Impl.SshKeyClient.SshKeyClient(NGitLab.Impl.API api, int? userId) -> void
-NGitLab.Impl.SshKeyClient.this[int keyId].get -> NGitLab.Models.SshKey
+NGitLab.Impl.SshKeyClient.Remove(long keyId) -> void
+NGitLab.Impl.SshKeyClient.SshKeyClient(NGitLab.Impl.API api, long? userId) -> void
+NGitLab.Impl.SshKeyClient.this[long keyId].get -> NGitLab.Models.SshKey
 NGitLab.Impl.SystemHookClient
 NGitLab.Impl.SystemHookClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.SystemHook>
 NGitLab.Impl.SystemHookClient.Create(NGitLab.Models.SystemHookUpsert hook) -> NGitLab.Models.SystemHook
-NGitLab.Impl.SystemHookClient.Delete(int hookId) -> void
+NGitLab.Impl.SystemHookClient.Delete(long hookId) -> void
 NGitLab.Impl.SystemHookClient.SystemHookClient(NGitLab.Impl.API api) -> void
-NGitLab.Impl.SystemHookClient.this[int hookId].get -> NGitLab.Models.SystemHook
+NGitLab.Impl.SystemHookClient.this[long hookId].get -> NGitLab.Models.SystemHook
 NGitLab.Impl.TagClient
 NGitLab.Impl.TagClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tag>
 NGitLab.Impl.TagClient.Create(NGitLab.Models.TagCreate tag) -> NGitLab.Models.Tag
@@ -980,11 +924,10 @@ NGitLab.Impl.TagClient.TagClient(NGitLab.Impl.API api, string repoPath) -> void
 NGitLab.Impl.TriggerClient
 NGitLab.Impl.TriggerClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Trigger>
 NGitLab.Impl.TriggerClient.Create(string description) -> NGitLab.Models.Trigger
-NGitLab.Impl.TriggerClient.this[int id].get -> NGitLab.Models.Trigger
-NGitLab.Impl.TriggerClient.TriggerClient(NGitLab.Impl.API api, int projectId) -> void
+NGitLab.Impl.TriggerClient.this[long id].get -> NGitLab.Models.Trigger
 NGitLab.Impl.TriggerClient.TriggerClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.UserClient
-NGitLab.Impl.UserClient.Activate(int userId) -> void
+NGitLab.Impl.UserClient.Activate(long userId) -> void
 NGitLab.Impl.UserClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.Create(NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.Impl.UserClient.CreateAsync(NGitLab.Models.UserUpsert user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
@@ -992,18 +935,18 @@ NGitLab.Impl.UserClient.CreateToken(NGitLab.Models.UserTokenCreate tokenRequest)
 NGitLab.Impl.UserClient.CreateTokenAsync(NGitLab.Models.UserTokenCreate tokenRequest, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.UserToken>
 NGitLab.Impl.UserClient.Current.get -> NGitLab.Models.Session
 NGitLab.Impl.UserClient.CurrentUserSShKeys.get -> NGitLab.ISshKeyClient
-NGitLab.Impl.UserClient.Deactivate(int userId) -> void
-NGitLab.Impl.UserClient.Delete(int userId) -> void
+NGitLab.Impl.UserClient.Deactivate(long userId) -> void
+NGitLab.Impl.UserClient.Delete(long userId) -> void
 NGitLab.Impl.UserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.Impl.UserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
-NGitLab.Impl.UserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
+NGitLab.Impl.UserClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetByUserNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.Impl.UserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
 NGitLab.Impl.UserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.Impl.UserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
-NGitLab.Impl.UserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
-NGitLab.Impl.UserClient.this[int id].get -> NGitLab.Models.User
-NGitLab.Impl.UserClient.Update(int id, NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
+NGitLab.Impl.UserClient.SShKeys(long userId) -> NGitLab.ISshKeyClient
+NGitLab.Impl.UserClient.this[long id].get -> NGitLab.Models.User
+NGitLab.Impl.UserClient.Update(long id, NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.Impl.UserClient.UserClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.VersionClient
 NGitLab.Impl.VersionClient.Get() -> NGitLab.Models.GitLabVersion
@@ -1014,12 +957,11 @@ NGitLab.Impl.WikiClient.Create(NGitLab.Models.WikiPageCreate wikiPage) -> NGitLa
 NGitLab.Impl.WikiClient.Delete(string slug) -> void
 NGitLab.Impl.WikiClient.this[string slug].get -> NGitLab.Models.WikiPage
 NGitLab.Impl.WikiClient.Update(string slug, NGitLab.Models.WikiPageUpdate wikiPage) -> NGitLab.Models.WikiPage
-NGitLab.Impl.WikiClient.WikiClient(NGitLab.Impl.API api, int projectId) -> void
 NGitLab.Impl.WikiClient.WikiClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.INamespacesClient
 NGitLab.INamespacesClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Namespace>
 NGitLab.INamespacesClient.Search(string search) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Namespace>
-NGitLab.INamespacesClient.this[int id].get -> NGitLab.Models.Namespace
+NGitLab.INamespacesClient.this[long id].get -> NGitLab.Models.Namespace
 NGitLab.INamespacesClient.this[string fullPath].get -> NGitLab.Models.Namespace
 NGitLab.IPipelineClient
 NGitLab.IPipelineClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
@@ -1028,59 +970,59 @@ NGitLab.IPipelineClient.Create(NGitLab.Models.PipelineCreate createOptions) -> N
 NGitLab.IPipelineClient.Create(string ref) -> NGitLab.Models.Pipeline
 NGitLab.IPipelineClient.CreateAsync(NGitLab.Models.PipelineCreate createOptions, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.IPipelineClient.CreatePipelineWithTrigger(string token, string ref, System.Collections.Generic.Dictionary<string, string> variables) -> NGitLab.Models.Pipeline
-NGitLab.IPipelineClient.Delete(int pipelineId) -> void
+NGitLab.IPipelineClient.Delete(long pipelineId) -> void
 NGitLab.IPipelineClient.GetAllJobsAsync() -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetBridgesAsync(NGitLab.Models.PipelineBridgeQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Bridge>
-NGitLab.IPipelineClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
-NGitLab.IPipelineClient.GetJobs(int pipelineId) -> NGitLab.Models.Job[]
+NGitLab.IPipelineClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.IPipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.IPipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.IPipelineClient.GetTestReports(int pipelineId) -> NGitLab.Models.TestReport
-NGitLab.IPipelineClient.GetTestReportsSummary(int pipelineId) -> NGitLab.Models.TestReportSummary
-NGitLab.IPipelineClient.GetVariables(int pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
-NGitLab.IPipelineClient.GetVariablesAsync(int pipelineId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineVariable>
-NGitLab.IPipelineClient.RetryAsync(int pipelineId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.IPipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
+NGitLab.IPipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
+NGitLab.IPipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
+NGitLab.IPipelineClient.GetVariablesAsync(long pipelineId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineVariable>
+NGitLab.IPipelineClient.RetryAsync(long pipelineId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.IPipelineClient.Search(NGitLab.Models.PipelineQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IPipelineClient.SearchAsync(NGitLab.Models.PipelineQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
-NGitLab.IPipelineClient.this[int id].get -> NGitLab.Models.Pipeline
-NGitLab.IPipelineClient.UpdateMetadataAsync(int pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
+NGitLab.IPipelineClient.this[long id].get -> NGitLab.Models.Pipeline
+NGitLab.IPipelineClient.UpdateMetadataAsync(long pipelineId, NGitLab.Models.PipelineMetadataUpdate update, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Pipeline>
 NGitLab.IPipelineScheduleClient
 NGitLab.IPipelineScheduleClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineScheduleBasic>
 NGitLab.IPipelineScheduleClient.GetAllAsync() -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineScheduleBasic>
-NGitLab.IPipelineScheduleClient.GetAllSchedulePipelinesAsync(int id) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
-NGitLab.IPipelineScheduleClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PipelineSchedule>
-NGitLab.IPipelineScheduleClient.this[int id].get -> NGitLab.Models.PipelineSchedule
+NGitLab.IPipelineScheduleClient.GetAllSchedulePipelinesAsync(long id) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.PipelineBasic>
+NGitLab.IPipelineScheduleClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.PipelineSchedule>
+NGitLab.IPipelineScheduleClient.this[long id].get -> NGitLab.Models.PipelineSchedule
 NGitLab.IProjectBadgeClient
 NGitLab.IProjectBadgeClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Badge>
 NGitLab.IProjectBadgeClient.Create(NGitLab.Models.BadgeCreate badge) -> NGitLab.Models.Badge
-NGitLab.IProjectBadgeClient.Delete(int id) -> void
+NGitLab.IProjectBadgeClient.Delete(long id) -> void
 NGitLab.IProjectBadgeClient.ProjectsOnly.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Badge>
-NGitLab.IProjectBadgeClient.this[int id].get -> NGitLab.Models.Badge
-NGitLab.IProjectBadgeClient.Update(int id, NGitLab.Models.BadgeUpdate badge) -> NGitLab.Models.Badge
+NGitLab.IProjectBadgeClient.this[long id].get -> NGitLab.Models.Badge
+NGitLab.IProjectBadgeClient.Update(long id, NGitLab.Models.BadgeUpdate badge) -> NGitLab.Models.Badge
 NGitLab.IProjectClient
 NGitLab.IProjectClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
-NGitLab.IProjectClient.Archive(int id) -> void
+NGitLab.IProjectClient.Archive(long id) -> void
 NGitLab.IProjectClient.Create(NGitLab.Models.ProjectCreate project) -> NGitLab.Models.Project
 NGitLab.IProjectClient.CreateAsync(NGitLab.Models.ProjectCreate project, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
-NGitLab.IProjectClient.Delete(int id) -> void
+NGitLab.IProjectClient.Delete(long id) -> void
 NGitLab.IProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IProjectClient.Fork(string id, NGitLab.Models.ForkProject forkProject) -> NGitLab.Models.Project
 NGitLab.IProjectClient.ForkAsync(string id, NGitLab.Models.ForkProject forkProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.Get(NGitLab.Models.ProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetAsync(NGitLab.Models.ProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
-NGitLab.IProjectClient.GetById(int id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
-NGitLab.IProjectClient.GetByIdAsync(int id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
+NGitLab.IProjectClient.GetById(long id, NGitLab.Models.SingleProjectQuery query) -> NGitLab.Models.Project
+NGitLab.IProjectClient.GetByIdAsync(long id, NGitLab.Models.SingleProjectQuery query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetByNamespacedPathAsync(string path, NGitLab.Models.SingleProjectQuery query = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetForks(string id, NGitLab.Models.ForkedProjectQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetForksAsync(string id, NGitLab.Models.ForkedProjectQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Project>
 NGitLab.IProjectClient.GetGroupsAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectGroupsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Group>
 NGitLab.IProjectClient.GetLanguages(string id) -> System.Collections.Generic.Dictionary<string, double>
 NGitLab.IProjectClient.Owned.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Project>
-NGitLab.IProjectClient.this[int id].get -> NGitLab.Models.Project
+NGitLab.IProjectClient.this[long id].get -> NGitLab.Models.Project
 NGitLab.IProjectClient.this[string fullName].get -> NGitLab.Models.Project
-NGitLab.IProjectClient.Unarchive(int id) -> void
+NGitLab.IProjectClient.Unarchive(long id) -> void
 NGitLab.IProjectClient.Update(string id, NGitLab.Models.ProjectUpdate projectUpdate) -> NGitLab.Models.Project
 NGitLab.IProjectClient.UpdateAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectUpdate projectUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Project>
 NGitLab.IProjectClient.UploadFile(string id, NGitLab.Models.FormDataContent data) -> NGitLab.Models.UploadedProjectFile
@@ -1088,19 +1030,19 @@ NGitLab.IProjectClient.Visible.get -> System.Collections.Generic.IEnumerable<NGi
 NGitLab.IProjectHooksClient
 NGitLab.IProjectHooksClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectHook>
 NGitLab.IProjectHooksClient.Create(NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
-NGitLab.IProjectHooksClient.Delete(int hookId) -> void
-NGitLab.IProjectHooksClient.this[int hookId].get -> NGitLab.Models.ProjectHook
-NGitLab.IProjectHooksClient.Update(int hookId, NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
+NGitLab.IProjectHooksClient.Delete(long hookId) -> void
+NGitLab.IProjectHooksClient.this[long hookId].get -> NGitLab.Models.ProjectHook
+NGitLab.IProjectHooksClient.Update(long hookId, NGitLab.Models.ProjectHookUpsert hook) -> NGitLab.Models.ProjectHook
 NGitLab.IProjectIssueNoteClient
 NGitLab.IProjectIssueNoteClient.Create(NGitLab.Models.ProjectIssueNoteCreate create) -> NGitLab.Models.ProjectIssueNote
 NGitLab.IProjectIssueNoteClient.Edit(NGitLab.Models.ProjectIssueNoteEdit edit) -> NGitLab.Models.ProjectIssueNote
-NGitLab.IProjectIssueNoteClient.ForIssue(int issueId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectIssueNote>
-NGitLab.IProjectIssueNoteClient.Get(int issueId, int noteId) -> NGitLab.Models.ProjectIssueNote
+NGitLab.IProjectIssueNoteClient.ForIssue(long issueId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.ProjectIssueNote>
+NGitLab.IProjectIssueNoteClient.Get(long issueId, long noteId) -> NGitLab.Models.ProjectIssueNote
 NGitLab.IProjectLevelApprovalRulesClient
 NGitLab.IProjectLevelApprovalRulesClient.CreateProjectLevelRule(NGitLab.Models.ApprovalRuleCreate approvalRuleCreate) -> NGitLab.Models.ApprovalRule
-NGitLab.IProjectLevelApprovalRulesClient.DeleteProjectLevelRule(int approvalRuleIdToDelete) -> void
+NGitLab.IProjectLevelApprovalRulesClient.DeleteProjectLevelRule(long approvalRuleIdToDelete) -> void
 NGitLab.IProjectLevelApprovalRulesClient.GetProjectLevelApprovalRules() -> System.Collections.Generic.List<NGitLab.Models.ApprovalRule>
-NGitLab.IProjectLevelApprovalRulesClient.UpdateProjectLevelApprovalRule(int approvalRuleIdToUpdate, NGitLab.Models.ApprovalRuleUpdate approvalRuleUpdate) -> NGitLab.Models.ApprovalRule
+NGitLab.IProjectLevelApprovalRulesClient.UpdateProjectLevelApprovalRule(long approvalRuleIdToUpdate, NGitLab.Models.ApprovalRuleUpdate approvalRuleUpdate) -> NGitLab.Models.ApprovalRule
 NGitLab.IProjectVariableClient
 NGitLab.IProjectVariableClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Variable>
 NGitLab.IProjectVariableClient.Create(NGitLab.Models.VariableCreate model) -> NGitLab.Models.Variable
@@ -1136,9 +1078,9 @@ NGitLab.IReleaseClient.Update(NGitLab.Models.ReleaseUpdate data) -> NGitLab.Mode
 NGitLab.IReleaseLinkClient
 NGitLab.IReleaseLinkClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.ReleaseLink>
 NGitLab.IReleaseLinkClient.Create(NGitLab.Models.ReleaseLinkCreate data) -> NGitLab.Models.ReleaseLink
-NGitLab.IReleaseLinkClient.Delete(int id) -> void
-NGitLab.IReleaseLinkClient.this[int id].get -> NGitLab.Models.ReleaseLink
-NGitLab.IReleaseLinkClient.Update(int id, NGitLab.Models.ReleaseLinkUpdate data) -> NGitLab.Models.ReleaseLink
+NGitLab.IReleaseLinkClient.Delete(long id) -> void
+NGitLab.IReleaseLinkClient.this[long id].get -> NGitLab.Models.ReleaseLink
+NGitLab.IReleaseLinkClient.Update(long id, NGitLab.Models.ReleaseLinkUpdate data) -> NGitLab.Models.ReleaseLink
 NGitLab.IRepositoryClient
 NGitLab.IRepositoryClient.Branches.get -> NGitLab.IBranchClient
 NGitLab.IRepositoryClient.Commits.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
@@ -1162,46 +1104,46 @@ NGitLab.IRepositoryClient.Tree.get -> System.Collections.Generic.IEnumerable<NGi
 NGitLab.IRunnerClient
 NGitLab.IRunnerClient.Accessible.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.Delete(int runnerId) -> void
+NGitLab.IRunnerClient.Delete(long runnerId) -> void
 NGitLab.IRunnerClient.Delete(NGitLab.Models.Runner runner) -> void
-NGitLab.IRunnerClient.DisableRunner(int projectId, NGitLab.Models.RunnerId runnerId) -> void
-NGitLab.IRunnerClient.EnableRunner(int projectId, NGitLab.Models.RunnerId runnerId) -> NGitLab.Models.Runner
-NGitLab.IRunnerClient.EnableRunnerAsync(int projectId, NGitLab.Models.RunnerId runnerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.DisableRunner(long projectId, NGitLab.Models.RunnerId runnerId) -> void
+NGitLab.IRunnerClient.EnableRunner(long projectId, NGitLab.Models.RunnerId runnerId) -> NGitLab.Models.Runner
+NGitLab.IRunnerClient.EnableRunnerAsync(long projectId, NGitLab.Models.RunnerId runnerId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.GetAllRunnersWithScope(NGitLab.Models.RunnerScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.GetAvailableRunners(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.GetJobs(int runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.IRunnerClient.GetJobs(int runnerId, NGitLab.Models.JobScope jobScope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
-NGitLab.IRunnerClient.OfGroup(int groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.OfGroupAsync(int groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.OfProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
-NGitLab.IRunnerClient.OfProjectAsync(int projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.GetAvailableRunners(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.GetJobs(long runnerId, NGitLab.JobStatus? status = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
+NGitLab.IRunnerClient.GetJobs(long runnerId, NGitLab.Models.JobScope jobScope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
+NGitLab.IRunnerClient.OfGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.OfGroupAsync(long groupId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.OfProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Runner>
+NGitLab.IRunnerClient.OfProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Runner>
 NGitLab.IRunnerClient.Register(NGitLab.Models.RunnerRegister request) -> NGitLab.Models.Runner
-NGitLab.IRunnerClient.this[int id].get -> NGitLab.Models.Runner
-NGitLab.IRunnerClient.Update(int runnerId, NGitLab.Models.RunnerUpdate runnerUpdate) -> NGitLab.Models.Runner
+NGitLab.IRunnerClient.this[long id].get -> NGitLab.Models.Runner
+NGitLab.IRunnerClient.Update(long runnerId, NGitLab.Models.RunnerUpdate runnerUpdate) -> NGitLab.Models.Runner
 NGitLab.ISearchClient
 NGitLab.ISearchClient.GetBlobsAsync(NGitLab.SearchQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.SearchBlob>
 NGitLab.ISnippetClient
 NGitLab.ISnippetClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
 NGitLab.ISnippetClient.Create(NGitLab.Models.SnippetCreate snippet) -> void
 NGitLab.ISnippetClient.Create(NGitLab.Models.SnippetProjectCreate snippet) -> void
-NGitLab.ISnippetClient.Delete(int projectId, int snippetId) -> void
-NGitLab.ISnippetClient.Delete(int snippetId) -> void
-NGitLab.ISnippetClient.ForProject(int projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
-NGitLab.ISnippetClient.Get(int projectId, int snippetId) -> NGitLab.Models.Snippet
-NGitLab.ISnippetClient.GetContent(int projectId, int snippetId, System.Action<System.IO.Stream> parser) -> void
+NGitLab.ISnippetClient.Delete(long projectId, long snippetId) -> void
+NGitLab.ISnippetClient.Delete(long snippetId) -> void
+NGitLab.ISnippetClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
+NGitLab.ISnippetClient.Get(long projectId, long snippetId) -> NGitLab.Models.Snippet
+NGitLab.ISnippetClient.GetContent(long projectId, long snippetId, System.Action<System.IO.Stream> parser) -> void
 NGitLab.ISnippetClient.Update(NGitLab.Models.SnippetProjectUpdate snippet) -> void
 NGitLab.ISnippetClient.Update(NGitLab.Models.SnippetUpdate snippet) -> void
 NGitLab.ISnippetClient.User.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Snippet>
 NGitLab.ISshKeyClient
 NGitLab.ISshKeyClient.Add(NGitLab.Models.SshKeyCreate key) -> NGitLab.Models.SshKey
 NGitLab.ISshKeyClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.SshKey>
-NGitLab.ISshKeyClient.Remove(int keyId) -> void
-NGitLab.ISshKeyClient.this[int keyId].get -> NGitLab.Models.SshKey
+NGitLab.ISshKeyClient.Remove(long keyId) -> void
+NGitLab.ISshKeyClient.this[long keyId].get -> NGitLab.Models.SshKey
 NGitLab.ISystemHookClient
 NGitLab.ISystemHookClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.SystemHook>
 NGitLab.ISystemHookClient.Create(NGitLab.Models.SystemHookUpsert hook) -> NGitLab.Models.SystemHook
-NGitLab.ISystemHookClient.Delete(int hookId) -> void
-NGitLab.ISystemHookClient.this[int hookId].get -> NGitLab.Models.SystemHook
+NGitLab.ISystemHookClient.Delete(long hookId) -> void
+NGitLab.ISystemHookClient.this[long hookId].get -> NGitLab.Models.SystemHook
 NGitLab.ITagClient
 NGitLab.ITagClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tag>
 NGitLab.ITagClient.Create(NGitLab.Models.TagCreate tag) -> NGitLab.Models.Tag
@@ -1211,9 +1153,9 @@ NGitLab.ITagClient.GetByNameAsync(string name, System.Threading.CancellationToke
 NGitLab.ITriggerClient
 NGitLab.ITriggerClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.Trigger>
 NGitLab.ITriggerClient.Create(string description) -> NGitLab.Models.Trigger
-NGitLab.ITriggerClient.this[int id].get -> NGitLab.Models.Trigger
+NGitLab.ITriggerClient.this[long id].get -> NGitLab.Models.Trigger
 NGitLab.IUserClient
-NGitLab.IUserClient.Activate(int id) -> void
+NGitLab.IUserClient.Activate(long id) -> void
 NGitLab.IUserClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.Create(NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.IUserClient.CreateAsync(NGitLab.Models.UserUpsert user, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
@@ -1221,18 +1163,18 @@ NGitLab.IUserClient.CreateToken(NGitLab.Models.UserTokenCreate tokenRequest) -> 
 NGitLab.IUserClient.CreateTokenAsync(NGitLab.Models.UserTokenCreate tokenRequest, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.UserToken>
 NGitLab.IUserClient.Current.get -> NGitLab.Models.Session
 NGitLab.IUserClient.CurrentUserSShKeys.get -> NGitLab.ISshKeyClient
-NGitLab.IUserClient.Deactivate(int id) -> void
-NGitLab.IUserClient.Delete(int id) -> void
+NGitLab.IUserClient.Deactivate(long id) -> void
+NGitLab.IUserClient.Delete(long id) -> void
 NGitLab.IUserClient.Get(NGitLab.UserQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
 NGitLab.IUserClient.Get(string username) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
-NGitLab.IUserClient.GetByIdAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
+NGitLab.IUserClient.GetByIdAsync(long id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.GetByUserNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.User>
 NGitLab.IUserClient.GetCurrentUserAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Session>
 NGitLab.IUserClient.GetLastActivityDatesAsync(System.DateTimeOffset? from = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.LastActivityDate>
 NGitLab.IUserClient.Search(string query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.User>
-NGitLab.IUserClient.SShKeys(int userId) -> NGitLab.ISshKeyClient
-NGitLab.IUserClient.this[int id].get -> NGitLab.Models.User
-NGitLab.IUserClient.Update(int id, NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
+NGitLab.IUserClient.SShKeys(long userId) -> NGitLab.ISshKeyClient
+NGitLab.IUserClient.this[long id].get -> NGitLab.Models.User
+NGitLab.IUserClient.Update(long id, NGitLab.Models.UserUpsert user) -> NGitLab.Models.User
 NGitLab.IVersionClient
 NGitLab.IVersionClient.Get() -> NGitLab.Models.GitLabVersion
 NGitLab.IWikiClient
@@ -1258,7 +1200,7 @@ NGitLab.JobStatus.Unknown = 0 -> NGitLab.JobStatus
 NGitLab.JobStatus.WaitingForResource = 11 -> NGitLab.JobStatus
 NGitLab.MergeRequestChangeClient
 NGitLab.MergeRequestChangeClient.MergeRequestChange.get -> NGitLab.Models.MergeRequestChange
-NGitLab.MergeRequestChangeClient.MergeRequestChangeClient(NGitLab.Impl.API api, string projectPath, int mergeRequestIid) -> void
+NGitLab.MergeRequestChangeClient.MergeRequestChangeClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Models.AccessControl
 NGitLab.Models.AccessControl.AccessControl() -> void
 NGitLab.Models.AccessLevel
@@ -1290,7 +1232,7 @@ NGitLab.Models.ApprovalRule.Name.get -> string
 NGitLab.Models.ApprovalRule.Name.set -> void
 NGitLab.Models.ApprovalRule.ProtectedBranch.get -> NGitLab.Models.Branch[]
 NGitLab.Models.ApprovalRule.ProtectedBranch.set -> void
-NGitLab.Models.ApprovalRule.RuleId.get -> int
+NGitLab.Models.ApprovalRule.RuleId.get -> long
 NGitLab.Models.ApprovalRule.RuleId.set -> void
 NGitLab.Models.ApprovalRule.Users.get -> NGitLab.Models.User[]
 NGitLab.Models.ApprovalRule.Users.set -> void
@@ -1298,40 +1240,36 @@ NGitLab.Models.ApprovalRuleCreate
 NGitLab.Models.ApprovalRuleCreate.ApprovalRuleCreate() -> void
 NGitLab.Models.ApprovalRuleCreate.ApprovalsRequired.get -> int
 NGitLab.Models.ApprovalRuleCreate.ApprovalsRequired.set -> void
-NGitLab.Models.ApprovalRuleCreate.GroupIds.get -> int[]
+NGitLab.Models.ApprovalRuleCreate.GroupIds.get -> long[]
 NGitLab.Models.ApprovalRuleCreate.GroupIds.set -> void
-NGitLab.Models.ApprovalRuleCreate.Id.get -> int
-NGitLab.Models.ApprovalRuleCreate.Id.set -> void
 NGitLab.Models.ApprovalRuleCreate.Name.get -> string
 NGitLab.Models.ApprovalRuleCreate.Name.set -> void
-NGitLab.Models.ApprovalRuleCreate.ProtectedBranchIds.get -> int[]
+NGitLab.Models.ApprovalRuleCreate.ProtectedBranchIds.get -> long[]
 NGitLab.Models.ApprovalRuleCreate.ProtectedBranchIds.set -> void
 NGitLab.Models.ApprovalRuleCreate.RuleType.get -> string
 NGitLab.Models.ApprovalRuleCreate.RuleType.set -> void
-NGitLab.Models.ApprovalRuleCreate.UserIds.get -> int[]
+NGitLab.Models.ApprovalRuleCreate.UserIds.get -> long[]
 NGitLab.Models.ApprovalRuleCreate.UserIds.set -> void
 NGitLab.Models.ApprovalRuleUpdate
-NGitLab.Models.ApprovalRuleUpdate.ApprovalRuleId.get -> int
+NGitLab.Models.ApprovalRuleUpdate.ApprovalRuleId.get -> long
 NGitLab.Models.ApprovalRuleUpdate.ApprovalRuleId.set -> void
 NGitLab.Models.ApprovalRuleUpdate.ApprovalRuleUpdate() -> void
 NGitLab.Models.ApprovalRuleUpdate.ApprovalsRequired.get -> int
 NGitLab.Models.ApprovalRuleUpdate.ApprovalsRequired.set -> void
-NGitLab.Models.ApprovalRuleUpdate.GroupIds.get -> int[]
+NGitLab.Models.ApprovalRuleUpdate.GroupIds.get -> long[]
 NGitLab.Models.ApprovalRuleUpdate.GroupIds.set -> void
-NGitLab.Models.ApprovalRuleUpdate.Id.get -> int
-NGitLab.Models.ApprovalRuleUpdate.Id.set -> void
 NGitLab.Models.ApprovalRuleUpdate.Name.get -> string
 NGitLab.Models.ApprovalRuleUpdate.Name.set -> void
-NGitLab.Models.ApprovalRuleUpdate.ProtectedBranchIds.get -> int[]
+NGitLab.Models.ApprovalRuleUpdate.ProtectedBranchIds.get -> long[]
 NGitLab.Models.ApprovalRuleUpdate.ProtectedBranchIds.set -> void
-NGitLab.Models.ApprovalRuleUpdate.UserIds.get -> int[]
+NGitLab.Models.ApprovalRuleUpdate.UserIds.get -> long[]
 NGitLab.Models.ApprovalRuleUpdate.UserIds.set -> void
 NGitLab.Models.Assignee
 NGitLab.Models.Assignee.Assignee() -> void
 NGitLab.Models.Assignee.AvatarURL -> string
 NGitLab.Models.Assignee.CreatedAt -> System.DateTime
 NGitLab.Models.Assignee.Email -> string
-NGitLab.Models.Assignee.Id -> int
+NGitLab.Models.Assignee.Id -> long
 NGitLab.Models.Assignee.Name -> string
 NGitLab.Models.Assignee.State -> string
 NGitLab.Models.Assignee.Username -> string
@@ -1340,14 +1278,14 @@ NGitLab.Models.Author.Author() -> void
 NGitLab.Models.Author.AvatarUrl -> string
 NGitLab.Models.Author.CreatedAt -> System.DateTime
 NGitLab.Models.Author.Email -> string
-NGitLab.Models.Author.Id -> int
+NGitLab.Models.Author.Id -> long
 NGitLab.Models.Author.Name -> string
 NGitLab.Models.Author.State -> string
 NGitLab.Models.Author.Username -> string
 NGitLab.Models.Author.WebUrl -> string
 NGitLab.Models.Badge
 NGitLab.Models.Badge.Badge() -> void
-NGitLab.Models.Badge.Id -> int
+NGitLab.Models.Badge.Id -> long
 NGitLab.Models.Badge.ImageUrl -> string
 NGitLab.Models.Badge.Kind -> NGitLab.Models.BadgeKind
 NGitLab.Models.Badge.LinkUrl -> string
@@ -1457,7 +1395,7 @@ NGitLab.Models.Change.RenamedFile.set -> void
 NGitLab.Models.ClusterInfo
 NGitLab.Models.ClusterInfo.ClusterInfo() -> void
 NGitLab.Models.ClusterInfo.EnvionmentScope -> string
-NGitLab.Models.ClusterInfo.Id -> int
+NGitLab.Models.ClusterInfo.Id -> long
 NGitLab.Models.ClusterInfo.Name -> string
 NGitLab.Models.ClusterInfo.PlatformType -> string
 NGitLab.Models.Commit
@@ -1494,7 +1432,6 @@ NGitLab.Models.CommitCreate.Branch -> string
 NGitLab.Models.CommitCreate.CommitCreate() -> void
 NGitLab.Models.CommitCreate.CommitMessage -> string
 NGitLab.Models.CommitCreate.Force -> bool?
-NGitLab.Models.CommitCreate.ProjectId -> int
 NGitLab.Models.CommitCreate.StartBranch -> string
 NGitLab.Models.CommitCreate.StartSha -> string
 NGitLab.Models.CommitInfo
@@ -1527,10 +1464,9 @@ NGitLab.Models.CommitStatus.CommitSha -> string
 NGitLab.Models.CommitStatus.CommitStatus() -> void
 NGitLab.Models.CommitStatus.Coverage -> int?
 NGitLab.Models.CommitStatus.Description -> string
-NGitLab.Models.CommitStatus.Id.get -> int
+NGitLab.Models.CommitStatus.Id.get -> long
 NGitLab.Models.CommitStatus.Id.set -> void
 NGitLab.Models.CommitStatus.Name -> string
-NGitLab.Models.CommitStatus.ProjectId -> int
 NGitLab.Models.CommitStatus.Ref -> string
 NGitLab.Models.CommitStatus.Status -> string
 NGitLab.Models.CommitStatus.TargetUrl -> string
@@ -1540,8 +1476,7 @@ NGitLab.Models.CommitStatusCreate.CommitStatusCreate() -> void
 NGitLab.Models.CommitStatusCreate.Coverage -> int?
 NGitLab.Models.CommitStatusCreate.Description -> string
 NGitLab.Models.CommitStatusCreate.Name -> string
-NGitLab.Models.CommitStatusCreate.PipelineId -> int?
-NGitLab.Models.CommitStatusCreate.ProjectId -> int
+NGitLab.Models.CommitStatusCreate.PipelineId -> long?
 NGitLab.Models.CommitStatusCreate.Ref -> string
 NGitLab.Models.CommitStatusCreate.State -> string
 NGitLab.Models.CommitStatusCreate.Status -> string
@@ -1589,11 +1524,11 @@ NGitLab.Models.Deployment
 NGitLab.Models.Deployment.CreatedAt.get -> System.DateTime
 NGitLab.Models.Deployment.CreatedAt.set -> void
 NGitLab.Models.Deployment.Deployment() -> void
-NGitLab.Models.Deployment.DeploymentId.get -> int
+NGitLab.Models.Deployment.DeploymentId.get -> long
 NGitLab.Models.Deployment.DeploymentId.set -> void
 NGitLab.Models.Deployment.Environment.get -> NGitLab.Models.EnvironmentInfo
 NGitLab.Models.Deployment.Environment.set -> void
-NGitLab.Models.Deployment.Id.get -> int
+NGitLab.Models.Deployment.Id.get -> long
 NGitLab.Models.Deployment.Id.set -> void
 NGitLab.Models.Deployment.Ref.get -> string
 NGitLab.Models.Deployment.Ref.set -> void
@@ -1657,7 +1592,7 @@ NGitLab.Models.DiffRefs.StartSha.set -> void
 NGitLab.Models.EnvironmentInfo
 NGitLab.Models.EnvironmentInfo.EnvironmentInfo() -> void
 NGitLab.Models.EnvironmentInfo.ExternalUrl -> string
-NGitLab.Models.EnvironmentInfo.Id -> int
+NGitLab.Models.EnvironmentInfo.Id -> long
 NGitLab.Models.EnvironmentInfo.LastDeployment -> NGitLab.Models.EnvironmentLastDeployment
 NGitLab.Models.EnvironmentInfo.Name -> string
 NGitLab.Models.EnvironmentInfo.Slug -> string
@@ -1668,9 +1603,9 @@ NGitLab.Models.EnvironmentLastDeployment.CreatedAt.set -> void
 NGitLab.Models.EnvironmentLastDeployment.Deployable.get -> NGitLab.Models.Job
 NGitLab.Models.EnvironmentLastDeployment.Deployable.set -> void
 NGitLab.Models.EnvironmentLastDeployment.EnvironmentLastDeployment() -> void
-NGitLab.Models.EnvironmentLastDeployment.Id.get -> int
+NGitLab.Models.EnvironmentLastDeployment.Id.get -> long
 NGitLab.Models.EnvironmentLastDeployment.Id.set -> void
-NGitLab.Models.EnvironmentLastDeployment.IId.get -> int
+NGitLab.Models.EnvironmentLastDeployment.IId.get -> long
 NGitLab.Models.EnvironmentLastDeployment.IId.set -> void
 NGitLab.Models.EnvironmentLastDeployment.Ref.get -> string
 NGitLab.Models.EnvironmentLastDeployment.Ref.set -> void
@@ -1696,11 +1631,11 @@ NGitLab.Models.Epic.CreatedAt.set -> void
 NGitLab.Models.Epic.Description.get -> string
 NGitLab.Models.Epic.Description.set -> void
 NGitLab.Models.Epic.Epic() -> void
-NGitLab.Models.Epic.EpicIid.get -> int
+NGitLab.Models.Epic.EpicIid.get -> long
 NGitLab.Models.Epic.EpicIid.set -> void
-NGitLab.Models.Epic.GroupId.get -> int
+NGitLab.Models.Epic.GroupId.get -> long
 NGitLab.Models.Epic.GroupId.set -> void
-NGitLab.Models.Epic.Id.get -> int
+NGitLab.Models.Epic.Id.get -> long
 NGitLab.Models.Epic.Id.set -> void
 NGitLab.Models.Epic.Labels.get -> string[]
 NGitLab.Models.Epic.Labels.set -> void
@@ -1724,10 +1659,8 @@ NGitLab.Models.EpicEdit
 NGitLab.Models.EpicEdit.Description.get -> string
 NGitLab.Models.EpicEdit.Description.set -> void
 NGitLab.Models.EpicEdit.EpicEdit() -> void
-NGitLab.Models.EpicEdit.EpicId.get -> int
+NGitLab.Models.EpicEdit.EpicId.get -> long
 NGitLab.Models.EpicEdit.EpicId.set -> void
-NGitLab.Models.EpicEdit.Id.get -> int
-NGitLab.Models.EpicEdit.Id.set -> void
 NGitLab.Models.EpicEdit.Labels.get -> string
 NGitLab.Models.EpicEdit.Labels.set -> void
 NGitLab.Models.EpicEdit.State.get -> string
@@ -1760,18 +1693,18 @@ NGitLab.Models.EpicState.opened = 0 -> NGitLab.Models.EpicState
 NGitLab.Models.Event
 NGitLab.Models.Event.Action.get -> NGitLab.DynamicEnum<NGitLab.Models.EventAction>
 NGitLab.Models.Event.Action.set -> void
-NGitLab.Models.Event.AuthorId.get -> int
+NGitLab.Models.Event.AuthorId.get -> long
 NGitLab.Models.Event.AuthorId.set -> void
 NGitLab.Models.Event.AuthorUserName.get -> string
 NGitLab.Models.Event.AuthorUserName.set -> void
 NGitLab.Models.Event.CreatedAt.get -> System.DateTime
 NGitLab.Models.Event.CreatedAt.set -> void
 NGitLab.Models.Event.Event() -> void
-NGitLab.Models.Event.Id.get -> int
+NGitLab.Models.Event.Id.get -> long
 NGitLab.Models.Event.Id.set -> void
 NGitLab.Models.Event.Note.get -> NGitLab.Models.Note
 NGitLab.Models.Event.Note.set -> void
-NGitLab.Models.Event.ProjectId.get -> int
+NGitLab.Models.Event.ProjectId.get -> long
 NGitLab.Models.Event.ProjectId.set -> void
 NGitLab.Models.Event.PushData.get -> NGitLab.Models.PushData
 NGitLab.Models.Event.PushData.set -> void
@@ -1908,11 +1841,11 @@ NGitLab.Models.Group.ExtraSharedRunnersMinutesLimit -> int?
 NGitLab.Models.Group.FullName -> string
 NGitLab.Models.Group.FullPath -> string
 NGitLab.Models.Group.Group() -> void
-NGitLab.Models.Group.Id -> int
+NGitLab.Models.Group.Id -> long
 NGitLab.Models.Group.LfsEnabled -> bool
 NGitLab.Models.Group.MarkedForDeletionOn -> string
 NGitLab.Models.Group.Name -> string
-NGitLab.Models.Group.ParentId -> int?
+NGitLab.Models.Group.ParentId -> long?
 NGitLab.Models.Group.Path -> string
 NGitLab.Models.Group.Projects -> NGitLab.Models.Project[]
 NGitLab.Models.Group.RequestAccessEnabled -> bool
@@ -1926,7 +1859,7 @@ NGitLab.Models.GroupCreate.ExtraSharedRunnersMinutesLimit.set -> void
 NGitLab.Models.GroupCreate.GroupCreate() -> void
 NGitLab.Models.GroupCreate.LfsEnabled -> bool
 NGitLab.Models.GroupCreate.Name -> string
-NGitLab.Models.GroupCreate.ParentId -> int?
+NGitLab.Models.GroupCreate.ParentId -> long?
 NGitLab.Models.GroupCreate.Path -> string
 NGitLab.Models.GroupCreate.RequestAccessEnabled -> bool
 NGitLab.Models.GroupCreate.SharedRunnersMinutesLimit.get -> int?
@@ -1938,9 +1871,9 @@ NGitLab.Models.GroupHook.CreatedAt.set -> void
 NGitLab.Models.GroupHook.EnableSslVerification.get -> bool
 NGitLab.Models.GroupHook.EnableSslVerification.set -> void
 NGitLab.Models.GroupHook.GroupHook() -> void
-NGitLab.Models.GroupHook.GroupId.get -> int
+NGitLab.Models.GroupHook.GroupId.get -> long
 NGitLab.Models.GroupHook.GroupId.set -> void
-NGitLab.Models.GroupHook.Id.get -> int
+NGitLab.Models.GroupHook.Id.get -> long
 NGitLab.Models.GroupHook.Id.set -> void
 NGitLab.Models.GroupHook.IssuesEvents.get -> bool
 NGitLab.Models.GroupHook.IssuesEvents.set -> void
@@ -2065,7 +1998,7 @@ NGitLab.Models.GroupQuery.MinAccessLevel -> NGitLab.Models.AccessLevel?
 NGitLab.Models.GroupQuery.OrderBy -> string
 NGitLab.Models.GroupQuery.Owned -> bool?
 NGitLab.Models.GroupQuery.Search -> string
-NGitLab.Models.GroupQuery.SkipGroups -> int[]
+NGitLab.Models.GroupQuery.SkipGroups -> long[]
 NGitLab.Models.GroupQuery.Sort -> string
 NGitLab.Models.GroupQuery.Statistics -> bool?
 NGitLab.Models.GroupQuery.TopLevelOnly -> bool?
@@ -2092,7 +2025,7 @@ NGitLab.Models.Identity
 NGitLab.Models.Identity.ExternUid -> string
 NGitLab.Models.Identity.Identity() -> void
 NGitLab.Models.Identity.Provider -> string
-NGitLab.Models.Identity.SamlProviderId -> int?
+NGitLab.Models.Identity.SamlProviderId -> long?
 NGitLab.Models.IdOrPathExtensions
 NGitLab.Models.IIdOrPathAddressable
 NGitLab.Models.Issue
@@ -2108,16 +2041,16 @@ NGitLab.Models.Issue.CreatedAt -> System.DateTime
 NGitLab.Models.Issue.Description -> string
 NGitLab.Models.Issue.DueDate -> System.DateTime?
 NGitLab.Models.Issue.Epic -> NGitLab.Models.IssueEpic
-NGitLab.Models.Issue.Id -> int
+NGitLab.Models.Issue.Id -> long
 NGitLab.Models.Issue.Issue() -> void
-NGitLab.Models.Issue.IssueId -> int
+NGitLab.Models.Issue.IssueId -> long
 NGitLab.Models.Issue.IssueType -> string
 NGitLab.Models.Issue.Labels -> string[]
 NGitLab.Models.Issue.MergeRequestsCount.get -> int
 NGitLab.Models.Issue.MergeRequestsCount.set -> void
 NGitLab.Models.Issue.Milestone -> NGitLab.Models.Milestone
-NGitLab.Models.Issue.MovedToId -> int?
-NGitLab.Models.Issue.ProjectId -> int
+NGitLab.Models.Issue.MovedToId -> long?
+NGitLab.Models.Issue.ProjectId -> long
 NGitLab.Models.Issue.References -> NGitLab.Models.References
 NGitLab.Models.Issue.State -> string
 NGitLab.Models.Issue.Title -> string
@@ -2127,45 +2060,43 @@ NGitLab.Models.Issue.Weight.get -> int?
 NGitLab.Models.Issue.Weight.set -> void
 NGitLab.Models.IssueClone
 NGitLab.Models.IssueClone.IssueClone() -> void
-NGitLab.Models.IssueClone.ToProjectId.get -> int
+NGitLab.Models.IssueClone.ToProjectId.get -> long
 NGitLab.Models.IssueClone.ToProjectId.set -> void
 NGitLab.Models.IssueClone.WithNotes.get -> bool
 NGitLab.Models.IssueClone.WithNotes.set -> void
 NGitLab.Models.IssueCreate
-NGitLab.Models.IssueCreate.AssigneeId -> int?
-NGitLab.Models.IssueCreate.AssigneeIds -> int[]
+NGitLab.Models.IssueCreate.AssigneeId -> long?
+NGitLab.Models.IssueCreate.AssigneeIds -> long[]
 NGitLab.Models.IssueCreate.Confidential -> bool
 NGitLab.Models.IssueCreate.Description -> string
 NGitLab.Models.IssueCreate.DueDate -> System.DateTime?
-NGitLab.Models.IssueCreate.EpicId -> int?
-NGitLab.Models.IssueCreate.Id -> int
+NGitLab.Models.IssueCreate.EpicId -> long?
 NGitLab.Models.IssueCreate.IssueCreate() -> void
 NGitLab.Models.IssueCreate.Labels -> string
-NGitLab.Models.IssueCreate.MileStoneId -> int?
-NGitLab.Models.IssueCreate.ProjectId.get -> int
+NGitLab.Models.IssueCreate.MileStoneId -> long?
+NGitLab.Models.IssueCreate.ProjectId.get -> long
 NGitLab.Models.IssueCreate.ProjectId.set -> void
 NGitLab.Models.IssueCreate.Title -> string
 NGitLab.Models.IssueEdit
-NGitLab.Models.IssueEdit.AssigneeId -> int?
-NGitLab.Models.IssueEdit.AssigneeIds -> int[]
+NGitLab.Models.IssueEdit.AssigneeId -> long?
+NGitLab.Models.IssueEdit.AssigneeIds -> long[]
 NGitLab.Models.IssueEdit.Description -> string
 NGitLab.Models.IssueEdit.DueDate -> System.DateTime?
-NGitLab.Models.IssueEdit.EpicId -> int?
-NGitLab.Models.IssueEdit.Id -> int
+NGitLab.Models.IssueEdit.EpicId -> long?
 NGitLab.Models.IssueEdit.IssueEdit() -> void
-NGitLab.Models.IssueEdit.IssueId -> int
+NGitLab.Models.IssueEdit.IssueId -> long
 NGitLab.Models.IssueEdit.Labels -> string
-NGitLab.Models.IssueEdit.MilestoneId -> int?
-NGitLab.Models.IssueEdit.ProjectId.get -> int
+NGitLab.Models.IssueEdit.MilestoneId -> long?
+NGitLab.Models.IssueEdit.ProjectId.get -> long
 NGitLab.Models.IssueEdit.ProjectId.set -> void
 NGitLab.Models.IssueEdit.State -> string
 NGitLab.Models.IssueEdit.Title -> string
 NGitLab.Models.IssueEpic
-NGitLab.Models.IssueEpic.EpicId.get -> int
+NGitLab.Models.IssueEpic.EpicId.get -> long
 NGitLab.Models.IssueEpic.EpicId.set -> void
-NGitLab.Models.IssueEpic.GroupId.get -> int
+NGitLab.Models.IssueEpic.GroupId.get -> long
 NGitLab.Models.IssueEpic.GroupId.set -> void
-NGitLab.Models.IssueEpic.Id.get -> int
+NGitLab.Models.IssueEpic.Id.get -> long
 NGitLab.Models.IssueEpic.Id.set -> void
 NGitLab.Models.IssueEpic.IssueEpic() -> void
 NGitLab.Models.IssueEpic.Title.get -> string
@@ -2175,7 +2106,7 @@ NGitLab.Models.IssueEpic.Url.set -> void
 NGitLab.Models.IssueQuery
 NGitLab.Models.IssueQuery.AssigneeId.get -> NGitLab.Models.QueryAssigneeId
 NGitLab.Models.IssueQuery.AssigneeId.set -> void
-NGitLab.Models.IssueQuery.AuthorId.get -> int?
+NGitLab.Models.IssueQuery.AuthorId.get -> long?
 NGitLab.Models.IssueQuery.AuthorId.set -> void
 NGitLab.Models.IssueQuery.Confidential.get -> bool?
 NGitLab.Models.IssueQuery.Confidential.set -> void
@@ -2224,7 +2155,7 @@ NGitLab.Models.Job.JobArtifact.JobArtifact() -> void
 NGitLab.Models.Job.JobArtifact.Size.get -> long
 NGitLab.Models.Job.JobArtifact.Size.set -> void
 NGitLab.Models.Job.JobProject
-NGitLab.Models.Job.JobProject.Id.get -> int
+NGitLab.Models.Job.JobProject.Id.get -> long
 NGitLab.Models.Job.JobProject.Id.set -> void
 NGitLab.Models.Job.JobProject.JobProject() -> void
 NGitLab.Models.Job.JobProject.Name.get -> string
@@ -2236,7 +2167,7 @@ NGitLab.Models.Job.JobRunner.Active.get -> bool
 NGitLab.Models.Job.JobRunner.Active.set -> void
 NGitLab.Models.Job.JobRunner.Description.get -> string
 NGitLab.Models.Job.JobRunner.Description.set -> void
-NGitLab.Models.Job.JobRunner.Id.get -> int
+NGitLab.Models.Job.JobRunner.Id.get -> long
 NGitLab.Models.Job.JobRunner.Id.set -> void
 NGitLab.Models.Job.JobRunner.IsShared.get -> bool
 NGitLab.Models.Job.JobRunner.IsShared.set -> void
@@ -2275,14 +2206,14 @@ NGitLab.Models.JobBasic.FailureReason.get -> string
 NGitLab.Models.JobBasic.FailureReason.set -> void
 NGitLab.Models.JobBasic.FinishedAt.get -> System.DateTime
 NGitLab.Models.JobBasic.FinishedAt.set -> void
-NGitLab.Models.JobBasic.Id.get -> int
+NGitLab.Models.JobBasic.Id.get -> long
 NGitLab.Models.JobBasic.Id.set -> void
 NGitLab.Models.JobBasic.JobBasic() -> void
 NGitLab.Models.JobBasic.JobPipeline
-NGitLab.Models.JobBasic.JobPipeline.Id.get -> int
+NGitLab.Models.JobBasic.JobPipeline.Id.get -> long
 NGitLab.Models.JobBasic.JobPipeline.Id.set -> void
 NGitLab.Models.JobBasic.JobPipeline.JobPipeline() -> void
-NGitLab.Models.JobBasic.JobPipeline.ProjectId.get -> int
+NGitLab.Models.JobBasic.JobPipeline.ProjectId.get -> long
 NGitLab.Models.JobBasic.JobPipeline.ProjectId.set -> void
 NGitLab.Models.JobBasic.JobPipeline.Ref.get -> string
 NGitLab.Models.JobBasic.JobPipeline.Ref.set -> void
@@ -2346,19 +2277,18 @@ NGitLab.Models.Label.Name -> string
 NGitLab.Models.LabelCreate
 NGitLab.Models.LabelCreate.Color -> string
 NGitLab.Models.LabelCreate.Description -> string
-NGitLab.Models.LabelCreate.Id -> int
+NGitLab.Models.LabelCreate.Id -> long
 NGitLab.Models.LabelCreate.LabelCreate() -> void
 NGitLab.Models.LabelCreate.Name -> string
 NGitLab.Models.LabelDelete
-NGitLab.Models.LabelDelete.Id -> int
+NGitLab.Models.LabelDelete.Id -> long
 NGitLab.Models.LabelDelete.LabelDelete() -> void
 NGitLab.Models.LabelDelete.Name -> string
 NGitLab.Models.LabelEdit
 NGitLab.Models.LabelEdit.Color -> string
 NGitLab.Models.LabelEdit.Description -> string
-NGitLab.Models.LabelEdit.Id -> int
+NGitLab.Models.LabelEdit.Id -> long
 NGitLab.Models.LabelEdit.LabelEdit() -> void
-NGitLab.Models.LabelEdit.LabelEdit(int projectId, NGitLab.Models.Label label) -> void
 NGitLab.Models.LabelEdit.Name -> string
 NGitLab.Models.LabelEdit.NewName -> string
 NGitLab.Models.LastActivityDate
@@ -2396,7 +2326,7 @@ NGitLab.Models.Membership.AccessLevel -> int
 NGitLab.Models.Membership.AvatarURL -> string
 NGitLab.Models.Membership.CreatedAt -> System.DateTime
 NGitLab.Models.Membership.ExpiresAt -> System.DateTime?
-NGitLab.Models.Membership.Id -> int
+NGitLab.Models.Membership.Id -> long
 NGitLab.Models.Membership.Membership() -> void
 NGitLab.Models.Membership.Name -> string
 NGitLab.Models.Membership.State -> string
@@ -2424,8 +2354,8 @@ NGitLab.Models.MergeRequest.ForceRemoveSourceBranch -> bool
 NGitLab.Models.MergeRequest.HasConflicts.get -> bool
 NGitLab.Models.MergeRequest.HasConflicts.set -> void
 NGitLab.Models.MergeRequest.HeadPipeline -> NGitLab.Models.Pipeline
-NGitLab.Models.MergeRequest.Id -> int
-NGitLab.Models.MergeRequest.Iid -> int
+NGitLab.Models.MergeRequest.Id -> long
+NGitLab.Models.MergeRequest.Iid -> long
 NGitLab.Models.MergeRequest.Labels -> string[]
 NGitLab.Models.MergeRequest.MergeCommitSha -> string
 NGitLab.Models.MergeRequest.MergedAt -> System.DateTime?
@@ -2436,18 +2366,18 @@ NGitLab.Models.MergeRequest.MergeRequest() -> void
 NGitLab.Models.MergeRequest.MergeStatus -> string
 NGitLab.Models.MergeRequest.MergeWhenPipelineSucceeds -> bool
 NGitLab.Models.MergeRequest.Milestone -> NGitLab.Models.Milestone
-NGitLab.Models.MergeRequest.ProjectId -> int
+NGitLab.Models.MergeRequest.ProjectId -> long
 NGitLab.Models.MergeRequest.RebaseInProgress -> bool
 NGitLab.Models.MergeRequest.Reviewers -> NGitLab.Models.User[]
 NGitLab.Models.MergeRequest.Sha -> string
 NGitLab.Models.MergeRequest.ShouldRemoveSourceBranch -> bool?
 NGitLab.Models.MergeRequest.SourceBranch -> string
-NGitLab.Models.MergeRequest.SourceProjectId -> int
+NGitLab.Models.MergeRequest.SourceProjectId -> long
 NGitLab.Models.MergeRequest.Squash -> bool
 NGitLab.Models.MergeRequest.SquashCommitSha -> string
 NGitLab.Models.MergeRequest.State -> string
 NGitLab.Models.MergeRequest.TargetBranch -> string
-NGitLab.Models.MergeRequest.TargetProjectId -> int
+NGitLab.Models.MergeRequest.TargetProjectId -> long
 NGitLab.Models.MergeRequest.Title -> string
 NGitLab.Models.MergeRequest.UpdatedAt -> System.DateTime
 NGitLab.Models.MergeRequest.Upvotes -> int
@@ -2495,8 +2425,8 @@ NGitLab.Models.MergeRequestApproveRequest.MergeRequestApproveRequest() -> void
 NGitLab.Models.MergeRequestApproveRequest.Sha.get -> string
 NGitLab.Models.MergeRequestApproveRequest.Sha.set -> void
 NGitLab.Models.MergeRequestApproversChange
-NGitLab.Models.MergeRequestApproversChange.ApproverGroups -> int[]
-NGitLab.Models.MergeRequestApproversChange.Approvers -> int[]
+NGitLab.Models.MergeRequestApproversChange.ApproverGroups -> long[]
+NGitLab.Models.MergeRequestApproversChange.Approvers -> long[]
 NGitLab.Models.MergeRequestApproversChange.MergeRequestApproversChange() -> void
 NGitLab.Models.MergeRequestChange
 NGitLab.Models.MergeRequestChange.Changes.get -> NGitLab.Models.Change[]
@@ -2535,19 +2465,19 @@ NGitLab.Models.MergeRequestCommentQuery.Sort.get -> string
 NGitLab.Models.MergeRequestCommentQuery.Sort.set -> void
 NGitLab.Models.MergeRequestCreate
 NGitLab.Models.MergeRequestCreate.AllowCollaboration -> bool?
-NGitLab.Models.MergeRequestCreate.AssigneeId -> int?
-NGitLab.Models.MergeRequestCreate.AssigneeIds -> int[]
+NGitLab.Models.MergeRequestCreate.AssigneeId -> long?
+NGitLab.Models.MergeRequestCreate.AssigneeIds -> long[]
 NGitLab.Models.MergeRequestCreate.Description -> string
 NGitLab.Models.MergeRequestCreate.Labels -> string
 NGitLab.Models.MergeRequestCreate.MergeRequestCreate() -> void
-NGitLab.Models.MergeRequestCreate.MilestoneId.get -> int?
+NGitLab.Models.MergeRequestCreate.MilestoneId.get -> long?
 NGitLab.Models.MergeRequestCreate.MilestoneId.set -> void
 NGitLab.Models.MergeRequestCreate.RemoveSourceBranch -> bool
-NGitLab.Models.MergeRequestCreate.ReviewerIds -> int[]
+NGitLab.Models.MergeRequestCreate.ReviewerIds -> long[]
 NGitLab.Models.MergeRequestCreate.SourceBranch -> string
 NGitLab.Models.MergeRequestCreate.Squash -> bool
 NGitLab.Models.MergeRequestCreate.TargetBranch -> string
-NGitLab.Models.MergeRequestCreate.TargetProjectId -> int?
+NGitLab.Models.MergeRequestCreate.TargetProjectId -> long?
 NGitLab.Models.MergeRequestCreate.Title -> string
 NGitLab.Models.MergeRequestDiscussion
 NGitLab.Models.MergeRequestDiscussion.Id.get -> string
@@ -2580,11 +2510,11 @@ NGitLab.Models.MergeRequestMerge.ShouldRemoveSourceBranch.set -> void
 NGitLab.Models.MergeRequestMerge.Squash.get -> bool?
 NGitLab.Models.MergeRequestMerge.Squash.set -> void
 NGitLab.Models.MergeRequestQuery
-NGitLab.Models.MergeRequestQuery.ApproverIds.get -> int[]
+NGitLab.Models.MergeRequestQuery.ApproverIds.get -> long[]
 NGitLab.Models.MergeRequestQuery.ApproverIds.set -> void
 NGitLab.Models.MergeRequestQuery.AssigneeId.get -> NGitLab.Models.QueryAssigneeId
 NGitLab.Models.MergeRequestQuery.AssigneeId.set -> void
-NGitLab.Models.MergeRequestQuery.AuthorId.get -> int?
+NGitLab.Models.MergeRequestQuery.AuthorId.get -> long?
 NGitLab.Models.MergeRequestQuery.AuthorId.set -> void
 NGitLab.Models.MergeRequestQuery.CreatedAfter.get -> System.DateTime?
 NGitLab.Models.MergeRequestQuery.CreatedAfter.set -> void
@@ -2637,16 +2567,16 @@ NGitLab.Models.MergeRequestStateEvent.reopen = 1 -> NGitLab.Models.MergeRequestS
 NGitLab.Models.MergeRequestUpdate
 NGitLab.Models.MergeRequestUpdate.AddLabels -> string
 NGitLab.Models.MergeRequestUpdate.AllowCollaboration -> bool?
-NGitLab.Models.MergeRequestUpdate.AssigneeId -> int?
-NGitLab.Models.MergeRequestUpdate.AssigneeIds -> int[]
+NGitLab.Models.MergeRequestUpdate.AssigneeId -> long?
+NGitLab.Models.MergeRequestUpdate.AssigneeIds -> long[]
 NGitLab.Models.MergeRequestUpdate.Description -> string
 NGitLab.Models.MergeRequestUpdate.Labels -> string
 NGitLab.Models.MergeRequestUpdate.MergeRequestUpdate() -> void
-NGitLab.Models.MergeRequestUpdate.MilestoneId -> int?
+NGitLab.Models.MergeRequestUpdate.MilestoneId -> long?
 NGitLab.Models.MergeRequestUpdate.NewState -> string
 NGitLab.Models.MergeRequestUpdate.RemoveLabels -> string
 NGitLab.Models.MergeRequestUpdate.RemoveSourceBranch -> bool?
-NGitLab.Models.MergeRequestUpdate.ReviewerIds -> int[]
+NGitLab.Models.MergeRequestUpdate.ReviewerIds -> long[]
 NGitLab.Models.MergeRequestUpdate.SourceBranch -> string
 NGitLab.Models.MergeRequestUpdate.Squash -> bool?
 NGitLab.Models.MergeRequestUpdate.SquashOnMerge -> bool?
@@ -2666,9 +2596,9 @@ NGitLab.Models.MergeRequestVersion.CreatedAt.get -> System.DateTime
 NGitLab.Models.MergeRequestVersion.CreatedAt.set -> void
 NGitLab.Models.MergeRequestVersion.HeadCommitSha.get -> string
 NGitLab.Models.MergeRequestVersion.HeadCommitSha.set -> void
-NGitLab.Models.MergeRequestVersion.Id.get -> int
+NGitLab.Models.MergeRequestVersion.Id.get -> long
 NGitLab.Models.MergeRequestVersion.Id.set -> void
-NGitLab.Models.MergeRequestVersion.MergeRequestId.get -> int
+NGitLab.Models.MergeRequestVersion.MergeRequestId.get -> long
 NGitLab.Models.MergeRequestVersion.MergeRequestId.set -> void
 NGitLab.Models.MergeRequestVersion.MergeRequestVersion() -> void
 NGitLab.Models.MergeRequestVersion.RealSize.get -> string
@@ -2681,11 +2611,11 @@ NGitLab.Models.Milestone
 NGitLab.Models.Milestone.CreatedAt -> System.DateTime
 NGitLab.Models.Milestone.Description -> string
 NGitLab.Models.Milestone.DueDate -> string
-NGitLab.Models.Milestone.GroupId -> int?
-NGitLab.Models.Milestone.Id -> int
-NGitLab.Models.Milestone.Iid -> int
+NGitLab.Models.Milestone.GroupId -> long?
+NGitLab.Models.Milestone.Id -> long
+NGitLab.Models.Milestone.Iid -> long
 NGitLab.Models.Milestone.Milestone() -> void
-NGitLab.Models.Milestone.ProjectId -> int?
+NGitLab.Models.Milestone.ProjectId -> long?
 NGitLab.Models.Milestone.StartDate -> string
 NGitLab.Models.Milestone.State -> string
 NGitLab.Models.Milestone.Title -> string
@@ -2720,7 +2650,7 @@ NGitLab.Models.MilestoneUpdateState.NewState -> string
 NGitLab.Models.Namespace
 NGitLab.Models.Namespace.FullPath -> string
 NGitLab.Models.Namespace.GetKind() -> NGitLab.Models.Namespace.Type
-NGitLab.Models.Namespace.Id -> int
+NGitLab.Models.Namespace.Id -> long
 NGitLab.Models.Namespace.Kind -> string
 NGitLab.Models.Namespace.Name -> string
 NGitLab.Models.Namespace.Namespace() -> void
@@ -2781,7 +2711,7 @@ NGitLab.Models.PageQuery<TQueryType>.Query.set -> void
 NGitLab.Models.Participant
 NGitLab.Models.Participant.AvatarURL.get -> string
 NGitLab.Models.Participant.AvatarURL.set -> void
-NGitLab.Models.Participant.Id.get -> int
+NGitLab.Models.Participant.Id.get -> long
 NGitLab.Models.Participant.Id.set -> void
 NGitLab.Models.Participant.Name.get -> string
 NGitLab.Models.Participant.Name.set -> void
@@ -2805,11 +2735,11 @@ NGitLab.Models.Pipeline.DetailedStatus.get -> NGitLab.Models.PipelineDetailedSta
 NGitLab.Models.Pipeline.DetailedStatus.set -> void
 NGitLab.Models.Pipeline.Duration -> long?
 NGitLab.Models.Pipeline.FinishedAt -> System.DateTime
-NGitLab.Models.Pipeline.Id -> int
+NGitLab.Models.Pipeline.Id -> long
 NGitLab.Models.Pipeline.Name.get -> string
 NGitLab.Models.Pipeline.Name.set -> void
 NGitLab.Models.Pipeline.Pipeline() -> void
-NGitLab.Models.Pipeline.ProjectId.get -> int
+NGitLab.Models.Pipeline.ProjectId.get -> long
 NGitLab.Models.Pipeline.ProjectId.set -> void
 NGitLab.Models.Pipeline.Ref -> string
 NGitLab.Models.Pipeline.Sha -> NGitLab.Sha1
@@ -2823,11 +2753,11 @@ NGitLab.Models.Pipeline.WebUrl -> string
 NGitLab.Models.Pipeline.YamlError -> string
 NGitLab.Models.PipelineBasic
 NGitLab.Models.PipelineBasic.CreatedAt -> System.DateTime
-NGitLab.Models.PipelineBasic.Id -> int
+NGitLab.Models.PipelineBasic.Id -> long
 NGitLab.Models.PipelineBasic.Name.get -> string
 NGitLab.Models.PipelineBasic.Name.set -> void
 NGitLab.Models.PipelineBasic.PipelineBasic() -> void
-NGitLab.Models.PipelineBasic.ProjectId -> int
+NGitLab.Models.PipelineBasic.ProjectId -> long
 NGitLab.Models.PipelineBasic.Ref -> string
 NGitLab.Models.PipelineBasic.Sha -> NGitLab.Sha1
 NGitLab.Models.PipelineBasic.Source -> string
@@ -2836,7 +2766,7 @@ NGitLab.Models.PipelineBasic.UpdatedAt -> System.DateTime
 NGitLab.Models.PipelineBasic.WebUrl -> string
 NGitLab.Models.PipelineBridgeQuery
 NGitLab.Models.PipelineBridgeQuery.PipelineBridgeQuery() -> void
-NGitLab.Models.PipelineBridgeQuery.PipelineId.get -> int
+NGitLab.Models.PipelineBridgeQuery.PipelineId.get -> long
 NGitLab.Models.PipelineBridgeQuery.PipelineId.set -> void
 NGitLab.Models.PipelineBridgeQuery.Scope.get -> string[]
 NGitLab.Models.PipelineBridgeQuery.Scope.set -> void
@@ -2868,7 +2798,7 @@ NGitLab.Models.PipelineDetailedStatus.ToolTip.set -> void
 NGitLab.Models.PipelineJobQuery
 NGitLab.Models.PipelineJobQuery.IncludeRetried.get -> bool?
 NGitLab.Models.PipelineJobQuery.IncludeRetried.set -> void
-NGitLab.Models.PipelineJobQuery.PipelineId.get -> int
+NGitLab.Models.PipelineJobQuery.PipelineId.get -> long
 NGitLab.Models.PipelineJobQuery.PipelineId.set -> void
 NGitLab.Models.PipelineJobQuery.PipelineJobQuery() -> void
 NGitLab.Models.PipelineJobQuery.Scope.get -> string[]
@@ -2924,7 +2854,7 @@ NGitLab.Models.PipelineScheduleBasic.Cron.get -> string
 NGitLab.Models.PipelineScheduleBasic.Cron.set -> void
 NGitLab.Models.PipelineScheduleBasic.Description.get -> string
 NGitLab.Models.PipelineScheduleBasic.Description.set -> void
-NGitLab.Models.PipelineScheduleBasic.Id.get -> int
+NGitLab.Models.PipelineScheduleBasic.Id.get -> long
 NGitLab.Models.PipelineScheduleBasic.Id.set -> void
 NGitLab.Models.PipelineScheduleBasic.NextRunAt.get -> System.DateTime
 NGitLab.Models.PipelineScheduleBasic.NextRunAt.set -> void
@@ -2980,7 +2910,7 @@ NGitLab.Models.Project.BuildsAccessLevel -> string
 NGitLab.Models.Project.BuildTimeout -> int?
 NGitLab.Models.Project.ContainerRegistryEnabled -> bool
 NGitLab.Models.Project.CreatedAt -> System.DateTime
-NGitLab.Models.Project.CreatorId -> int
+NGitLab.Models.Project.CreatorId -> long
 NGitLab.Models.Project.DefaultBranch -> string
 NGitLab.Models.Project.Description -> string
 NGitLab.Models.Project.EmptyRepo -> bool
@@ -2989,7 +2919,7 @@ NGitLab.Models.Project.ForkingAccessLevel -> NGitLab.Models.RepositoryAccessLeve
 NGitLab.Models.Project.ForksCount -> int
 NGitLab.Models.Project.GroupRunnersEnabled -> bool
 NGitLab.Models.Project.HttpUrl -> string
-NGitLab.Models.Project.Id -> int
+NGitLab.Models.Project.Id -> long
 NGitLab.Models.Project.ImportError -> string
 NGitLab.Models.Project.ImportStatus -> string
 NGitLab.Models.Project.IssuesAccessLevel -> string
@@ -3006,7 +2936,7 @@ NGitLab.Models.Project.MergeTrainsEnabled -> bool
 NGitLab.Models.Project.Mirror -> bool
 NGitLab.Models.Project.MirrorOverwritesDivergedBranches -> bool
 NGitLab.Models.Project.MirrorTriggerBuilds -> bool
-NGitLab.Models.Project.MirrorUserId -> int
+NGitLab.Models.Project.MirrorUserId -> long
 NGitLab.Models.Project.MrDefaultTargetSelf.get -> bool?
 NGitLab.Models.Project.MrDefaultTargetSelf.set -> void
 NGitLab.Models.Project.Name -> string
@@ -3081,21 +3011,21 @@ NGitLab.Models.ProjectGroupsQuery.SharedMinAccessLevel.get -> NGitLab.Models.Acc
 NGitLab.Models.ProjectGroupsQuery.SharedMinAccessLevel.set -> void
 NGitLab.Models.ProjectGroupsQuery.SharedVisibleOnly.get -> bool?
 NGitLab.Models.ProjectGroupsQuery.SharedVisibleOnly.set -> void
-NGitLab.Models.ProjectGroupsQuery.SkipGroups.get -> int[]
+NGitLab.Models.ProjectGroupsQuery.SkipGroups.get -> long[]
 NGitLab.Models.ProjectGroupsQuery.SkipGroups.set -> void
 NGitLab.Models.ProjectGroupsQuery.WithShared.get -> bool?
 NGitLab.Models.ProjectGroupsQuery.WithShared.set -> void
 NGitLab.Models.ProjectHook
 NGitLab.Models.ProjectHook.CreatedAt -> System.DateTime
 NGitLab.Models.ProjectHook.EnableSslVerification -> bool
-NGitLab.Models.ProjectHook.Id -> int
+NGitLab.Models.ProjectHook.Id -> long
 NGitLab.Models.ProjectHook.IssuesEvents -> bool
 NGitLab.Models.ProjectHook.JobEvents -> bool
 NGitLab.Models.ProjectHook.MergeRequestsEvents -> bool
 NGitLab.Models.ProjectHook.NoteEvents -> bool
 NGitLab.Models.ProjectHook.PipelineEvents -> bool
 NGitLab.Models.ProjectHook.ProjectHook() -> void
-NGitLab.Models.ProjectHook.ProjectId -> int
+NGitLab.Models.ProjectHook.ProjectId -> long
 NGitLab.Models.ProjectHook.PushEvents -> bool
 NGitLab.Models.ProjectHook.TagPushEvents -> bool
 NGitLab.Models.ProjectHook.Url -> System.Uri
@@ -3126,10 +3056,10 @@ NGitLab.Models.ProjectIssueNote.Author -> NGitLab.Models.Author
 NGitLab.Models.ProjectIssueNote.Body -> string
 NGitLab.Models.ProjectIssueNote.Confidential -> bool
 NGitLab.Models.ProjectIssueNote.CreatedAt -> System.DateTime
-NGitLab.Models.ProjectIssueNote.NoteableId -> int
+NGitLab.Models.ProjectIssueNote.NoteableId -> long
 NGitLab.Models.ProjectIssueNote.NoteableType -> string
-NGitLab.Models.ProjectIssueNote.Noteable_Iid -> int
-NGitLab.Models.ProjectIssueNote.NoteId -> int
+NGitLab.Models.ProjectIssueNote.Noteable_Iid -> long
+NGitLab.Models.ProjectIssueNote.NoteId -> long
 NGitLab.Models.ProjectIssueNote.ProjectIssueNote() -> void
 NGitLab.Models.ProjectIssueNote.Resolvable -> bool
 NGitLab.Models.ProjectIssueNote.System -> bool
@@ -3137,12 +3067,12 @@ NGitLab.Models.ProjectIssueNote.UpdatedAt -> System.DateTime
 NGitLab.Models.ProjectIssueNoteCreate
 NGitLab.Models.ProjectIssueNoteCreate.Body -> string
 NGitLab.Models.ProjectIssueNoteCreate.Confidential -> bool
-NGitLab.Models.ProjectIssueNoteCreate.IssueId -> int
+NGitLab.Models.ProjectIssueNoteCreate.IssueId -> long
 NGitLab.Models.ProjectIssueNoteCreate.ProjectIssueNoteCreate() -> void
 NGitLab.Models.ProjectIssueNoteEdit
 NGitLab.Models.ProjectIssueNoteEdit.Body -> string
-NGitLab.Models.ProjectIssueNoteEdit.IssueId -> int
-NGitLab.Models.ProjectIssueNoteEdit.NoteId -> int
+NGitLab.Models.ProjectIssueNoteEdit.IssueId -> long
+NGitLab.Models.ProjectIssueNoteEdit.NoteId -> long
 NGitLab.Models.ProjectIssueNoteEdit.ProjectIssueNoteEdit() -> void
 NGitLab.Models.ProjectLabelCreate
 NGitLab.Models.ProjectLabelCreate.Color.get -> string
@@ -3153,7 +3083,7 @@ NGitLab.Models.ProjectLabelCreate.Name.get -> string
 NGitLab.Models.ProjectLabelCreate.Name.set -> void
 NGitLab.Models.ProjectLabelCreate.ProjectLabelCreate() -> void
 NGitLab.Models.ProjectLabelDelete
-NGitLab.Models.ProjectLabelDelete.Id.get -> int
+NGitLab.Models.ProjectLabelDelete.Id.get -> long
 NGitLab.Models.ProjectLabelDelete.Id.set -> void
 NGitLab.Models.ProjectLabelDelete.Name.get -> string
 NGitLab.Models.ProjectLabelDelete.Name.set -> void
@@ -3212,7 +3142,7 @@ NGitLab.Models.ProjectQuery.Search -> string
 NGitLab.Models.ProjectQuery.Simple -> bool?
 NGitLab.Models.ProjectQuery.Statistics -> bool?
 NGitLab.Models.ProjectQuery.Topics.get -> System.Collections.Generic.IList<string>
-NGitLab.Models.ProjectQuery.UserId -> int?
+NGitLab.Models.ProjectQuery.UserId -> long?
 NGitLab.Models.ProjectQuery.Visibility -> NGitLab.Models.VisibilityLevel?
 NGitLab.Models.ProjectQueryScope
 NGitLab.Models.ProjectQueryScope.Accessible = 0 -> NGitLab.Models.ProjectQueryScope
@@ -3429,7 +3359,7 @@ NGitLab.Models.ReleaseLink.DirectAssetUrl.get -> string
 NGitLab.Models.ReleaseLink.DirectAssetUrl.set -> void
 NGitLab.Models.ReleaseLink.External.get -> bool
 NGitLab.Models.ReleaseLink.External.set -> void
-NGitLab.Models.ReleaseLink.Id.get -> int?
+NGitLab.Models.ReleaseLink.Id.get -> long?
 NGitLab.Models.ReleaseLink.Id.set -> void
 NGitLab.Models.ReleaseLink.LinkType.get -> NGitLab.Models.ReleaseLinkType
 NGitLab.Models.ReleaseLink.LinkType.set -> void
@@ -3510,11 +3440,11 @@ NGitLab.Models.ResourceLabelEvent.Action.get -> NGitLab.Models.ResourceLabelEven
 NGitLab.Models.ResourceLabelEvent.Action.set -> void
 NGitLab.Models.ResourceLabelEvent.CreatedAt.get -> System.DateTime
 NGitLab.Models.ResourceLabelEvent.CreatedAt.set -> void
-NGitLab.Models.ResourceLabelEvent.Id.get -> int
+NGitLab.Models.ResourceLabelEvent.Id.get -> long
 NGitLab.Models.ResourceLabelEvent.Id.set -> void
 NGitLab.Models.ResourceLabelEvent.Label.get -> NGitLab.Models.Label
 NGitLab.Models.ResourceLabelEvent.Label.set -> void
-NGitLab.Models.ResourceLabelEvent.ResourceId.get -> int
+NGitLab.Models.ResourceLabelEvent.ResourceId.get -> long
 NGitLab.Models.ResourceLabelEvent.ResourceId.set -> void
 NGitLab.Models.ResourceLabelEvent.ResourceLabelEvent() -> void
 NGitLab.Models.ResourceLabelEvent.ResourceType.get -> string
@@ -3529,11 +3459,11 @@ NGitLab.Models.ResourceMilestoneEvent.Action.get -> NGitLab.Models.ResourceMiles
 NGitLab.Models.ResourceMilestoneEvent.Action.set -> void
 NGitLab.Models.ResourceMilestoneEvent.CreatedAt.get -> System.DateTime
 NGitLab.Models.ResourceMilestoneEvent.CreatedAt.set -> void
-NGitLab.Models.ResourceMilestoneEvent.Id.get -> int
+NGitLab.Models.ResourceMilestoneEvent.Id.get -> long
 NGitLab.Models.ResourceMilestoneEvent.Id.set -> void
 NGitLab.Models.ResourceMilestoneEvent.Milestone.get -> NGitLab.Models.Milestone
 NGitLab.Models.ResourceMilestoneEvent.Milestone.set -> void
-NGitLab.Models.ResourceMilestoneEvent.ResourceId.get -> int
+NGitLab.Models.ResourceMilestoneEvent.ResourceId.get -> long
 NGitLab.Models.ResourceMilestoneEvent.ResourceId.set -> void
 NGitLab.Models.ResourceMilestoneEvent.ResourceMilestoneEvent() -> void
 NGitLab.Models.ResourceMilestoneEvent.ResourceType.get -> string
@@ -3546,9 +3476,9 @@ NGitLab.Models.ResourceMilestoneEventAction.Remove = 1 -> NGitLab.Models.Resourc
 NGitLab.Models.ResourceStateEvent
 NGitLab.Models.ResourceStateEvent.CreatedAt.get -> System.DateTime
 NGitLab.Models.ResourceStateEvent.CreatedAt.set -> void
-NGitLab.Models.ResourceStateEvent.Id.get -> int
+NGitLab.Models.ResourceStateEvent.Id.get -> long
 NGitLab.Models.ResourceStateEvent.Id.set -> void
-NGitLab.Models.ResourceStateEvent.ResourceId.get -> int
+NGitLab.Models.ResourceStateEvent.ResourceId.get -> long
 NGitLab.Models.ResourceStateEvent.ResourceId.set -> void
 NGitLab.Models.ResourceStateEvent.ResourceStateEvent() -> void
 NGitLab.Models.ResourceStateEvent.ResourceType.get -> string
@@ -3562,7 +3492,7 @@ NGitLab.Models.Runner.Active -> bool
 NGitLab.Models.Runner.ContactedAt -> System.DateTime
 NGitLab.Models.Runner.Description -> string
 NGitLab.Models.Runner.Groups -> NGitLab.Models.Group[]
-NGitLab.Models.Runner.Id -> int
+NGitLab.Models.Runner.Id -> long
 NGitLab.Models.Runner.IpAddress -> string
 NGitLab.Models.Runner.IsShared -> bool
 NGitLab.Models.Runner.Locked -> bool
@@ -3577,9 +3507,9 @@ NGitLab.Models.Runner.TagList -> string[]
 NGitLab.Models.Runner.Token -> string
 NGitLab.Models.Runner.Version -> string
 NGitLab.Models.RunnerId
-NGitLab.Models.RunnerId.Id -> int
+NGitLab.Models.RunnerId.Id -> long
 NGitLab.Models.RunnerId.RunnerId() -> void
-NGitLab.Models.RunnerId.RunnerId(int id) -> void
+NGitLab.Models.RunnerId.RunnerId(long id) -> void
 NGitLab.Models.RunnerRegister
 NGitLab.Models.RunnerRegister.Active.get -> bool?
 NGitLab.Models.RunnerRegister.Active.set -> void
@@ -3619,7 +3549,7 @@ NGitLab.Models.SearchBlob.FileName.get -> string
 NGitLab.Models.SearchBlob.FileName.set -> void
 NGitLab.Models.SearchBlob.Path.get -> string
 NGitLab.Models.SearchBlob.Path.set -> void
-NGitLab.Models.SearchBlob.ProjectId.get -> int
+NGitLab.Models.SearchBlob.ProjectId.get -> long
 NGitLab.Models.SearchBlob.ProjectId.set -> void
 NGitLab.Models.SearchBlob.Ref.get -> NGitLab.Sha1
 NGitLab.Models.SearchBlob.Ref.set -> void
@@ -3647,7 +3577,7 @@ NGitLab.Models.Snippet.Description -> string
 NGitLab.Models.Snippet.FileName -> string
 NGitLab.Models.Snippet.Files.get -> NGitLab.Models.SnippetFile[]
 NGitLab.Models.Snippet.Files.set -> void
-NGitLab.Models.Snippet.Id -> int
+NGitLab.Models.Snippet.Id -> long
 NGitLab.Models.Snippet.Snippet() -> void
 NGitLab.Models.Snippet.Title -> string
 NGitLab.Models.Snippet.UpdatedAt -> string
@@ -3679,7 +3609,7 @@ NGitLab.Models.SnippetProjectCreate.Description -> string
 NGitLab.Models.SnippetProjectCreate.FileName -> string
 NGitLab.Models.SnippetProjectCreate.Files.get -> NGitLab.Models.SnippetCreateFile[]
 NGitLab.Models.SnippetProjectCreate.Files.set -> void
-NGitLab.Models.SnippetProjectCreate.ProjectId -> int
+NGitLab.Models.SnippetProjectCreate.ProjectId -> long
 NGitLab.Models.SnippetProjectCreate.SnippetProjectCreate() -> void
 NGitLab.Models.SnippetProjectCreate.Title -> string
 NGitLab.Models.SnippetProjectCreate.Visibility -> NGitLab.Models.VisibilityLevel
@@ -3689,8 +3619,8 @@ NGitLab.Models.SnippetProjectUpdate.Description -> string
 NGitLab.Models.SnippetProjectUpdate.FileName -> string
 NGitLab.Models.SnippetProjectUpdate.Files.get -> NGitLab.Models.SnippetUpdateFile[]
 NGitLab.Models.SnippetProjectUpdate.Files.set -> void
-NGitLab.Models.SnippetProjectUpdate.ProjectId -> int
-NGitLab.Models.SnippetProjectUpdate.SnippetId.get -> int
+NGitLab.Models.SnippetProjectUpdate.ProjectId -> long
+NGitLab.Models.SnippetProjectUpdate.SnippetId.get -> long
 NGitLab.Models.SnippetProjectUpdate.SnippetId.set -> void
 NGitLab.Models.SnippetProjectUpdate.SnippetProjectUpdate() -> void
 NGitLab.Models.SnippetProjectUpdate.Title -> string
@@ -3701,7 +3631,7 @@ NGitLab.Models.SnippetUpdate.Description -> string
 NGitLab.Models.SnippetUpdate.FileName -> string
 NGitLab.Models.SnippetUpdate.Files.get -> NGitLab.Models.SnippetUpdateFile[]
 NGitLab.Models.SnippetUpdate.Files.set -> void
-NGitLab.Models.SnippetUpdate.SnippetId.get -> int
+NGitLab.Models.SnippetUpdate.SnippetId.get -> long
 NGitLab.Models.SnippetUpdate.SnippetId.set -> void
 NGitLab.Models.SnippetUpdate.SnippetUpdate() -> void
 NGitLab.Models.SnippetUpdate.Title -> string
@@ -3728,7 +3658,7 @@ NGitLab.Models.SquashOption.DefaultOn = 3 -> NGitLab.Models.SquashOption
 NGitLab.Models.SquashOption.Never = 0 -> NGitLab.Models.SquashOption
 NGitLab.Models.SshKey
 NGitLab.Models.SshKey.CreateAt -> System.DateTime
-NGitLab.Models.SshKey.Id -> int
+NGitLab.Models.SshKey.Id -> long
 NGitLab.Models.SshKey.Key -> string
 NGitLab.Models.SshKey.SshKey() -> void
 NGitLab.Models.SshKey.Title -> string
@@ -3749,7 +3679,7 @@ NGitLab.Models.SubgroupQuery.Owned.get -> bool?
 NGitLab.Models.SubgroupQuery.Owned.set -> void
 NGitLab.Models.SubgroupQuery.Search.get -> string
 NGitLab.Models.SubgroupQuery.Search.set -> void
-NGitLab.Models.SubgroupQuery.SkipGroups.get -> int[]
+NGitLab.Models.SubgroupQuery.SkipGroups.get -> long[]
 NGitLab.Models.SubgroupQuery.SkipGroups.set -> void
 NGitLab.Models.SubgroupQuery.Sort.get -> string
 NGitLab.Models.SubgroupQuery.Sort.set -> void
@@ -3763,7 +3693,7 @@ NGitLab.Models.SystemHook.CreatedAt.get -> System.DateTime
 NGitLab.Models.SystemHook.CreatedAt.set -> void
 NGitLab.Models.SystemHook.EnableSslVerification.get -> bool
 NGitLab.Models.SystemHook.EnableSslVerification.set -> void
-NGitLab.Models.SystemHook.Id.get -> int
+NGitLab.Models.SystemHook.Id.get -> long
 NGitLab.Models.SystemHook.Id.set -> void
 NGitLab.Models.SystemHook.MergeRequestsEvents.get -> bool
 NGitLab.Models.SystemHook.MergeRequestsEvents.set -> void
@@ -3913,7 +3843,7 @@ NGitLab.Models.Tree.Type -> NGitLab.Models.ObjectType
 NGitLab.Models.Trigger
 NGitLab.Models.Trigger.CreatedAt -> System.DateTime
 NGitLab.Models.Trigger.Description -> string
-NGitLab.Models.Trigger.Id -> int
+NGitLab.Models.Trigger.Id -> long
 NGitLab.Models.Trigger.LastUsed -> System.DateTime
 NGitLab.Models.Trigger.Token -> string
 NGitLab.Models.Trigger.Trigger() -> void
@@ -3942,7 +3872,7 @@ NGitLab.Models.User.Blocked -> bool
 NGitLab.Models.User.Bot -> bool
 NGitLab.Models.User.CanCreateGroup -> bool
 NGitLab.Models.User.CanCreateProject -> bool
-NGitLab.Models.User.ColorSchemeId -> int
+NGitLab.Models.User.ColorSchemeId -> long
 NGitLab.Models.User.CommitEmail -> string
 NGitLab.Models.User.ConfirmedAt -> System.DateTime
 NGitLab.Models.User.CreatedAt -> System.DateTime
@@ -3953,7 +3883,7 @@ NGitLab.Models.User.ExternUid -> string
 NGitLab.Models.User.ExtraSharedRunnersMinutesLimit -> int
 NGitLab.Models.User.Followers -> int
 NGitLab.Models.User.Following -> int
-NGitLab.Models.User.Id -> int
+NGitLab.Models.User.Id -> long
 NGitLab.Models.User.Identities -> NGitLab.Models.Identity[]
 NGitLab.Models.User.IsAdmin -> bool
 NGitLab.Models.User.IsAuditor -> bool
@@ -3968,12 +3898,12 @@ NGitLab.Models.User.Organization -> string
 NGitLab.Models.User.PrivateProfile -> bool
 NGitLab.Models.User.ProjectsLimit -> int
 NGitLab.Models.User.Provider -> string
-NGitLab.Models.User.ProvisionedByGroupId -> int
+NGitLab.Models.User.ProvisionedByGroupId -> long
 NGitLab.Models.User.PublicEmail -> string
 NGitLab.Models.User.SharedRunnersMinutesLimit -> int
 NGitLab.Models.User.Skype -> string
 NGitLab.Models.User.State -> string
-NGitLab.Models.User.ThemeId -> int
+NGitLab.Models.User.ThemeId -> long
 NGitLab.Models.User.Twitter -> string
 NGitLab.Models.User.TwoFactorEnabled -> bool
 NGitLab.Models.User.User() -> void
@@ -3993,7 +3923,7 @@ NGitLab.Models.UserToken.CreatedAt.get -> System.DateTime
 NGitLab.Models.UserToken.CreatedAt.set -> void
 NGitLab.Models.UserToken.ExpiresAt.get -> System.DateTime?
 NGitLab.Models.UserToken.ExpiresAt.set -> void
-NGitLab.Models.UserToken.Id.get -> int
+NGitLab.Models.UserToken.Id.get -> long
 NGitLab.Models.UserToken.Id.set -> void
 NGitLab.Models.UserToken.Impersonation.get -> bool
 NGitLab.Models.UserToken.Impersonation.set -> void
@@ -4013,7 +3943,7 @@ NGitLab.Models.UserTokenCreate.Name.get -> string
 NGitLab.Models.UserTokenCreate.Name.set -> void
 NGitLab.Models.UserTokenCreate.Scopes.get -> string[]
 NGitLab.Models.UserTokenCreate.Scopes.set -> void
-NGitLab.Models.UserTokenCreate.UserId.get -> int
+NGitLab.Models.UserTokenCreate.UserId.get -> long
 NGitLab.Models.UserTokenCreate.UserId.set -> void
 NGitLab.Models.UserTokenCreate.UserTokenCreate() -> void
 NGitLab.Models.UserUpsert
@@ -4215,7 +4145,7 @@ static NGitLab.Models.ProjectId.operator ==(NGitLab.Models.Project a, NGitLab.Mo
 static NGitLab.Models.ProjectId.operator ==(NGitLab.Models.ProjectId a, NGitLab.Models.Project b) -> bool
 static NGitLab.Models.ProjectId.operator ==(NGitLab.Models.ProjectId a, NGitLab.Models.ProjectId b) -> bool
 static NGitLab.Models.QueryAssigneeId.Any.get -> NGitLab.Models.QueryAssigneeId
-static NGitLab.Models.QueryAssigneeId.implicit operator NGitLab.Models.QueryAssigneeId(int id) -> NGitLab.Models.QueryAssigneeId
+static NGitLab.Models.QueryAssigneeId.implicit operator NGitLab.Models.QueryAssigneeId(long id) -> NGitLab.Models.QueryAssigneeId
 static NGitLab.Models.QueryAssigneeId.None.get -> NGitLab.Models.QueryAssigneeId
 static NGitLab.RequestOptions.Default.get -> NGitLab.RequestOptions
 static NGitLab.Sha1.operator !=(NGitLab.Sha1 left, NGitLab.Sha1 right) -> bool

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1208,7 +1208,6 @@ NGitLab.Models.AccessLevel.Admin = 60 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.Developer = 30 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.Guest = 10 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.Maintainer = 40 -> NGitLab.Models.AccessLevel
-NGitLab.Models.AccessLevel.Master = 40 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.NoAccess = 0 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.Owner = 50 -> NGitLab.Models.AccessLevel
 NGitLab.Models.AccessLevel.Reporter = 20 -> NGitLab.Models.AccessLevel
@@ -1925,7 +1924,6 @@ NGitLab.Models.GroupId.Equals(NGitLab.Models.GroupId other) -> bool
 NGitLab.Models.GroupId.Equals(string otherPath, long otherId) -> bool
 NGitLab.Models.GroupId.GroupId() -> void
 NGitLab.Models.GroupId.GroupId(long id) -> void
-NGitLab.Models.GroupId.GroupId(NGitLab.Models.Group group) -> void
 NGitLab.Models.GroupId.GroupId(string path) -> void
 NGitLab.Models.GroupIdControl
 NGitLab.Models.GroupIdControl.GroupId.get -> long
@@ -3048,7 +3046,6 @@ NGitLab.Models.ProjectId.Equals(NGitLab.Models.ProjectId other) -> bool
 NGitLab.Models.ProjectId.Equals(string otherPath, long otherId) -> bool
 NGitLab.Models.ProjectId.ProjectId() -> void
 NGitLab.Models.ProjectId.ProjectId(long id) -> void
-NGitLab.Models.ProjectId.ProjectId(NGitLab.Models.Project project) -> void
 NGitLab.Models.ProjectId.ProjectId(string path) -> void
 NGitLab.Models.ProjectIssueNote
 NGitLab.Models.ProjectIssueNote.Attachment -> string
@@ -3146,9 +3143,8 @@ NGitLab.Models.ProjectQuery.UserId -> long?
 NGitLab.Models.ProjectQuery.Visibility -> NGitLab.Models.VisibilityLevel?
 NGitLab.Models.ProjectQueryScope
 NGitLab.Models.ProjectQueryScope.Accessible = 0 -> NGitLab.Models.ProjectQueryScope
-NGitLab.Models.ProjectQueryScope.All = 3 -> NGitLab.Models.ProjectQueryScope
+NGitLab.Models.ProjectQueryScope.All = 2 -> NGitLab.Models.ProjectQueryScope
 NGitLab.Models.ProjectQueryScope.Owned = 1 -> NGitLab.Models.ProjectQueryScope
-NGitLab.Models.ProjectQueryScope.Visible = 2 -> NGitLab.Models.ProjectQueryScope
 NGitLab.Models.ProjectStatistics
 NGitLab.Models.ProjectStatistics.CommitCount -> long
 NGitLab.Models.ProjectStatistics.JobArtifactsSize -> long
@@ -3488,7 +3484,6 @@ NGitLab.Models.ResourceStateEvent.State.set -> void
 NGitLab.Models.ResourceStateEvent.User.get -> NGitLab.Models.Author
 NGitLab.Models.ResourceStateEvent.User.set -> void
 NGitLab.Models.Runner
-NGitLab.Models.Runner.Active -> bool
 NGitLab.Models.Runner.ContactedAt -> System.DateTime
 NGitLab.Models.Runner.Description -> string
 NGitLab.Models.Runner.Groups -> NGitLab.Models.Group[]
@@ -3511,8 +3506,6 @@ NGitLab.Models.RunnerId.Id -> long
 NGitLab.Models.RunnerId.RunnerId() -> void
 NGitLab.Models.RunnerId.RunnerId(long id) -> void
 NGitLab.Models.RunnerRegister
-NGitLab.Models.RunnerRegister.Active.get -> bool?
-NGitLab.Models.RunnerRegister.Active.set -> void
 NGitLab.Models.RunnerRegister.Description.get -> string
 NGitLab.Models.RunnerRegister.Description.set -> void
 NGitLab.Models.RunnerRegister.Locked.get -> bool?
@@ -3533,7 +3526,6 @@ NGitLab.Models.RunnerScope.Paused = 3 -> NGitLab.Models.RunnerScope
 NGitLab.Models.RunnerScope.Shared = 1 -> NGitLab.Models.RunnerScope
 NGitLab.Models.RunnerScope.Specific = 0 -> NGitLab.Models.RunnerScope
 NGitLab.Models.RunnerUpdate
-NGitLab.Models.RunnerUpdate.Active -> bool?
 NGitLab.Models.RunnerUpdate.Description -> string
 NGitLab.Models.RunnerUpdate.Locked -> bool?
 NGitLab.Models.RunnerUpdate.Paused -> bool?
@@ -3574,7 +3566,6 @@ NGitLab.Models.Snippet
 NGitLab.Models.Snippet.Author -> NGitLab.Models.Author
 NGitLab.Models.Snippet.CreatedAt -> System.DateTime
 NGitLab.Models.Snippet.Description -> string
-NGitLab.Models.Snippet.FileName -> string
 NGitLab.Models.Snippet.Files.get -> NGitLab.Models.SnippetFile[]
 NGitLab.Models.Snippet.Files.set -> void
 NGitLab.Models.Snippet.Id -> long
@@ -3583,9 +3574,7 @@ NGitLab.Models.Snippet.Title -> string
 NGitLab.Models.Snippet.UpdatedAt -> string
 NGitLab.Models.Snippet.WebUrl -> string
 NGitLab.Models.SnippetCreate
-NGitLab.Models.SnippetCreate.Content -> string
 NGitLab.Models.SnippetCreate.Description -> string
-NGitLab.Models.SnippetCreate.FileName -> string
 NGitLab.Models.SnippetCreate.Files.get -> NGitLab.Models.SnippetCreateFile[]
 NGitLab.Models.SnippetCreate.Files.set -> void
 NGitLab.Models.SnippetCreate.SnippetCreate() -> void
@@ -3604,9 +3593,7 @@ NGitLab.Models.SnippetFile.RawUrl.get -> string
 NGitLab.Models.SnippetFile.RawUrl.set -> void
 NGitLab.Models.SnippetFile.SnippetFile() -> void
 NGitLab.Models.SnippetProjectCreate
-NGitLab.Models.SnippetProjectCreate.Code -> string
 NGitLab.Models.SnippetProjectCreate.Description -> string
-NGitLab.Models.SnippetProjectCreate.FileName -> string
 NGitLab.Models.SnippetProjectCreate.Files.get -> NGitLab.Models.SnippetCreateFile[]
 NGitLab.Models.SnippetProjectCreate.Files.set -> void
 NGitLab.Models.SnippetProjectCreate.ProjectId -> long
@@ -3614,9 +3601,7 @@ NGitLab.Models.SnippetProjectCreate.SnippetProjectCreate() -> void
 NGitLab.Models.SnippetProjectCreate.Title -> string
 NGitLab.Models.SnippetProjectCreate.Visibility -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.SnippetProjectUpdate
-NGitLab.Models.SnippetProjectUpdate.Code -> string
 NGitLab.Models.SnippetProjectUpdate.Description -> string
-NGitLab.Models.SnippetProjectUpdate.FileName -> string
 NGitLab.Models.SnippetProjectUpdate.Files.get -> NGitLab.Models.SnippetUpdateFile[]
 NGitLab.Models.SnippetProjectUpdate.Files.set -> void
 NGitLab.Models.SnippetProjectUpdate.ProjectId -> long
@@ -3626,9 +3611,7 @@ NGitLab.Models.SnippetProjectUpdate.SnippetProjectUpdate() -> void
 NGitLab.Models.SnippetProjectUpdate.Title -> string
 NGitLab.Models.SnippetProjectUpdate.Visibility -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.SnippetUpdate
-NGitLab.Models.SnippetUpdate.Content -> string
 NGitLab.Models.SnippetUpdate.Description -> string
-NGitLab.Models.SnippetUpdate.FileName -> string
 NGitLab.Models.SnippetUpdate.Files.get -> NGitLab.Models.SnippetUpdateFile[]
 NGitLab.Models.SnippetUpdate.Files.set -> void
 NGitLab.Models.SnippetUpdate.SnippetId.get -> long
@@ -3736,7 +3719,6 @@ NGitLab.Models.TagCreate
 NGitLab.Models.TagCreate.Message -> string
 NGitLab.Models.TagCreate.Name -> string
 NGitLab.Models.TagCreate.Ref -> string
-NGitLab.Models.TagCreate.ReleaseDescription -> string
 NGitLab.Models.TagCreate.TagCreate() -> void
 NGitLab.Models.TagProtect
 NGitLab.Models.TagProtect.AllowedToCreate.get -> NGitLab.Models.AccessControl[]
@@ -3868,7 +3850,6 @@ NGitLab.Models.User
 NGitLab.Models.User.AvatarURL -> string
 NGitLab.Models.User.Bio -> string
 NGitLab.Models.User.BioHtml -> string
-NGitLab.Models.User.Blocked -> bool
 NGitLab.Models.User.Bot -> bool
 NGitLab.Models.User.CanCreateGroup -> bool
 NGitLab.Models.User.CanCreateProject -> bool
@@ -3879,7 +3860,6 @@ NGitLab.Models.User.CreatedAt -> System.DateTime
 NGitLab.Models.User.CurrentSignIn -> System.DateTime
 NGitLab.Models.User.Email -> string
 NGitLab.Models.User.External -> bool
-NGitLab.Models.User.ExternUid -> string
 NGitLab.Models.User.ExtraSharedRunnersMinutesLimit -> int
 NGitLab.Models.User.Followers -> int
 NGitLab.Models.User.Following -> int
@@ -3897,7 +3877,6 @@ NGitLab.Models.User.Note -> string
 NGitLab.Models.User.Organization -> string
 NGitLab.Models.User.PrivateProfile -> bool
 NGitLab.Models.User.ProjectsLimit -> int
-NGitLab.Models.User.Provider -> string
 NGitLab.Models.User.ProvisionedByGroupId -> long
 NGitLab.Models.User.PublicEmail -> string
 NGitLab.Models.User.SharedRunnersMinutesLimit -> int
@@ -3978,8 +3957,6 @@ NGitLab.Models.Variable.Protected.get -> bool
 NGitLab.Models.Variable.Protected.set -> void
 NGitLab.Models.Variable.Raw.get -> bool
 NGitLab.Models.Variable.Raw.set -> void
-NGitLab.Models.Variable.Scope.get -> string
-NGitLab.Models.Variable.Scope.set -> void
 NGitLab.Models.Variable.Type.get -> NGitLab.Models.VariableType
 NGitLab.Models.Variable.Type.set -> void
 NGitLab.Models.Variable.Value.get -> string
@@ -4120,12 +4097,9 @@ static NGitLab.DynamicEnum<TEnum>.operator !=(NGitLab.DynamicEnum<TEnum> obj1, N
 static NGitLab.DynamicEnum<TEnum>.operator !=(NGitLab.DynamicEnum<TEnum> obj1, TEnum obj2) -> bool
 static NGitLab.DynamicEnum<TEnum>.operator ==(NGitLab.DynamicEnum<TEnum> obj1, NGitLab.DynamicEnum<TEnum> obj2) -> bool
 static NGitLab.DynamicEnum<TEnum>.operator ==(NGitLab.DynamicEnum<TEnum> obj1, TEnum obj2) -> bool
-static NGitLab.GitLabClient.Connect(string hostUrl, string apiToken) -> NGitLab.GitLabClient
-static NGitLab.GitLabClient.Connect(string hostUrl, string username, string password) -> NGitLab.GitLabClient
 static NGitLab.Models.FileData.Base64Decode(string base64EncodedData) -> string
 static NGitLab.Models.FileUpsert.Base64Encode(string plainText) -> string
 static NGitLab.Models.GroupId.implicit operator NGitLab.Models.GroupId(long id) -> NGitLab.Models.GroupId
-static NGitLab.Models.GroupId.implicit operator NGitLab.Models.GroupId(NGitLab.Models.Group group) -> NGitLab.Models.GroupId
 static NGitLab.Models.GroupId.implicit operator NGitLab.Models.GroupId(string path) -> NGitLab.Models.GroupId
 static NGitLab.Models.GroupId.operator !=(NGitLab.Models.Group a, NGitLab.Models.GroupId b) -> bool
 static NGitLab.Models.GroupId.operator !=(NGitLab.Models.GroupId a, NGitLab.Models.Group b) -> bool
@@ -4136,7 +4110,6 @@ static NGitLab.Models.GroupId.operator ==(NGitLab.Models.GroupId a, NGitLab.Mode
 static NGitLab.Models.IdOrPathExtensions.ValueAsString(this NGitLab.Models.IIdOrPathAddressable idOrPath) -> string
 static NGitLab.Models.IdOrPathExtensions.ValueAsUriParameter(this NGitLab.Models.IIdOrPathAddressable idOrPath) -> string
 static NGitLab.Models.ProjectId.implicit operator NGitLab.Models.ProjectId(long id) -> NGitLab.Models.ProjectId
-static NGitLab.Models.ProjectId.implicit operator NGitLab.Models.ProjectId(NGitLab.Models.Project project) -> NGitLab.Models.ProjectId
 static NGitLab.Models.ProjectId.implicit operator NGitLab.Models.ProjectId(string path) -> NGitLab.Models.ProjectId
 static NGitLab.Models.ProjectId.operator !=(NGitLab.Models.Project a, NGitLab.Models.ProjectId b) -> bool
 static NGitLab.Models.ProjectId.operator !=(NGitLab.Models.ProjectId a, NGitLab.Models.Project b) -> bool

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2987,7 +2987,8 @@ NGitLab.Models.ProjectCreate.MergeRequestsAccessLevel -> string
 NGitLab.Models.ProjectCreate.MergeRequestsEnabled -> bool
 NGitLab.Models.ProjectCreate.MergeTrainsEnabled -> bool
 NGitLab.Models.ProjectCreate.Name -> string
-NGitLab.Models.ProjectCreate.NamespaceId -> string
+NGitLab.Models.ProjectCreate.NamespaceId.get -> long?
+NGitLab.Models.ProjectCreate.NamespaceId.set -> void
 NGitLab.Models.ProjectCreate.Path -> string
 NGitLab.Models.ProjectCreate.ProjectCreate() -> void
 NGitLab.Models.ProjectCreate.SnippetsAccessLevel -> string


### PR DESCRIPTION
- Convert `int` IDs to `long`
- As this introduces breaking API changes, take the opportunity to
  - Remove some deprecated code
  - Fix ProjectCreate.NamespaceId's type

Fixes #491, #797