### PR TITLE
Issue model: Add UserNotesCount property

### DIFF
--- a/NGitLab/Models/Issue.cs
+++ b/NGitLab/Models/Issue.cs
@@ -76,4 +76,7 @@ public class Issue
 
     [JsonPropertyName("references")]
     public References References { get; set; }
+
+    [JsonPropertyName("user_notes_count")]
+    public int UserNotesCount { get; set; }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2269,6 +2269,8 @@ NGitLab.Models.Issue.Title.get -> string
 NGitLab.Models.Issue.Title.set -> void
 NGitLab.Models.Issue.UpdatedAt.get -> System.DateTime
 NGitLab.Models.Issue.UpdatedAt.set -> void
+NGitLab.Models.Issue.UserNotesCount.get -> int
+NGitLab.Models.Issue.UserNotesCount.set -> void
 NGitLab.Models.Issue.WebUrl.get -> string
 NGitLab.Models.Issue.WebUrl.set -> void
 NGitLab.Models.Issue.Weight.get -> int?


### PR DESCRIPTION
As can be seen in GitLab API documentation, Issue model has 'user_notes_count' property:
https://docs.gitlab.com/ee/api/issues.html

We need this property to see if issue has user comments (notes) and enable/disable 'Show comments' button depending on the value.

This PR adds UserNotesCount property to Issue model.