### PR TITLE
Add AutoStopAt to EnvironmentInfo

### DIFF
--- a/NGitLab/Models/EnvironmentInfo.cs
+++ b/NGitLab/Models/EnvironmentInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
@@ -21,4 +22,7 @@ public class EnvironmentInfo
 
     [JsonPropertyName("last_deployment")]
     public EnvironmentLastDeployment LastDeployment { get; set; }
+
+    [JsonPropertyName("auto_stop_at")]
+    public DateTime AutoStopAt { get; set;  }
 }

--- a/NGitLab/Models/EnvironmentInfo.cs
+++ b/NGitLab/Models/EnvironmentInfo.cs
@@ -24,5 +24,5 @@ public class EnvironmentInfo
     public EnvironmentLastDeployment LastDeployment { get; set; }
 
     [JsonPropertyName("auto_stop_at")]
-    public DateTime AutoStopAt { get; set;  }
+    public DateTime? AutoStopAt { get; set;  }
 }

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1710,7 +1710,7 @@ NGitLab.Models.DiffRefs.HeadSha.set -> void
 NGitLab.Models.DiffRefs.StartSha.get -> string
 NGitLab.Models.DiffRefs.StartSha.set -> void
 NGitLab.Models.EnvironmentInfo
-NGitLab.Models.EnvironmentInfo.AutoStopAt.get -> System.DateTime
+NGitLab.Models.EnvironmentInfo.AutoStopAt.get -> System.DateTime?
 NGitLab.Models.EnvironmentInfo.AutoStopAt.set -> void
 NGitLab.Models.EnvironmentInfo.EnvironmentInfo() -> void
 NGitLab.Models.EnvironmentInfo.ExternalUrl.get -> string

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -1710,6 +1710,8 @@ NGitLab.Models.DiffRefs.HeadSha.set -> void
 NGitLab.Models.DiffRefs.StartSha.get -> string
 NGitLab.Models.DiffRefs.StartSha.set -> void
 NGitLab.Models.EnvironmentInfo
+NGitLab.Models.EnvironmentInfo.AutoStopAt.get -> System.DateTime
+NGitLab.Models.EnvironmentInfo.AutoStopAt.set -> void
 NGitLab.Models.EnvironmentInfo.EnvironmentInfo() -> void
 NGitLab.Models.EnvironmentInfo.ExternalUrl.get -> string
 NGitLab.Models.EnvironmentInfo.ExternalUrl.set -> void


### PR DESCRIPTION
This PR adds AutoStopAt to EnvironmentInfo. 

GitLab environments have a property `auto_stop_at` which is not yet part of EnvironmentInfo in this client.

The file NGitLab/PublicAPI.Unshipped.txt has been updated as well to allow for the new property.