### PR TITLE
Expose GitLabClient without authentication

### DIFF
--- a/NGitLab.Tests/GitLabClientTests.cs
+++ b/NGitLab.Tests/GitLabClientTests.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NGitLab.Tests;
+
+public sealed class GitLabClientTests
+{
+    [Test]
+    public async Task ShouldWorkWithoutToken()
+    {
+        // https://gitlab.com/gitlab-org/gitlab
+        const long GitLabProjectId = 278964;
+
+        var client = new GitLabClient("https://gitlab.com");
+        var project = await client.Projects.GetByIdAsync(GitLabProjectId, new Models.SingleProjectQuery { Statistics = false});
+
+        Assert.That(project, Is.Not.Null);
+        Assert.That(project.Id, Is.EqualTo(GitLabProjectId));
+        Assert.That(project.Name, Is.EqualTo("GitLab"));
+    }
+}

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -51,7 +51,7 @@ public class GitLabClient : IGitLabClient
     }
 
     /// <summary>
-    /// Initialize a GitLab client without any authentication and default options
+    /// Initialize a GitLab client without any authentication
     /// </summary>
     /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
     public GitLabClient(string hostUrl)

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -50,21 +50,67 @@ public class GitLabClient : IGitLabClient
         set => _api.RequestOptions = value;
     }
 
+    /// <summary>
+    /// Initialize a GitLab client without any authentication and default options
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    public GitLabClient(string hostUrl)
+        : this(new GitLabCredentials(hostUrl), RequestOptions.Default)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a GitLab client without any authentication
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    /// <param name="options">Request options</param>
+    public GitLabClient(string hostUrl, RequestOptions options)
+       : this(new GitLabCredentials(hostUrl), options)
+    {
+    }
+
+    /// <summary>
+    /// Initialize an authenticated GitLab client
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    /// <param name="apiToken">Token to use in any request</param>
     public GitLabClient(string hostUrl, string apiToken)
         : this(hostUrl, apiToken, RequestOptions.Default)
     {
     }
 
+    /// <summary>
+    /// Initialize an authenticated GitLab client
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    /// <param name="userName">Username to connect with</param>
+    /// <param name="password">Password of the user account</param>
+    /// <remarks>
+    /// When using username/password, a <see cref="Session"/> will be created and its token will be used to authenticate
+    /// </remarks>
     public GitLabClient(string hostUrl, string userName, string password)
         : this(hostUrl, userName, password, RequestOptions.Default)
     {
     }
 
+    /// <summary>
+    /// Initialize an authenticated GitLab client
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    /// <param name="apiToken">Token to use in any request</param>
+    /// <param name="options">Request options</param>
     public GitLabClient(string hostUrl, string apiToken, RequestOptions options)
         : this(new GitLabCredentials(hostUrl, apiToken), options)
     {
     }
 
+    /// <summary>
+    /// Initialize an authenticated GitLab client
+    /// </summary>
+    /// <param name="hostUrl">GitLab absolute URL (with or without the /api/v* path)</param>
+    /// <param name="userName">Username to connect with</param>
+    /// <param name="password">Password of the user account</param>
+    /// <param name="options">Request options</param>
     public GitLabClient(string hostUrl, string userName, string password, RequestOptions options)
         : this(new GitLabCredentials(hostUrl, userName, password), options)
     {

--- a/NGitLab/Impl/API.cs
+++ b/NGitLab/Impl/API.cs
@@ -38,9 +38,22 @@ public class API
 
     protected virtual IHttpRequestor CreateRequestor(MethodType methodType)
     {
-        _credentials.ApiToken ??= OpenPrivateSession();
+        string token;
+        if (_credentials.AuthenticationMethod == AuthenticationMethod.ApiKey)
+        {
+            token = _credentials.ApiToken;
+        }
+        else if (_credentials.AuthenticationMethod == AuthenticationMethod.UsernamePassword)
+        {
+            _credentials.ApiToken ??= OpenPrivateSession();
+            token = _credentials.ApiToken;
+        }
+        else
+        {
+            token = null;
+        }
 
-        return new HttpRequestor(_credentials.HostUrl, _credentials.ApiToken, methodType, RequestOptions);
+        return new HttpRequestor(_credentials.HostUrl, token, methodType, RequestOptions);
     }
 
     private string OpenPrivateSession()

--- a/NGitLab/Impl/AuthenticationMethod.cs
+++ b/NGitLab/Impl/AuthenticationMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace NGitLab.Impl;
+
+internal enum AuthenticationMethod
+{
+    None,
+    ApiKey,
+    UsernamePassword,
+}

--- a/NGitLab/Impl/GitLabCredentials.cs
+++ b/NGitLab/Impl/GitLabCredentials.cs
@@ -14,11 +14,24 @@ public class GitLabCredentials
 {
     private string _apiToken;
 
+    internal AuthenticationMethod AuthenticationMethod { get; }
+
     public string HostUrl { get; }
 
     public string UserName { get; set; }
 
     public string Password { get; set; }
+
+    internal GitLabCredentials(string hostUrl)
+    {
+        if (string.IsNullOrEmpty(hostUrl))
+            throw new ArgumentException("HostUrl is mandatory", nameof(hostUrl));
+
+        ValidateHostUrl(hostUrl);
+
+        HostUrl = GetApiUrl(hostUrl);
+        AuthenticationMethod = AuthenticationMethod.None;
+    }
 
     public GitLabCredentials(string hostUrl, string apiToken)
     {
@@ -31,6 +44,7 @@ public class GitLabCredentials
 
         HostUrl = GetApiUrl(hostUrl);
         _apiToken = apiToken;
+        AuthenticationMethod = AuthenticationMethod.ApiKey;
     }
 
     public GitLabCredentials(string hostUrl, string userName, string password)
@@ -47,6 +61,7 @@ public class GitLabCredentials
         HostUrl = GetApiUrl(hostUrl);
         UserName = userName;
         Password = password;
+        AuthenticationMethod = AuthenticationMethod.UsernamePassword;
     }
 
     public string ApiToken

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -77,6 +77,8 @@ NGitLab.GitLabClient.GetRepository(NGitLab.Models.ProjectId projectId) -> NGitLa
 NGitLab.GitLabClient.GetTriggers(NGitLab.Models.ProjectId projectId) -> NGitLab.ITriggerClient
 NGitLab.GitLabClient.GetUserEvents(long userId) -> NGitLab.IEventClient
 NGitLab.GitLabClient.GetWikiClient(NGitLab.Models.ProjectId projectId) -> NGitLab.IWikiClient
+NGitLab.GitLabClient.GitLabClient(string hostUrl) -> void
+NGitLab.GitLabClient.GitLabClient(string hostUrl, NGitLab.RequestOptions options) -> void
 NGitLab.GitLabClient.GitLabClient(string hostUrl, string apiToken) -> void
 NGitLab.GitLabClient.GitLabClient(string hostUrl, string apiToken, NGitLab.RequestOptions options) -> void
 NGitLab.GitLabClient.GitLabClient(string hostUrl, string userName, string password) -> void


### PR DESCRIPTION
- References https://github.com/ubisoft/NGitLab/issues/840
- Add ctors to be able to get a GitLabClient without any authentication
- Didn't touch the actuall logic that, with username/password, set the ApiToken after getting a session