### PR TITLE
Support query parameters in members and labels searching endpoints

### DIFF
--- a/NGitLab.Mock/Clients/LabelClient.cs
+++ b/NGitLab.Mock/Clients/LabelClient.cs
@@ -150,7 +150,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public IEnumerable<Models.Label> ForGroup(long groupId)
+    public IEnumerable<Models.Label> ForGroup(long groupId, LabelQuery query = null)
     {
         using (Context.BeginOperationScope())
         {
@@ -159,7 +159,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    public IEnumerable<Models.Label> ForProject(long projectId)
+    public IEnumerable<Models.Label> ForProject(long projectId, LabelQuery query = null)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/LabelClient.cs
+++ b/NGitLab.Mock/Clients/LabelClient.cs
@@ -150,7 +150,12 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         });
     }
 
-    public IEnumerable<Models.Label> ForGroup(long groupId, LabelQuery query = null)
+    public IEnumerable<Models.Label> ForGroup(long groupId)
+    {
+        return ForGroup(groupId, query: null);
+    }
+
+    public IEnumerable<Models.Label> ForGroup(long groupId, LabelQuery query)
     {
         using (Context.BeginOperationScope())
         {
@@ -159,7 +164,12 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    public IEnumerable<Models.Label> ForProject(long projectId, LabelQuery query = null)
+    public IEnumerable<Models.Label> ForProject(long projectId)
+    {
+        return ForProject(projectId, query: null);
+    }
+
+    public IEnumerable<Models.Label> ForProject(long projectId, LabelQuery query)
     {
         using (Context.BeginOperationScope())
         {

--- a/NGitLab.Mock/Clients/MembersClient.cs
+++ b/NGitLab.Mock/Clients/MembersClient.cs
@@ -19,10 +19,15 @@ internal sealed class MembersClient : ClientBase, IMembersClient
 
     public IEnumerable<Membership> OfProject(string projectId)
     {
-        return OfProject(projectId, includeInheritedMembers: false);
+        return OfProject(projectId, includeInheritedMembers: false, query: null);
     }
 
-    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null)
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers)
+    {
+        return OfProject(projectId, includeInheritedMembers, query: null);
+    }
+
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query)
     {
         using (Context.BeginOperationScope())
         {
@@ -30,6 +35,11 @@ internal sealed class MembersClient : ClientBase, IMembersClient
             var members = project.GetEffectivePermissions(includeInheritedMembers).Permissions;
             return members.Select(member => member.ToMembershipClient());
         }
+    }
+
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers)
+    {
+        return OfProjectAsync(projectId, includeInheritedMembers, query: null);
     }
 
     public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null)
@@ -133,10 +143,15 @@ internal sealed class MembersClient : ClientBase, IMembersClient
 
     public IEnumerable<Membership> OfGroup(string groupId)
     {
-        return OfGroup(groupId, includeInheritedMembers: false);
+        return OfGroup(groupId, includeInheritedMembers: false, null);
     }
 
-    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null)
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
+    {
+        return OfGroup(groupId, includeInheritedMembers, query: null);
+    }
+
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query)
     {
         using (Context.BeginOperationScope())
         {
@@ -144,6 +159,11 @@ internal sealed class MembersClient : ClientBase, IMembersClient
             var members = group.GetEffectivePermissions(includeInheritedMembers).Permissions;
             return members.Select(member => member.ToMembershipClient());
         }
+    }
+
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers)
+    {
+        return OfGroupAsync(groupId, includeInheritedMembers, query: null);
     }
 
     public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null)

--- a/NGitLab.Mock/Clients/MembersClient.cs
+++ b/NGitLab.Mock/Clients/MembersClient.cs
@@ -22,7 +22,7 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         return OfProject(projectId, includeInheritedMembers: false);
     }
 
-    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers)
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null)
     {
         using (Context.BeginOperationScope())
         {
@@ -32,7 +32,7 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         }
     }
 
-    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false)
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null)
     {
         return GitLabCollectionResponse.Create(OfProject(projectId.ValueAsString(), includeInheritedMembers));
     }
@@ -136,7 +136,7 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         return OfGroup(groupId, includeInheritedMembers: false);
     }
 
-    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null)
     {
         using (Context.BeginOperationScope())
         {
@@ -146,7 +146,7 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         }
     }
 
-    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false)
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null)
     {
         return GitLabCollectionResponse.Create(OfGroup(groupId.ValueAsString(), includeInheritedMembers));
     }

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -11,14 +11,28 @@ public interface ILabelClient
     /// </summary>
     /// <param name="projectId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForProject(long projectId, LabelQuery labelQuery = null);
+    IEnumerable<Label> ForProject(long projectId);
+
+    /// <summary>
+    /// Return a list of labels for a project.
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <returns></returns>
+    IEnumerable<Label> ForProject(long projectId, LabelQuery labelQuery);
 
     /// <summary>
     /// Return a list of labels for a group.
     /// </summary>
     /// <param name="groupId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForGroup(long groupId, LabelQuery labelQuery = null);
+    IEnumerable<Label> ForGroup(long groupId);
+
+    /// <summary>
+    /// Return a list of labels for a group.
+    /// </summary>
+    /// <param name="groupId"></param>
+    /// <returns></returns>
+    IEnumerable<Label> ForGroup(long groupId, LabelQuery labelQuery);
 
     /// <summary>
     /// Return a specified label from the project or null;

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -11,14 +11,14 @@ public interface ILabelClient
     /// </summary>
     /// <param name="projectId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForProject(long projectId);
+    IEnumerable<Label> ForProject(long projectId, LabelQuery labelQuery = null);
 
     /// <summary>
     /// Return a list of labels for a group.
     /// </summary>
     /// <param name="groupId"></param>
     /// <returns></returns>
-    IEnumerable<Label> ForGroup(long groupId);
+    IEnumerable<Label> ForGroup(long groupId, LabelQuery labelQuery = null);
 
     /// <summary>
     /// Return a specified label from the project or null;

--- a/NGitLab/IMembersClient.cs
+++ b/NGitLab/IMembersClient.cs
@@ -13,9 +13,9 @@ public interface IMembersClient
 {
     IEnumerable<Membership> OfProject(string projectId);
 
-    IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers);
+    IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null);
 
-    GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false);
+    GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null);
 
     Membership GetMemberOfProject(string projectId, string userId);
 
@@ -38,9 +38,9 @@ public interface IMembersClient
 
     IEnumerable<Membership> OfGroup(string groupId);
 
-    IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers);
+    IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null);
 
-    GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false);
+    GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null);
 
     Membership GetMemberOfGroup(string groupId, string userId);
 

--- a/NGitLab/IMembersClient.cs
+++ b/NGitLab/IMembersClient.cs
@@ -13,7 +13,11 @@ public interface IMembersClient
 {
     IEnumerable<Membership> OfProject(string projectId);
 
-    IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null);
+    IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers);
+
+    IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query);
+
+    GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers);
 
     GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null);
 
@@ -38,7 +42,11 @@ public interface IMembersClient
 
     IEnumerable<Membership> OfGroup(string groupId);
 
-    IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null);
+    IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers);
+
+    IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query);
+
+    GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers);
 
     GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null);
 

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -19,19 +19,39 @@ public class LabelClient : ILabelClient
         _api = api;
     }
 
-    public IEnumerable<Label> ForProject(long projectId)
+    public IEnumerable<Label> ForProject(long projectId, LabelQuery query = null)
     {
-        return _api.Get().GetAll<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
+        string url = string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId);
+
+        if (query != null)
+        {
+            url = Utils.AddParameter(url, "with_counts", query.WithCounts);
+            url = Utils.AddParameter(url, "per_page", query.PerPage);
+            url = Utils.AddParameter(url, "search", query.Search);
+            url = Utils.AddParameter(url, "include_ancestor_groups ", query.IncludeAncestorGroups);
+        }
+
+        return _api.Get().GetAll<Label>(url);
     }
 
-    public IEnumerable<Label> ForGroup(long groupId)
+    public IEnumerable<Label> ForGroup(long groupId, LabelQuery query = null)
     {
-        return _api.Get().GetAll<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
+        string url = string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId);
+
+        if (query != null)
+        {
+            url = Utils.AddParameter(url, "with_counts", query.WithCounts);
+            url = Utils.AddParameter(url, "per_page", query.PerPage);
+            url = Utils.AddParameter(url, "search", query.Search);
+            url = Utils.AddParameter(url, "include_ancestor_groups ", query.IncludeAncestorGroups);
+        }
+
+        return _api.Get().GetAll<Label>(url);
     }
 
     public Label GetProjectLabel(long projectId, string name)
     {
-        return ForProject(projectId).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
+        return ForProject(projectId, new LabelQuery() { Search = name }).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -42,7 +62,7 @@ public class LabelClient : ILabelClient
 
     public Label GetGroupLabel(long groupId, string name)
     {
-        return ForGroup(groupId).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
+        return ForGroup(groupId, new LabelQuery() { Search = name }).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
     public Label CreateProjectLabel(long projectId, ProjectLabelCreate label)

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -26,15 +26,7 @@ public class LabelClient : ILabelClient
 
     public IEnumerable<Label> ForProject(long projectId, LabelQuery query)
     {
-        string url = string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId);
-
-        if (query != null)
-        {
-            url = Utils.AddParameter(url, "with_counts", query.WithCounts);
-            url = Utils.AddParameter(url, "per_page", query.PerPage);
-            url = Utils.AddParameter(url, "search", query.Search);
-            url = Utils.AddParameter(url, "include_ancestor_groups ", query.IncludeAncestorGroups);
-        }
+        string url = AddLabelParameterQuery(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId), query);
 
         return _api.Get().GetAll<Label>(url);
     }
@@ -46,15 +38,7 @@ public class LabelClient : ILabelClient
 
     public IEnumerable<Label> ForGroup(long groupId, LabelQuery query)
     {
-        string url = string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId);
-
-        if (query != null)
-        {
-            url = Utils.AddParameter(url, "with_counts", query.WithCounts);
-            url = Utils.AddParameter(url, "per_page", query.PerPage);
-            url = Utils.AddParameter(url, "search", query.Search);
-            url = Utils.AddParameter(url, "include_ancestor_groups ", query.IncludeAncestorGroups);
-        }
+        string url = AddLabelParameterQuery(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId), query);
 
         return _api.Get().GetAll<Label>(url);
     }
@@ -154,5 +138,20 @@ public class LabelClient : ILabelClient
             Id = label.Id,
             Name = label.Name,
         });
+    }
+
+    private static string AddLabelParameterQuery(string url, LabelQuery query)
+    {
+        if (query == null)
+        {
+            return url;
+        }
+
+        url = Utils.AddParameter(url, "with_counts", query.WithCounts);
+        url = Utils.AddParameter(url, "per_page", query.PerPage);
+        url = Utils.AddParameter(url, "search", query.Search);
+        url = Utils.AddParameter(url, "include_ancestor_groups ", query.IncludeAncestorGroups);
+
+        return url;
     }
 }

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -19,7 +19,12 @@ public class LabelClient : ILabelClient
         _api = api;
     }
 
-    public IEnumerable<Label> ForProject(long projectId, LabelQuery query = null)
+    public IEnumerable<Label> ForProject(long projectId)
+    {
+        return ForProject(projectId, query: null);
+    }
+
+    public IEnumerable<Label> ForProject(long projectId, LabelQuery query)
     {
         string url = string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId);
 
@@ -34,7 +39,12 @@ public class LabelClient : ILabelClient
         return _api.Get().GetAll<Label>(url);
     }
 
-    public IEnumerable<Label> ForGroup(long groupId, LabelQuery query = null)
+    public IEnumerable<Label> ForGroup(long groupId)
+    {
+        return ForGroup(groupId, query: null);
+    }
+
+    public IEnumerable<Label> ForGroup(long groupId, LabelQuery query)
     {
         string url = string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId);
 

--- a/NGitLab/Impl/MembersClient.cs
+++ b/NGitLab/Impl/MembersClient.cs
@@ -19,41 +19,14 @@ public class MembersClient : IMembersClient
 
     private IEnumerable<Membership> GetAll(string url, bool includeInheritedMembers, MemberQuery query)
     {
-        url += "/members";
-        if (includeInheritedMembers)
-        {
-            url += "/all";
-
-        }
-
-        if (query != null)
-        {
-            url = Utils.AddParameter(url, "user_ids", query.UserIds);
-            url = Utils.AddParameter(url, "state", query.State);
-            url = Utils.AddParameter(url, "per_page ", query.PerPage);
-            url = Utils.AddParameter(url, "query", query.Query);
-            url = Utils.AddParameter(url, "show_seat_info", query.ShowSeatInfo);
-        }
+        url = GetMemberUrlWithQueryParameters(url, includeInheritedMembers, query);
 
         return _api.Get().GetAll<Membership>(url);
     }
 
     private GitLabCollectionResponse<Membership> GetAllAsync(string url, bool includeInheritedMembers, MemberQuery query)
     {
-        url += "/members";
-        if (includeInheritedMembers)
-        {
-            url += "/all";
-        }
-
-        if (query != null)
-        {
-            url = Utils.AddParameter(url, "user_ids", query.UserIds);
-            url = Utils.AddParameter(url, "state", query.State);
-            url = Utils.AddParameter(url, "per_page ", query.PerPage);
-            url = Utils.AddParameter(url, "query", query.Query);
-            url = Utils.AddParameter(url, "show_seat_info", query.ShowSeatInfo);
-        }
+        url = GetMemberUrlWithQueryParameters(url, includeInheritedMembers, query);
 
         return _api.Get().GetAllAsync<Membership>(url);
     }
@@ -196,5 +169,26 @@ public class MembersClient : IMembersClient
     public Task RemoveMemberFromGroupAsync(GroupId groupId, long userId, CancellationToken cancellationToken = default)
     {
         return _api.Delete().ExecuteAsync($"{Group.Url}/{groupId.ValueAsUriParameter()}/members/{userId.ToStringInvariant()}", cancellationToken);
+    }
+
+    private static string GetMemberUrlWithQueryParameters(string url, bool includeInheritedMembers, MemberQuery query)
+    {
+        url += "/members";
+        if (includeInheritedMembers)
+        {
+            url += "/all";
+        }
+
+        if (query != null)
+        {
+            url = Utils.AddParameter(url, "user_ids", query.UserIds);
+            url = Utils.AddParameter(url, "state", query.State);
+            url = Utils.AddParameter(url, "per_page ", query.PerPage);
+            url = Utils.AddParameter(url, "query", query.Query);
+            url = Utils.AddParameter(url, "show_seat_info", query.ShowSeatInfo);
+            url = Utils.AddParameter(url, "skip_users", query.SkipUsers);
+        }
+
+        return url;
     }
 }

--- a/NGitLab/Impl/MembersClient.cs
+++ b/NGitLab/Impl/MembersClient.cs
@@ -17,7 +17,28 @@ public class MembersClient : IMembersClient
         _api = api;
     }
 
-    private IEnumerable<Membership> GetAll(string url, bool includeInheritedMembers)
+    private IEnumerable<Membership> GetAll(string url, bool includeInheritedMembers, MemberQuery query)
+    {
+        url += "/members";
+        if (includeInheritedMembers)
+        {
+            url += "/all";
+
+        }
+
+        if (query != null)
+        {
+            url = Utils.AddParameter(url, "user_ids", query.UserIds);
+            url = Utils.AddParameter(url, "state", query.State);
+            url = Utils.AddParameter(url, "per_page ", query.PerPage);
+            url = Utils.AddParameter(url, "query", query.Query);
+            url = Utils.AddParameter(url, "show_seat_info", query.ShowSeatInfo);
+        }
+
+        return _api.Get().GetAll<Membership>(url);
+    }
+
+    private GitLabCollectionResponse<Membership> GetAllAsync(string url, bool includeInheritedMembers, MemberQuery query)
     {
         url += "/members";
         if (includeInheritedMembers)
@@ -25,15 +46,13 @@ public class MembersClient : IMembersClient
             url += "/all";
         }
 
-        return _api.Get().GetAll<Membership>(url);
-    }
-
-    private GitLabCollectionResponse<Membership> GetAllAsync(string url, bool includeInheritedMembers)
-    {
-        url += "/members";
-        if (includeInheritedMembers)
+        if (query != null)
         {
-            url += "/all";
+            url = Utils.AddParameter(url, "user_ids", query.UserIds);
+            url = Utils.AddParameter(url, "state", query.State);
+            url = Utils.AddParameter(url, "per_page ", query.PerPage);
+            url = Utils.AddParameter(url, "query", query.Query);
+            url = Utils.AddParameter(url, "show_seat_info", query.ShowSeatInfo);
         }
 
         return _api.Get().GetAllAsync<Membership>(url);
@@ -41,17 +60,17 @@ public class MembersClient : IMembersClient
 
     public IEnumerable<Membership> OfProject(string projectId)
     {
-        return OfProject(projectId, includeInheritedMembers: false);
+        return OfProject(projectId, includeInheritedMembers: false, null);
     }
 
-    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers)
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null)
     {
-        return GetAll($"{Project.Url}/{WebUtility.UrlEncode(projectId)}", includeInheritedMembers);
+        return GetAll($"{Project.Url}/{WebUtility.UrlEncode(projectId)}", includeInheritedMembers, query);
     }
 
-    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false)
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null)
     {
-        return GetAllAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}", includeInheritedMembers);
+        return GetAllAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}", includeInheritedMembers, query);
     }
 
     public Membership GetMemberOfProject(string projectId, string userId)
@@ -104,17 +123,17 @@ public class MembersClient : IMembersClient
 
     public IEnumerable<Membership> OfGroup(string groupId)
     {
-        return OfGroup(groupId, includeInheritedMembers: false);
+        return OfGroup(groupId, includeInheritedMembers: false, null);
     }
 
-    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null)
     {
-        return GetAll($"{Group.Url}/{WebUtility.UrlEncode(groupId)}", includeInheritedMembers);
+        return GetAll($"{Group.Url}/{WebUtility.UrlEncode(groupId)}", includeInheritedMembers, query);
     }
 
-    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false)
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null)
     {
-        return GetAllAsync($"{Group.Url}/{groupId.ValueAsUriParameter()}", includeInheritedMembers);
+        return GetAllAsync($"{Group.Url}/{groupId.ValueAsUriParameter()}", includeInheritedMembers, query);
     }
 
     public Membership GetMemberOfGroup(string groupId, string userId)

--- a/NGitLab/Impl/MembersClient.cs
+++ b/NGitLab/Impl/MembersClient.cs
@@ -60,12 +60,22 @@ public class MembersClient : IMembersClient
 
     public IEnumerable<Membership> OfProject(string projectId)
     {
-        return OfProject(projectId, includeInheritedMembers: false, null);
+        return OfProject(projectId, includeInheritedMembers: false, query: null);
     }
 
-    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query = null)
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers)
+    {
+        return OfProject(projectId, includeInheritedMembers, query: null);
+    }
+
+    public IEnumerable<Membership> OfProject(string projectId, bool includeInheritedMembers, MemberQuery query)
     {
         return GetAll($"{Project.Url}/{WebUtility.UrlEncode(projectId)}", includeInheritedMembers, query);
+    }
+
+    public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers)
+    {
+        return OfProjectAsync(projectId, includeInheritedMembers, query: null);
     }
 
     public GitLabCollectionResponse<Membership> OfProjectAsync(ProjectId projectId, bool includeInheritedMembers = false, MemberQuery query = null)
@@ -126,9 +136,19 @@ public class MembersClient : IMembersClient
         return OfGroup(groupId, includeInheritedMembers: false, null);
     }
 
-    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query = null)
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers)
+    {
+        return OfGroup(groupId, includeInheritedMembers, query: null);
+    }
+
+    public IEnumerable<Membership> OfGroup(string groupId, bool includeInheritedMembers, MemberQuery query)
     {
         return GetAll($"{Group.Url}/{WebUtility.UrlEncode(groupId)}", includeInheritedMembers, query);
+    }
+
+    public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers)
+    {
+        return OfGroupAsync(groupId, includeInheritedMembers, query: null);
     }
 
     public GitLabCollectionResponse<Membership> OfGroupAsync(GroupId groupId, bool includeInheritedMembers = false, MemberQuery query = null)

--- a/NGitLab/Impl/UserClient.cs
+++ b/NGitLab/Impl/UserClient.cs
@@ -65,6 +65,10 @@ public class UserClient : IUserClient
         url = Utils.AddParameter(url, "with_custom_attributes", query.WithCustomAttributes);
         url = Utils.AddParameter(url, "two_factor", query.TwoFactor);
         url = Utils.AddParameter(url, "admins", query.IsAdmin);
+        url = Utils.AddParameter(url, "humans", query.IsHuman);
+        url = Utils.AddParameter(url, "exclude_active", query.ExcludeActive);
+        url = Utils.AddParameter(url, "exclude_humans", query.ExcludeHumans);
+        url = Utils.AddParameter(url, "exclude_internal", query.ExcludeInternal);
 
         return _api.Get().GetAll<User>(url);
     }

--- a/NGitLab/Models/Label.cs
+++ b/NGitLab/Models/Label.cs
@@ -14,11 +14,11 @@ public class Label
     public string Description { get; set; }
 
     [JsonPropertyName("open_issues_count")]
-    public string OpenIssuesCount { get; set; }
+    public int OpenIssuesCount { get; set; }
 
     [JsonPropertyName("closed_issues_count")]
-    public string ClosedIssuesCount { get; set; }
+    public int ClosedIssuesCount { get; set; }
 
     [JsonPropertyName("open_merge_requests_count")]
-    public string OpenMergeRequestsCount { get; set; }
+    public int OpenMergeRequestsCount { get; set; }
 }

--- a/NGitLab/Models/Label.cs
+++ b/NGitLab/Models/Label.cs
@@ -12,4 +12,13 @@ public class Label
 
     [JsonPropertyName("description")]
     public string Description { get; set; }
+
+    [JsonPropertyName("open_issues_count")]
+    public string OpenIssuesCount { get; set; }
+
+    [JsonPropertyName("closed_issues_count")]
+    public string ClosedIssuesCount { get; set; }
+
+    [JsonPropertyName("open_merge_requests_count")]
+    public string OpenMergeRequestsCount { get; set; }
 }

--- a/NGitLab/Models/LabelQuery.cs
+++ b/NGitLab/Models/LabelQuery.cs
@@ -1,0 +1,24 @@
+﻿namespace NGitLab.Models;
+
+public class LabelQuery
+{
+    /// <summary>
+    /// Specifies how many records per page (GitLab supports a maximum of 100 items per page and defaults to 20).
+    /// </summary>
+    public int? PerPage { get; set; }
+
+    /// <summary>
+    /// Keyword to filter labels by.
+    /// </summary>
+    public string Search { get; set; }
+
+    /// <summary>
+    /// Include ancestor groups. Defaults to true.
+    /// </summary>
+    public bool? IncludeAncestorGroups { get; set; }
+
+    /// <summary>
+    /// Whether or not to include issue and merge request counts. Defaults to false.
+    /// </summary>
+    public bool? WithCounts { get; set; }
+}

--- a/NGitLab/Models/MemberQuery.cs
+++ b/NGitLab/Models/MemberQuery.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace NGitLab.Models;
+﻿namespace NGitLab.Models;
 
 public class MemberQuery
 {
@@ -17,12 +15,12 @@ public class MemberQuery
     /// <summary>
     /// Filter the results on the given user IDs.
     /// </summary>
-    public List<int> UserIds { get; set; }
+    public long[] UserIds { get; set; }
 
     /// <summary>
     /// Filter skipped users out of the results.
     /// </summary>
-    public List<int> SkipUsers { get; set; }
+    public long[] SkipUsers { get; set; }
 
     /// <summary>
     /// Filter results by member state, one of awaiting or active. Premium and Ultimate only.

--- a/NGitLab/Models/MemberQuery.cs
+++ b/NGitLab/Models/MemberQuery.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+namespace NGitLab.Models;
+
+public class MemberQuery
+{
+    /// <summary>
+    /// Specifies how many records per page (GitLab supports a maximum of 100 items per page and defaults to 20).
+    /// </summary>
+    public int? PerPage { get; set; }
+
+    /// <summary>
+    /// Filters results based on a given name, email, or username. Use partial values to widen the scope of the query.
+    /// </summary>
+    public string Query { get; set; }
+
+    /// <summary>
+    /// Filter the results on the given user IDs.
+    /// </summary>
+    public List<int> UserIds { get; set; }
+
+    /// <summary>
+    /// Filter skipped users out of the results.
+    /// </summary>
+    public List<int> SkipUsers { get; set; }
+
+    /// <summary>
+    /// Filter results by member state, one of awaiting or active. Premium and Ultimate only.
+    /// </summary>
+    public string State { get; set; }
+
+    /// <summary>
+    /// Show seat information for users.
+    /// </summary>
+    public bool? ShowSeatInfo { get; set; }
+}

--- a/NGitLab/Models/UserQuery.cs
+++ b/NGitLab/Models/UserQuery.cs
@@ -36,9 +36,29 @@ public class UserQuery
     public bool? IsExternal { get; set; }
 
     /// <summary>
-    /// Exclude external users
+    /// If true, get regular users that are not bot or internal users.
+    /// </summary>
+    public bool? IsHuman { get; set; }
+
+    /// <summary>
+    /// Exclude external users.
     /// </summary>
     public bool? ExcludeExternal { get; set; }
+
+    /// <summary>
+    /// Exclude internal users.
+    /// </summary>
+    public bool? ExcludeInternal { get; set; }
+
+    /// <summary>
+    /// Exclude active users.
+    /// </summary>
+    public bool? ExcludeActive { get; set; }
+
+    /// <summary>
+    /// Exclude regular users that are not bot or internal users.
+    /// </summary>
+    public bool? ExcludeHumans { get; set; }
 
     /// <summary>
     /// (Admin only) Return projects ordered by id, name, username, created_at, or updated_at. Default is id.

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -348,8 +348,10 @@ NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Labe
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
@@ -368,12 +370,16 @@ NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId) -> NG
 NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
 NGitLab.IMembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IMembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IMembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership
@@ -647,8 +653,10 @@ NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
@@ -670,12 +678,16 @@ NGitLab.Impl.MembersClient.GetMemberOfProject(string projectId, string userId, b
 NGitLab.Impl.MembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.MembersClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.MembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.MembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.MembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2629,11 +2629,11 @@ NGitLab.Models.MemberQuery.Query.get -> string
 NGitLab.Models.MemberQuery.Query.set -> void
 NGitLab.Models.MemberQuery.ShowSeatInfo.get -> bool?
 NGitLab.Models.MemberQuery.ShowSeatInfo.set -> void
-NGitLab.Models.MemberQuery.SkipUsers.get -> System.Collections.Generic.List<int>
+NGitLab.Models.MemberQuery.SkipUsers.get -> long[]
 NGitLab.Models.MemberQuery.SkipUsers.set -> void
 NGitLab.Models.MemberQuery.State.get -> string
 NGitLab.Models.MemberQuery.State.set -> void
-NGitLab.Models.MemberQuery.UserIds.get -> System.Collections.Generic.List<int>
+NGitLab.Models.MemberQuery.UserIds.get -> long[]
 NGitLab.Models.MemberQuery.UserIds.set -> void
 NGitLab.Models.Membership
 NGitLab.Models.Membership.AccessLevel.get -> int

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2540,7 +2540,7 @@ NGitLab.Models.JobScopeMask.Running = 4 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Skipped = 64 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Success = 16 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.Label
-NGitLab.Models.Label.ClosedIssuesCount.get -> string
+NGitLab.Models.Label.ClosedIssuesCount.get -> int
 NGitLab.Models.Label.ClosedIssuesCount.set -> void
 NGitLab.Models.Label.Color.get -> string
 NGitLab.Models.Label.Color.set -> void
@@ -2549,9 +2549,9 @@ NGitLab.Models.Label.Description.set -> void
 NGitLab.Models.Label.Label() -> void
 NGitLab.Models.Label.Name.get -> string
 NGitLab.Models.Label.Name.set -> void
-NGitLab.Models.Label.OpenIssuesCount.get -> string
+NGitLab.Models.Label.OpenIssuesCount.get -> int
 NGitLab.Models.Label.OpenIssuesCount.set -> void
-NGitLab.Models.Label.OpenMergeRequestsCount.get -> string
+NGitLab.Models.Label.OpenMergeRequestsCount.get -> int
 NGitLab.Models.Label.OpenMergeRequestsCount.set -> void
 NGitLab.Models.LabelCreate
 NGitLab.Models.LabelCreate.Color.get -> string

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -348,8 +348,8 @@ NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Labe
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
@@ -368,12 +368,12 @@ NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId) -> NG
 NGitLab.IMembersClient.GetMemberOfProject(string projectId, string userId, bool includeInheritedMembers) -> NGitLab.Models.Membership
 NGitLab.IMembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.IMembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IMembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IMembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership
@@ -647,8 +647,8 @@ NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.ForGroup(long groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
-NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
+NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
@@ -670,12 +670,12 @@ NGitLab.Impl.MembersClient.GetMemberOfProject(string projectId, string userId, b
 NGitLab.Impl.MembersClient.GetMemberOfProjectAsync(NGitLab.Models.ProjectId projectId, long userId, bool includeInheritedMembers = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.MembersClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.MembersClient.OfGroup(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query = null) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
+NGitLab.Impl.MembersClient.OfProjectAsync(NGitLab.Models.ProjectId projectId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.RemoveMemberFromGroupAsync(NGitLab.Models.GroupId groupId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.MembersClient.RemoveMemberFromProjectAsync(NGitLab.Models.ProjectId projectId, long userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.MembersClient.UpdateMemberOfGroup(string groupId, NGitLab.Models.GroupMemberUpdate user) -> NGitLab.Models.Membership
@@ -2563,6 +2563,16 @@ NGitLab.Models.LabelEdit.Name.get -> string
 NGitLab.Models.LabelEdit.Name.set -> void
 NGitLab.Models.LabelEdit.NewName.get -> string
 NGitLab.Models.LabelEdit.NewName.set -> void
+NGitLab.Models.LabelQuery
+NGitLab.Models.LabelQuery.IncludeAncestorGroups.get -> bool?
+NGitLab.Models.LabelQuery.IncludeAncestorGroups.set -> void
+NGitLab.Models.LabelQuery.LabelQuery() -> void
+NGitLab.Models.LabelQuery.PerPage.get -> int?
+NGitLab.Models.LabelQuery.PerPage.set -> void
+NGitLab.Models.LabelQuery.Search.get -> string
+NGitLab.Models.LabelQuery.Search.set -> void
+NGitLab.Models.LabelQuery.WithCounts.get -> bool?
+NGitLab.Models.LabelQuery.WithCounts.set -> void
 NGitLab.Models.LastActivityDate
 NGitLab.Models.LastActivityDate.LastActivityDate() -> void
 NGitLab.Models.LastActivityDate.LastActivityOn.get -> System.DateTimeOffset
@@ -2593,6 +2603,20 @@ NGitLab.Models.LintCIOptions.IncludeJobs.set -> void
 NGitLab.Models.LintCIOptions.LintCIOptions() -> void
 NGitLab.Models.LintCIOptions.Ref.get -> string
 NGitLab.Models.LintCIOptions.Ref.set -> void
+NGitLab.Models.MemberQuery
+NGitLab.Models.MemberQuery.MemberQuery() -> void
+NGitLab.Models.MemberQuery.PerPage.get -> int?
+NGitLab.Models.MemberQuery.PerPage.set -> void
+NGitLab.Models.MemberQuery.Query.get -> string
+NGitLab.Models.MemberQuery.Query.set -> void
+NGitLab.Models.MemberQuery.ShowSeatInfo.get -> bool?
+NGitLab.Models.MemberQuery.ShowSeatInfo.set -> void
+NGitLab.Models.MemberQuery.SkipUsers.get -> System.Collections.Generic.List<int>
+NGitLab.Models.MemberQuery.SkipUsers.set -> void
+NGitLab.Models.MemberQuery.State.get -> string
+NGitLab.Models.MemberQuery.State.set -> void
+NGitLab.Models.MemberQuery.UserIds.get -> System.Collections.Generic.List<int>
+NGitLab.Models.MemberQuery.UserIds.set -> void
 NGitLab.Models.Membership
 NGitLab.Models.Membership.AccessLevel.get -> int
 NGitLab.Models.Membership.AccessLevel.set -> void
@@ -4827,8 +4851,14 @@ NGitLab.UserQuery.CreatedAfter.get -> System.DateTime?
 NGitLab.UserQuery.CreatedAfter.set -> void
 NGitLab.UserQuery.CreatedBefore.get -> System.DateTime?
 NGitLab.UserQuery.CreatedBefore.set -> void
+NGitLab.UserQuery.ExcludeActive.get -> bool?
+NGitLab.UserQuery.ExcludeActive.set -> void
 NGitLab.UserQuery.ExcludeExternal.get -> bool?
 NGitLab.UserQuery.ExcludeExternal.set -> void
+NGitLab.UserQuery.ExcludeHumans.get -> bool?
+NGitLab.UserQuery.ExcludeHumans.set -> void
+NGitLab.UserQuery.ExcludeInternal.get -> bool?
+NGitLab.UserQuery.ExcludeInternal.set -> void
 NGitLab.UserQuery.ExternalUid.get -> string
 NGitLab.UserQuery.ExternalUid.set -> void
 NGitLab.UserQuery.IsActive.get -> bool?
@@ -4839,6 +4869,8 @@ NGitLab.UserQuery.IsBlocked.get -> bool?
 NGitLab.UserQuery.IsBlocked.set -> void
 NGitLab.UserQuery.IsExternal.get -> bool?
 NGitLab.UserQuery.IsExternal.set -> void
+NGitLab.UserQuery.IsHuman.get -> bool?
+NGitLab.UserQuery.IsHuman.set -> void
 NGitLab.UserQuery.OrderBy.get -> string
 NGitLab.UserQuery.OrderBy.set -> void
 NGitLab.UserQuery.PerPage.get -> int?

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -2540,6 +2540,8 @@ NGitLab.Models.JobScopeMask.Running = 4 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Skipped = 64 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Success = 16 -> NGitLab.Models.JobScopeMask
 NGitLab.Models.Label
+NGitLab.Models.Label.ClosedIssuesCount.get -> string
+NGitLab.Models.Label.ClosedIssuesCount.set -> void
 NGitLab.Models.Label.Color.get -> string
 NGitLab.Models.Label.Color.set -> void
 NGitLab.Models.Label.Description.get -> string
@@ -2547,6 +2549,10 @@ NGitLab.Models.Label.Description.set -> void
 NGitLab.Models.Label.Label() -> void
 NGitLab.Models.Label.Name.get -> string
 NGitLab.Models.Label.Name.set -> void
+NGitLab.Models.Label.OpenIssuesCount.get -> string
+NGitLab.Models.Label.OpenIssuesCount.set -> void
+NGitLab.Models.Label.OpenMergeRequestsCount.get -> string
+NGitLab.Models.Label.OpenMergeRequestsCount.set -> void
 NGitLab.Models.LabelCreate
 NGitLab.Models.LabelCreate.Color.get -> string
 NGitLab.Models.LabelCreate.Color.set -> void


### PR DESCRIPTION
Support query parameters in GET projects/:id/labels, GET groups/:id/labels, GET projects/:id/members and GET groups/:id/members endpoints.
Also present PR updates the GET projects/:id/users