### PR TITLE
Add GetMetaData API

### DIFF
--- a/NGitLab/IHttpRequestor.cs
+++ b/NGitLab/IHttpRequestor.cs
@@ -9,6 +9,8 @@ namespace NGitLab;
 
 public interface IHttpRequestor
 {
+    IReadOnlyDictionary<string, IEnumerable<string>> GetHeader(string tailAPIUrl);
+
     IEnumerable<T> GetAll<T>(string tailUrl);
 
     GitLabCollectionResponse<T> GetAllAsync<T>(string tailUrl);

--- a/NGitLab/Impl/FilesClient.cs
+++ b/NGitLab/Impl/FilesClient.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,6 +57,13 @@ public class FilesClient : IFilesClient
     public Task<FileData> GetAsync(string filePath, string @ref, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<FileData>(_repoPath + $"/files/{EncodeFilePath(filePath)}?ref={Uri.EscapeDataString(@ref)}", cancellationToken);
+    }
+
+    public string GetMetaData(string filePath, string @ref)
+    {
+        IEnumerable<string> aa;
+        _api.Head().GetHeader(_repoPath + $"/files/{EncodeFilePath(filePath)}?ref={Uri.EscapeDataString(@ref)}").TryGetValue("X-Gitlab-Content-Sha256", out aa);
+        return aa.FirstOrDefault();
     }
 
     public bool FileExists(string filePath, string @ref)

--- a/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/Impl/HttpRequestor.cs
@@ -43,6 +43,14 @@ public partial class HttpRequestor : IHttpRequestor
         _options = options;
     }
 
+    public IReadOnlyDictionary<string, IEnumerable<string>> GetHeader(string tailAPIUrl)
+    {
+        var request = new GitLabRequest(GetAPIUrl(tailAPIUrl), _methodType, _data, _apiToken, _options);
+
+        using var response = request.GetResponse(_options);
+        return new WebHeadersDictionaryAdaptor(response.Headers);
+    }
+
     public IHttpRequestor With(object data)
     {
         _data = data;

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -281,6 +281,7 @@ NGitLab.IHttpRequestor.Execute(string tailAPIUrl) -> void
 NGitLab.IHttpRequestor.ExecuteAsync(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 NGitLab.IHttpRequestor.GetAll<T>(string tailUrl) -> System.Collections.Generic.IEnumerable<T>
 NGitLab.IHttpRequestor.GetAllAsync<T>(string tailUrl) -> NGitLab.GitLabCollectionResponse<T>
+NGitLab.IHttpRequestor.GetHeader(string tailAPIUrl) -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>>
 NGitLab.IHttpRequestor.Page<T>(string tailAPIUrl) -> NGitLab.Models.PagedResponse<T>
 NGitLab.IHttpRequestor.PageAsync<T>(string tailAPIUrl, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<NGitLab.Models.PagedResponse<T>>
 NGitLab.IHttpRequestor.Stream(string tailAPIUrl, System.Action<System.IO.Stream> parser) -> void
@@ -528,6 +529,7 @@ NGitLab.Impl.FilesClient.FileExistsAsync(string filePath, string ref, System.Thr
 NGitLab.Impl.FilesClient.FilesClient(NGitLab.Impl.API api, string repoPath) -> void
 NGitLab.Impl.FilesClient.Get(string filePath, string ref) -> NGitLab.Models.FileData
 NGitLab.Impl.FilesClient.GetAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.FileData>
+NGitLab.Impl.FilesClient.GetMetaData(string filePath, string ref) -> string
 NGitLab.Impl.FilesClient.Update(NGitLab.Models.FileUpsert file) -> void
 NGitLab.Impl.FilesClient.UpdateAsync(NGitLab.Models.FileUpsert file, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.GitLabChangeDiffCounter
@@ -582,6 +584,7 @@ NGitLab.Impl.GroupsClient.Update(long id, NGitLab.Models.GroupUpdate groupUpdate
 NGitLab.Impl.GroupsClient.UpdateAsync(long id, NGitLab.Models.GroupUpdate groupUpdate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Group>
 NGitLab.Impl.HttpRequestor
 NGitLab.Impl.HttpRequestor.GetAPIUrl(string tailAPIUrl) -> System.Uri
+NGitLab.Impl.HttpRequestor.GetHeader(string tailAPIUrl) -> System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>>
 NGitLab.Impl.HttpRequestor.GetUrl(string tailAPIUrl) -> System.Uri
 NGitLab.Impl.HttpRequestor.HttpRequestor(string hostUrl, string apiToken, NGitLab.Impl.MethodType methodType) -> void
 NGitLab.Impl.HttpRequestor.HttpRequestor(string hostUrl, string apiToken, NGitLab.Impl.MethodType methodType, NGitLab.RequestOptions options) -> void


### PR DESCRIPTION
This interface is used to obtain the header of a file without obtaining the body of the file, in order to improve speed