### PR TITLE
fixed #858  typo on JsonProperty of TestCases.SystemOutput

### DIFF
--- a/NGitLab/Models/TestCases.cs
+++ b/NGitLab/Models/TestCases.cs
@@ -16,7 +16,7 @@ public class TestCases
     [JsonPropertyName("execution_time")]
     public int ExecutionTime { get; set; }
 
-    [JsonPropertyName("system_ouput")]
+    [JsonPropertyName("system_output")]
     public string SystemOutput { get; set; }
 
     [JsonPropertyName("stack_trace")]


### PR DESCRIPTION
This caused the Property to be always empty.

this closes #858 