### PR TITLE
fix!: Commit Status-related API inconsistencies

### DIFF
--- a/NGitLab.Mock/Clients/CommitStatusClient.cs
+++ b/NGitLab.Mock/Clients/CommitStatusClient.cs
@@ -15,7 +15,7 @@ internal sealed class CommitStatusClient : ClientBase, ICommitStatusClient
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
     }
 
-    CommitStatusCreate ICommitStatusClient.AddOrUpdate(CommitStatusCreate status)
+    Models.CommitStatus ICommitStatusClient.AddOrUpdate(CommitStatusCreate status)
     {
         using (Context.BeginOperationScope())
         {
@@ -32,10 +32,10 @@ internal sealed class CommitStatusClient : ClientBase, ICommitStatusClient
             commitStatus.Coverage = status.Coverage;
             commitStatus.Ref = status.Ref;
             commitStatus.Sha = status.CommitSha;
-            commitStatus.Status = status.Status;
+            commitStatus.Status = status.State;
             commitStatus.TargetUrl = status.TargetUrl;
 
-            return commitStatus.ToClientCommitStatusCreate();
+            return commitStatus.ToClientCommitStatus();
         }
 
         static bool Equals(CommitStatus a, CommitStatusCreate b)

--- a/NGitLab.Mock/CommitStatus.cs
+++ b/NGitLab.Mock/CommitStatus.cs
@@ -1,6 +1,4 @@
-﻿using NGitLab.Models;
-
-namespace NGitLab.Mock;
+﻿namespace NGitLab.Mock;
 
 public sealed class CommitStatus : GitLabObject
 {
@@ -19,21 +17,6 @@ public sealed class CommitStatus : GitLabObject
     public string Description { get; set; }
 
     public int? Coverage { get; set; }
-
-    public CommitStatusCreate ToClientCommitStatusCreate()
-    {
-        return new CommitStatusCreate
-        {
-            Name = Name,
-            TargetUrl = TargetUrl,
-            Status = Status,
-            Ref = Ref,
-            CommitSha = Sha,
-            Description = Description,
-            State = Status,
-            Coverage = Coverage,
-        };
-    }
 
     public Models.CommitStatus ToClientCommitStatus()
     {

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -84,7 +84,6 @@ NGitLab.Mock.CommitStatus.Status.set -> void
 NGitLab.Mock.CommitStatus.TargetUrl.get -> string
 NGitLab.Mock.CommitStatus.TargetUrl.set -> void
 NGitLab.Mock.CommitStatus.ToClientCommitStatus() -> NGitLab.Models.CommitStatus
-NGitLab.Mock.CommitStatus.ToClientCommitStatusCreate() -> NGitLab.Models.CommitStatusCreate
 NGitLab.Mock.CommitStatusCollection
 NGitLab.Mock.CommitStatusCollection.CommitStatusCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.Config.GitLabCollection<TItem, TParent>

--- a/NGitLab.Tests/CommitStatusTests.cs
+++ b/NGitLab.Tests/CommitStatusTests.cs
@@ -62,7 +62,7 @@ public class CommitStatusTests
         var commitStatus2 = context.CommitStatusClient.AddOrUpdate(commitStatusCreate);
 
         // Assert
-        var properties = typeof(CommitStatusCreate).GetProperties();
+        var properties = typeof(CommitStatus).GetProperties();
 
         // All properties should be the same except 'Name' & 'Id'
         foreach (var property in properties)
@@ -205,7 +205,7 @@ public class CommitStatusTests
             return new CommitStatusTestContext(context, project, commit, client);
         }
 
-        public CommitStatusCreate AddOrUpdateCommitStatus(string state = "success", int? coverage = null)
+        public CommitStatus AddOrUpdateCommitStatus(string state = "success", int? coverage = null)
         {
             var commitStatusCreate = SetUpCommitStatusCreate(state, coverage: coverage);
 

--- a/NGitLab/ICommitStatusClient.cs
+++ b/NGitLab/ICommitStatusClient.cs
@@ -15,5 +15,5 @@ public interface ICommitStatusClient
     /// <remarks>
     /// Refer to <see href="https://docs.gitlab.com/ee/api/commits.html#set-the-pipeline-status-of-a-commit">"Set the pipeline status of a commit" GitLab doc</see>
     /// </remarks>
-    CommitStatusCreate AddOrUpdate(CommitStatusCreate status);
+    CommitStatus AddOrUpdate(CommitStatusCreate status);
 }

--- a/NGitLab/Impl/CommitStatusClient.cs
+++ b/NGitLab/Impl/CommitStatusClient.cs
@@ -25,7 +25,7 @@ public class CommitStatusClient : ICommitStatusClient
         return _api.Get().GetAllAsync<CommitStatus>(url);
     }
 
-    public CommitStatusCreate AddOrUpdate(CommitStatusCreate status) => _api.Post().With(status).To<CommitStatusCreate>($"{_statusCreatePath}/{status.CommitSha}");
+    public CommitStatus AddOrUpdate(CommitStatusCreate status) => _api.Post().With(status).To<CommitStatus>($"{_statusCreatePath}/{status.CommitSha}");
 
     private string GetCommitStatusesPath(string commitSha) => $"{_projectPath}/repository/commits/{commitSha.ToLowerInvariant()}/statuses";
 

--- a/NGitLab/Models/CommitStatusCreate.cs
+++ b/NGitLab/Models/CommitStatusCreate.cs
@@ -9,14 +9,11 @@ namespace NGitLab.Models;
 /// </summary>
 public class CommitStatusCreate
 {
-    [JsonPropertyName("sha")]
+    [JsonIgnore]
     public string CommitSha { get; set; }
 
     [JsonPropertyName("state")]
-    public string State { get; set; }
-
-    [JsonPropertyName("status")]
-    public string Status { get; set; }
+    public required string State { get; set; }
 
     [JsonPropertyName("ref")]
     public string Ref { get; set; }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -142,7 +142,7 @@ NGitLab.ICommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.ICommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.ICommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.ICommitStatusClient
-NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.ICommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.ICommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
 NGitLab.IContributorClient
@@ -498,7 +498,7 @@ NGitLab.Impl.CommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.Impl.CommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.CommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.Impl.CommitStatusClient
-NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.Impl.CommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.Impl.CommitStatusClient.CommitStatusClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
@@ -1643,8 +1643,6 @@ NGitLab.Models.CommitStatusCreate.Ref.get -> string
 NGitLab.Models.CommitStatusCreate.Ref.set -> void
 NGitLab.Models.CommitStatusCreate.State.get -> string
 NGitLab.Models.CommitStatusCreate.State.set -> void
-NGitLab.Models.CommitStatusCreate.Status.get -> string
-NGitLab.Models.CommitStatusCreate.Status.set -> void
 NGitLab.Models.CommitStatusCreate.TargetUrl.get -> string
 NGitLab.Models.CommitStatusCreate.TargetUrl.set -> void
 NGitLab.Models.CommitStatusQuery

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -141,7 +141,7 @@ NGitLab.ICommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.ICommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.ICommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.ICommitStatusClient
-NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.ICommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.ICommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
 NGitLab.IContributorClient
@@ -497,7 +497,7 @@ NGitLab.Impl.CommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.Impl.CommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.CommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.Impl.CommitStatusClient
-NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.Impl.CommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.Impl.CommitStatusClient.CommitStatusClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
@@ -1642,8 +1642,6 @@ NGitLab.Models.CommitStatusCreate.Ref.get -> string
 NGitLab.Models.CommitStatusCreate.Ref.set -> void
 NGitLab.Models.CommitStatusCreate.State.get -> string
 NGitLab.Models.CommitStatusCreate.State.set -> void
-NGitLab.Models.CommitStatusCreate.Status.get -> string
-NGitLab.Models.CommitStatusCreate.Status.set -> void
 NGitLab.Models.CommitStatusCreate.TargetUrl.get -> string
 NGitLab.Models.CommitStatusCreate.TargetUrl.set -> void
 NGitLab.Models.CommitStatusQuery

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -142,7 +142,7 @@ NGitLab.ICommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.ICommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.ICommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.ICommitStatusClient
-NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.ICommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.ICommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.ICommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
 NGitLab.IContributorClient
@@ -498,7 +498,7 @@ NGitLab.Impl.CommitClient.GetJobStatus(string branchName) -> NGitLab.JobStatus
 NGitLab.Impl.CommitClient.GetRelatedMergeRequestsAsync(NGitLab.Models.RelatedMergeRequestsQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequest>
 NGitLab.Impl.CommitClient.Revert(NGitLab.Models.CommitRevert revert) -> NGitLab.Models.Commit
 NGitLab.Impl.CommitStatusClient
-NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatusCreate
+NGitLab.Impl.CommitStatusClient.AddOrUpdate(NGitLab.Models.CommitStatusCreate status) -> NGitLab.Models.CommitStatus
 NGitLab.Impl.CommitStatusClient.AllBySha(string commitSha) -> System.Collections.Generic.IEnumerable<NGitLab.Models.CommitStatus>
 NGitLab.Impl.CommitStatusClient.CommitStatusClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
 NGitLab.Impl.CommitStatusClient.GetAsync(string commitSha, NGitLab.Models.CommitStatusQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.CommitStatus>
@@ -1643,8 +1643,6 @@ NGitLab.Models.CommitStatusCreate.Ref.get -> string
 NGitLab.Models.CommitStatusCreate.Ref.set -> void
 NGitLab.Models.CommitStatusCreate.State.get -> string
 NGitLab.Models.CommitStatusCreate.State.set -> void
-NGitLab.Models.CommitStatusCreate.Status.get -> string
-NGitLab.Models.CommitStatusCreate.Status.set -> void
 NGitLab.Models.CommitStatusCreate.TargetUrl.get -> string
 NGitLab.Models.CommitStatusCreate.TargetUrl.set -> void
 NGitLab.Models.CommitStatusQuery


### PR DESCRIPTION
These changes, although "minor" in scope, break the public API. They should be made part of the next major release.

Closes #868