### PR TITLE
Add IssueQuery parameter overload to IssueClient.ForProjectAsync

### DIFF
--- a/NGitLab.Mock/Clients/IssueClient.cs
+++ b/NGitLab.Mock/Clients/IssueClient.cs
@@ -248,6 +248,11 @@ internal sealed class IssueClient : ClientBase, IIssueClient
         return GitLabCollectionResponse.Create(ForProject(projectId));
     }
 
+    public GitLabCollectionResponse<Models.Issue> ForProjectAsync(long projectId, IssueQuery query)
+    {
+        throw new NotImplementedException();
+    }
+
     public GitLabCollectionResponse<Models.Issue> ForGroupsAsync(long groupId)
     {
         throw new NotImplementedException();

--- a/NGitLab/IIssueClient.cs
+++ b/NGitLab/IIssueClient.cs
@@ -19,6 +19,8 @@ public interface IIssueClient
 
     GitLabCollectionResponse<Issue> ForProjectAsync(long projectId);
 
+    GitLabCollectionResponse<Issue> ForProjectAsync(long projectId, IssueQuery query);
+
     GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId);
 
     GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId, IssueQuery query);

--- a/NGitLab/Impl/IssueClient.cs
+++ b/NGitLab/Impl/IssueClient.cs
@@ -46,6 +46,11 @@ public class IssueClient : IIssueClient
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId));
     }
 
+    public GitLabCollectionResponse<Issue> ForProjectAsync(long projectId, IssueQuery query)
+    {
+        return Get(string.Format(CultureInfo.InvariantCulture, ProjectIssuesUrl, projectId), query);
+    }
+
     public GitLabCollectionResponse<Issue> ForGroupsAsync(long groupId)
     {
         return _api.Get().GetAllAsync<Issue>(string.Format(CultureInfo.InvariantCulture, GroupIssuesUrl, groupId));

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -303,6 +303,7 @@ NGitLab.IIssueClient.ForGroupsAsync(long groupId) -> NGitLab.GitLabCollectionRes
 NGitLab.IIssueClient.ForGroupsAsync(long groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.ForProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.IIssueClient.ForProjectAsync(long projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Get(long projectId, long issueIid) -> NGitLab.Models.Issue
 NGitLab.IIssueClient.Get(long projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.IIssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
@@ -608,6 +609,7 @@ NGitLab.Impl.IssueClient.ForGroupsAsync(long groupId) -> NGitLab.GitLabCollectio
 NGitLab.Impl.IssueClient.ForGroupsAsync(long groupId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.ForProjectAsync(long projectId) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
+NGitLab.Impl.IssueClient.ForProjectAsync(long projectId, NGitLab.Models.IssueQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Get(long projectId, long issueIid) -> NGitLab.Models.Issue
 NGitLab.Impl.IssueClient.Get(long projectId, NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>
 NGitLab.Impl.IssueClient.Get(NGitLab.Models.IssueQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Issue>


### PR DESCRIPTION
Adds the `IssueQuery` parameter to retrieve the issues for projects.

Implementation matches what was done with `IssueClient.ForGroupsAsync(long groupId, IssueQuery query)`

docs: https://archives.docs.gitlab.com/15.11/ee/api/issues.html#list-project-issues