### PR TITLE
Getting the HEAD commit of a branch with a slash fails

### DIFF
--- a/NGitLab.Tests/CommitsTests.cs
+++ b/NGitLab.Tests/CommitsTests.cs
@@ -24,6 +24,24 @@ public class CommitsTests
 
     [Test]
     [NGitLabRetry]
+    public async Task Test_can_get_commit_of_branch()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject(initializeWithCommits: true);
+
+        var branch = context.Client.GetRepository(project.Id).Branches.Create(new()
+        {
+            Name = "feature/my-branch",
+            Ref = project.DefaultBranch,
+        });
+
+        var commit = context.Client.GetCommits(project.Id).GetCommit(branch.Name);
+        Assert.That(commit.Message, Is.Not.Null);
+        Assert.That(commit.ShortId, Is.Not.Null);
+    }
+
+    [Test]
+    [NGitLabRetry]
     public async Task Test_can_get_stats_in_commit()
     {
         using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/Impl/CommitClient.cs
+++ b/NGitLab/Impl/CommitClient.cs
@@ -18,7 +18,9 @@ public class CommitClient : ICommitClient
 
     public Commit GetCommit(string @ref)
     {
-        return _api.Get().To<Commit>(_repoPath + $"/commits/{@ref}");
+        var encodedRef = WebUtility.UrlEncode(@ref);
+
+        return _api.Get().To<Commit>(_repoPath + $"/commits/{encodedRef}");
     }
 
     public Commit CherryPick(CommitCherryPick cherryPick)


### PR DESCRIPTION
In the Commit Client,  trying to get the latest commit of a branch that contains a "/" such as "feature/mybranch" fails.

This is due to the API thinking we're calling a missing sub-path, instead of interpreting the complete ref