### PR TITLE
fix!: Remove Obsolete stuff

### DIFF
--- a/NGitLab.Mock.Tests/LabelsMockTests.cs
+++ b/NGitLab.Mock.Tests/LabelsMockTests.cs
@@ -35,7 +35,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.Create(new LabelCreate { Id = 1, Name = "test1" });
+        client.Labels.CreateProjectLabel(1, new ProjectLabelCreate { Name = "test1" });
         var labels = client.Labels.ForProject(1).ToArray();
 
         Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
@@ -52,7 +52,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.Edit(new LabelEdit { Id = 1, Name = "test1", NewName = "test2" });
+        client.Labels.EditProjectLabel(1, new ProjectLabelEdit { Name = "test1", NewName = "test2" });
         var labels = client.Labels.ForProject(1).ToArray();
 
         Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
@@ -69,7 +69,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.Delete(new LabelDelete { Id = 1, Name = "test1" });
+        client.Labels.DeleteProjectLabel(1, new ProjectLabelDelete { Name = "test1" });
         var labels = client.Labels.ForProject(1).ToArray();
 
         Assert.That(labels, Is.Empty, "Labels count is invalid");
@@ -102,7 +102,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.CreateGroupLabel(new LabelCreate { Id = 2, Name = "test1" });
+        client.Labels.CreateGroupLabel(2, new GroupLabelCreate { Name = "test1" });
         var labels = client.Labels.ForGroup(2).ToArray();
 
         Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
@@ -119,7 +119,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.EditGroupLabel(new LabelEdit { Id = 2, Name = "test1", NewName = "test2" });
+        client.Labels.EditGroupLabel(2, new GroupLabelEdit { Name = "test1", NewName = "test2" });
         var labels = client.Labels.ForGroup(2).ToArray();
 
         Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");

--- a/NGitLab.Mock/Clients/LabelClient.cs
+++ b/NGitLab.Mock/Clients/LabelClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using NGitLab.Models;
 
@@ -22,7 +21,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use CreateProjectLabel instead")]
     public Models.Label Create(LabelCreate label)
     {
         return CreateProjectLabel(label.Id, new ProjectLabelCreate
@@ -42,7 +41,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other CreateGroupLabel instead")]
     public Models.Label CreateGroupLabel(LabelCreate label)
     {
         return CreateGroupLabel(label.Id, new GroupLabelCreate
@@ -64,7 +63,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use DeleteProjectLabel instead")]
     public Models.Label Delete(LabelDelete label)
     {
         return DeleteProjectLabel(label.Id, new ProjectLabelDelete
@@ -100,7 +99,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use EditProjectLabel instead")]
     public Models.Label Edit(LabelEdit label)
     {
         return EditProjectLabel(label.Id, new ProjectLabelEdit
@@ -138,7 +137,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other EditGroupLabel instead")]
     public Models.Label EditGroupLabel(LabelEdit label)
     {
         return EditGroupLabel(label.Id, new GroupLabelEdit
@@ -196,7 +195,7 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use GetProjectLabel instead")]
     public Models.Label GetLabel(long projectId, string name)
     {
         return GetProjectLabel(projectId, name);

--- a/NGitLab.Mock/Clients/MembersClient.cs
+++ b/NGitLab.Mock/Clients/MembersClient.cs
@@ -135,12 +135,6 @@ internal sealed class MembersClient : ClientBase, IMembersClient
         }
     }
 
-    [Obsolete("Use OfGroup")]
-    public IEnumerable<Membership> OfNamespace(string groupId)
-    {
-        return OfGroup(groupId);
-    }
-
     public IEnumerable<Membership> OfGroup(string groupId)
     {
         return OfGroup(groupId, includeInheritedMembers: false, null);

--- a/NGitLab.Mock/Clients/PipelineClient.cs
+++ b/NGitLab.Mock/Clients/PipelineClient.cs
@@ -156,12 +156,6 @@ internal sealed class PipelineClient : ClientBase, IPipelineClient
         }
     }
 
-    [Obsolete("Use JobClient.GetJobs() instead")]
-    public IEnumerable<Models.Job> GetJobsInProject(JobScope scope)
-    {
-        throw new NotImplementedException();
-    }
-
     public IEnumerable<PipelineBasic> Search(PipelineQuery query)
     {
         using (Context.BeginOperationScope())

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System;
+using System.Collections.Generic;
 using NGitLab.Models;
 
 namespace NGitLab;
@@ -42,7 +42,7 @@ public interface ILabelClient
     /// <returns></returns>
     Label GetProjectLabel(long projectId, string name);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use GetProjectLabel instead")]
     Label GetLabel(long projectId, string name);
 
     /// <summary>
@@ -61,7 +61,7 @@ public interface ILabelClient
     /// <returns></returns>
     Label CreateProjectLabel(long projectId, ProjectLabelCreate label);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use CreateProjectLabel instead")]
     Label Create(LabelCreate label);
 
     /// <summary>
@@ -72,7 +72,7 @@ public interface ILabelClient
     /// <returns></returns>
     Label CreateGroupLabel(long groupId, GroupLabelCreate label);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other CreateGroupLabel instead")]
     Label CreateGroupLabel(LabelCreate label);
 
     /// <summary>
@@ -83,7 +83,7 @@ public interface ILabelClient
     /// <returns></returns>
     Label EditProjectLabel(long projectId, ProjectLabelEdit label);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use EditProjectLabel instead")]
     Label Edit(LabelEdit label);
 
     /// <summary>
@@ -94,7 +94,7 @@ public interface ILabelClient
     /// <returns></returns>
     Label EditGroupLabel(long groupId, GroupLabelEdit label);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other EditGroupLabel instead")]
     Label EditGroupLabel(LabelEdit label);
 
     /// <summary>
@@ -105,6 +105,6 @@ public interface ILabelClient
     /// <returns>True if "200", the success code for delete, was returned from the service.</returns>
     Label DeleteProjectLabel(long projectId, ProjectLabelDelete label);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use DeleteProjectLabel instead")]
     Label Delete(LabelDelete label);
 }

--- a/NGitLab/IMembersClient.cs
+++ b/NGitLab/IMembersClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -36,9 +35,6 @@ public interface IMembersClient
     Task<Membership> UpdateMemberOfProjectAsync(ProjectId projectId, ProjectMemberUpdate user, CancellationToken cancellationToken = default);
 
     Task RemoveMemberFromProjectAsync(ProjectId projectId, long userId, CancellationToken cancellationToken = default);
-
-    [Obsolete("Use OfGroup")]
-    IEnumerable<Membership> OfNamespace(string groupId);
 
     IEnumerable<Membership> OfGroup(string groupId);
 

--- a/NGitLab/IPipelineClient.cs
+++ b/NGitLab/IPipelineClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -28,13 +27,6 @@ public interface IPipelineClient
     IEnumerable<Job> AllJobs { get; }
 
     GitLabCollectionResponse<Job> GetAllJobsAsync();
-
-    /// <summary>
-    /// Get jobs in a project meeting the scope
-    /// </summary>
-    /// <param name="scope"></param>
-    [Obsolete("Use JobClient.GetJobs() instead")]
-    IEnumerable<Job> GetJobsInProject(JobScope scope);
 
     /// <summary>
     /// Returns the jobs of a pipeline.

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using NGitLab.Models;
@@ -48,7 +47,7 @@ public class LabelClient : ILabelClient
         return ForProject(projectId, new LabelQuery() { Search = name }).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use GetProjectLabel instead")]
     public Label GetLabel(long projectId, string name)
     {
         return GetProjectLabel(projectId, name);
@@ -64,7 +63,7 @@ public class LabelClient : ILabelClient
         return _api.Post().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use CreateProjectLabel instead")]
     public Label Create(LabelCreate label)
     {
         return CreateProjectLabel(label.Id, new ProjectLabelCreate
@@ -80,7 +79,7 @@ public class LabelClient : ILabelClient
         return _api.Post().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other CreateGroupLabel instead")]
     public Label CreateGroupLabel(LabelCreate label)
     {
         return CreateGroupLabel(label.Id, new GroupLabelCreate
@@ -96,7 +95,7 @@ public class LabelClient : ILabelClient
         return _api.Put().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use EditProjectLabel instead")]
     public Label Edit(LabelEdit label)
     {
         return EditProjectLabel(label.Id, new ProjectLabelEdit
@@ -113,7 +112,7 @@ public class LabelClient : ILabelClient
         return _api.Put().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, GroupLabelUrl, groupId));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use other EditGroupLabel instead")]
     public Label EditGroupLabel(LabelEdit label)
     {
         return EditGroupLabel(label.Id, new GroupLabelEdit
@@ -130,7 +129,7 @@ public class LabelClient : ILabelClient
         return _api.Delete().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use DeleteProjectLabel instead")]
     public Label Delete(LabelDelete label)
     {
         return DeleteProjectLabel(label.Id, new ProjectLabelDelete

--- a/NGitLab/Impl/MembersClient.cs
+++ b/NGitLab/Impl/MembersClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -96,12 +95,6 @@ public class MembersClient : IMembersClient
     public Task RemoveMemberFromProjectAsync(ProjectId projectId, long userId, CancellationToken cancellationToken = default)
     {
         return _api.Delete().ExecuteAsync($"{Project.Url}/{projectId.ValueAsUriParameter()}/members/{userId.ToStringInvariant()}", cancellationToken);
-    }
-
-    [Obsolete("Use OfGroup")]
-    public IEnumerable<Membership> OfNamespace(string groupId)
-    {
-        return OfGroup(groupId);
     }
 
     public IEnumerable<Membership> OfGroup(string groupId)

--- a/NGitLab/Impl/PipelineClient.cs
+++ b/NGitLab/Impl/PipelineClient.cs
@@ -31,19 +31,6 @@ public class PipelineClient : IPipelineClient
         return _api.Get().GetAllAsync<Job>($"{_projectPath}/jobs");
     }
 
-    [Obsolete("Use JobClient.GetJobs() instead")]
-    public IEnumerable<Job> GetJobsInProject(JobScope scope)
-    {
-        var url = $"{_projectPath}/jobs";
-
-        if (scope != JobScope.All)
-        {
-            url = Utils.AddParameter(url, "scope", scope.ToString().ToLowerInvariant());
-        }
-
-        return _api.Get().GetAll<Job>(url);
-    }
-
     public Pipeline this[long id] => _api.Get().To<Pipeline>($"{_pipelinesPath}/{id.ToStringInvariant()}");
 
     public Task<Pipeline> GetByIdAsync(long id, CancellationToken cancellationToken = default)

--- a/NGitLab/Models/JobScopeMask.cs
+++ b/NGitLab/Models/JobScopeMask.cs
@@ -2,20 +2,6 @@
 
 namespace NGitLab.Models;
 
-[Obsolete("Use JobScopeMask instead")]
-public enum JobScope
-{
-    All,
-    Created,
-    Pending,
-    Running,
-    Failed,
-    Success,
-    Canceled,
-    Skipped,
-    Manual,
-}
-
 [Flags]
 public enum JobScopeMask
 {

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -22,10 +22,6 @@ public sealed class ProjectUpdate
     [Obsolete("Deprecated by GitLab. Use IssuesAccessLevel instead")]
     public bool? IssuesEnabled { get; set; }
 
-    [JsonIgnore]
-    [Obsolete("Use IssuesAccessLevel instead")]
-    public string IssuesAccessLeve { get => IssuesAccessLevel; set => IssuesAccessLevel = value; }
-
     [JsonPropertyName("issues_access_level")]
     public string IssuesAccessLevel { get; set; }
 

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -384,7 +384,6 @@ NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> 
 NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -697,7 +696,6 @@ NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers)
 NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -814,7 +812,6 @@ NGitLab.Impl.PipelineClient.GetByIdAsync(long id, System.Threading.CancellationT
 NGitLab.Impl.PipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.Impl.PipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.Impl.PipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.Impl.PipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.Impl.PipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -1012,7 +1009,6 @@ NGitLab.IPipelineClient.GetByIdAsync(long id, System.Threading.CancellationToken
 NGitLab.IPipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.IPipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.IPipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.IPipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.IPipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -2610,16 +2606,6 @@ NGitLab.Models.JobQuery.PerPage.get -> int?
 NGitLab.Models.JobQuery.PerPage.set -> void
 NGitLab.Models.JobQuery.Scope.get -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobQuery.Scope.set -> void
-NGitLab.Models.JobScope
-NGitLab.Models.JobScope.All = 0 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Canceled = 6 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Created = 1 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Failed = 4 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Manual = 8 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Pending = 2 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Running = 3 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Skipped = 7 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Success = 5 -> NGitLab.Models.JobScope
 NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.All = NGitLab.Models.JobScopeMask.Created | NGitLab.Models.JobScopeMask.Pending | NGitLab.Models.JobScopeMask.Running | NGitLab.Models.JobScopeMask.Failed | NGitLab.Models.JobScopeMask.Success | NGitLab.Models.JobScopeMask.Canceled | NGitLab.Models.JobScopeMask.Skipped | NGitLab.Models.JobScopeMask.Manual -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Canceled = 32 -> NGitLab.Models.JobScopeMask
@@ -3944,8 +3930,6 @@ NGitLab.Models.ProjectUpdate.Description.get -> string
 NGitLab.Models.ProjectUpdate.Description.set -> void
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.set -> void
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.get -> string
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.set -> void
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.IssuesEnabled.get -> bool?

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -383,7 +383,6 @@ NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> 
 NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -696,7 +695,6 @@ NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers)
 NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -813,7 +811,6 @@ NGitLab.Impl.PipelineClient.GetByIdAsync(long id, System.Threading.CancellationT
 NGitLab.Impl.PipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.Impl.PipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.Impl.PipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.Impl.PipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.Impl.PipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -1011,7 +1008,6 @@ NGitLab.IPipelineClient.GetByIdAsync(long id, System.Threading.CancellationToken
 NGitLab.IPipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.IPipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.IPipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.IPipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.IPipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -2609,16 +2605,6 @@ NGitLab.Models.JobQuery.PerPage.get -> int?
 NGitLab.Models.JobQuery.PerPage.set -> void
 NGitLab.Models.JobQuery.Scope.get -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobQuery.Scope.set -> void
-NGitLab.Models.JobScope
-NGitLab.Models.JobScope.All = 0 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Canceled = 6 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Created = 1 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Failed = 4 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Manual = 8 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Pending = 2 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Running = 3 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Skipped = 7 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Success = 5 -> NGitLab.Models.JobScope
 NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.All = NGitLab.Models.JobScopeMask.Created | NGitLab.Models.JobScopeMask.Pending | NGitLab.Models.JobScopeMask.Running | NGitLab.Models.JobScopeMask.Failed | NGitLab.Models.JobScopeMask.Success | NGitLab.Models.JobScopeMask.Canceled | NGitLab.Models.JobScopeMask.Skipped | NGitLab.Models.JobScopeMask.Manual -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Canceled = 32 -> NGitLab.Models.JobScopeMask
@@ -3943,8 +3929,6 @@ NGitLab.Models.ProjectUpdate.Description.get -> string
 NGitLab.Models.ProjectUpdate.Description.set -> void
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.set -> void
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.get -> string
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.set -> void
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.IssuesEnabled.get -> bool?

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -384,7 +384,6 @@ NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers) -> 
 NGitLab.IMembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.IMembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.IMembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -697,7 +696,6 @@ NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers)
 NGitLab.Impl.MembersClient.OfGroup(string groupId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers = false, NGitLab.Models.MemberQuery query = null) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfGroupAsync(NGitLab.Models.GroupId groupId, bool includeInheritedMembers) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Membership>
-NGitLab.Impl.MembersClient.OfNamespace(string groupId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
 NGitLab.Impl.MembersClient.OfProject(string projectId, bool includeInheritedMembers, NGitLab.Models.MemberQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Membership>
@@ -814,7 +812,6 @@ NGitLab.Impl.PipelineClient.GetByIdAsync(long id, System.Threading.CancellationT
 NGitLab.Impl.PipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.Impl.PipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.Impl.PipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.Impl.PipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.Impl.PipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.Impl.PipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -1012,7 +1009,6 @@ NGitLab.IPipelineClient.GetByIdAsync(long id, System.Threading.CancellationToken
 NGitLab.IPipelineClient.GetJobs(long pipelineId) -> NGitLab.Models.Job[]
 NGitLab.IPipelineClient.GetJobs(NGitLab.Models.PipelineJobQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetJobsAsync(NGitLab.Models.PipelineJobQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Job>
-NGitLab.IPipelineClient.GetJobsInProject(NGitLab.Models.JobScope scope) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Job>
 NGitLab.IPipelineClient.GetTestReports(long pipelineId) -> NGitLab.Models.TestReport
 NGitLab.IPipelineClient.GetTestReportsSummary(long pipelineId) -> NGitLab.Models.TestReportSummary
 NGitLab.IPipelineClient.GetVariables(long pipelineId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineVariable>
@@ -2610,16 +2606,6 @@ NGitLab.Models.JobQuery.PerPage.get -> int?
 NGitLab.Models.JobQuery.PerPage.set -> void
 NGitLab.Models.JobQuery.Scope.get -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobQuery.Scope.set -> void
-NGitLab.Models.JobScope
-NGitLab.Models.JobScope.All = 0 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Canceled = 6 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Created = 1 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Failed = 4 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Manual = 8 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Pending = 2 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Running = 3 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Skipped = 7 -> NGitLab.Models.JobScope
-NGitLab.Models.JobScope.Success = 5 -> NGitLab.Models.JobScope
 NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.All = NGitLab.Models.JobScopeMask.Created | NGitLab.Models.JobScopeMask.Pending | NGitLab.Models.JobScopeMask.Running | NGitLab.Models.JobScopeMask.Failed | NGitLab.Models.JobScopeMask.Success | NGitLab.Models.JobScopeMask.Canceled | NGitLab.Models.JobScopeMask.Skipped | NGitLab.Models.JobScopeMask.Manual -> NGitLab.Models.JobScopeMask
 NGitLab.Models.JobScopeMask.Canceled = 32 -> NGitLab.Models.JobScopeMask
@@ -3944,8 +3930,6 @@ NGitLab.Models.ProjectUpdate.Description.get -> string
 NGitLab.Models.ProjectUpdate.Description.set -> void
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.GroupRunnersEnabled.set -> void
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.get -> string
-NGitLab.Models.ProjectUpdate.IssuesAccessLeve.set -> void
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.IssuesAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.IssuesEnabled.get -> bool?


### PR DESCRIPTION
- Remove some of the code tagged as `[Obsolete]`
- Replace attribute on some of the code as follows
  `[EditorBrowsable(EditorBrowsableState.Never)]` -> `[Obsolete("Use <other method> instead")]`