### PR TITLE
fix!: LabelClient API

### DIFF
--- a/NGitLab.Mock.Tests/LabelsMockTests.cs
+++ b/NGitLab.Mock.Tests/LabelsMockTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Mock.Config;
 using NGitLab.Models;
 using NUnit.Framework;
@@ -35,7 +37,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.CreateProjectLabel(1, new ProjectLabelCreate { Name = "test1" });
+        client.Labels.CreateProjectLabel(1, new ProjectLabelCreate { Name = "test1", Color = "rebeccapurple" });
         var labels = client.Labels.ForProject(1).ToArray();
 
         Assert.That(labels, Has.Length.EqualTo(1), "Labels count is invalid");
@@ -60,7 +62,7 @@ public class LabelsMockTests
     }
 
     [Test]
-    public void Test_labels_can_be_deleted_from_project()
+    public async Task Test_labels_can_be_deleted_from_project()
     {
         using var server = new GitLabConfig()
             .WithUser("user1", isDefault: true)
@@ -69,7 +71,7 @@ public class LabelsMockTests
             .BuildServer();
 
         var client = server.CreateClient();
-        client.Labels.DeleteProjectLabel(1, new ProjectLabelDelete { Name = "test1" });
+        await client.Labels.DeleteProjectLabelAsync(1, "test1", CancellationToken.None);
         var labels = client.Labels.ForProject(1).ToArray();
 
         Assert.That(labels, Is.Empty, "Labels count is invalid");

--- a/NGitLab.Tests/LabelClientTests.cs
+++ b/NGitLab.Tests/LabelClientTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NGitLab.Tests.Docker;
+using NUnit.Framework;
+
+namespace NGitLab.Tests;
+
+public class LabelClientTests
+{
+    [Test]
+    [NGitLabRetry]
+    public async Task CreateProjectLabel()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var labelClient = context.Client.Labels;
+        var labelName = Guid.NewGuid().ToString();
+
+        // Act
+        var createdLabel = labelClient.CreateProjectLabel(project.Id, new ProjectLabelCreate { Name = labelName, Color = "blue" });
+
+        // Assert
+        Assert.That(createdLabel, Is.Not.Null);
+        Assert.That(createdLabel.Name, Is.EqualTo(labelName));
+        Assert.That(createdLabel.Color, Is.EqualTo("#0000FF").IgnoreCase);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetProjectLabel()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var labelClient = context.Client.Labels;
+        var labelName = Guid.NewGuid().ToString();
+
+        labelClient.CreateProjectLabel(project.Id, new ProjectLabelCreate { Name = labelName, Color = "#ff0099" });
+
+        // Act
+        var rightLabel = labelClient.GetProjectLabel(project.Id, labelName);
+        var wrongLabel = labelClient.GetProjectLabel(project.Id, "NotMyLabel");
+
+        // Assert
+        Assert.That(rightLabel, Is.Not.Null);
+        Assert.That(rightLabel.Name, Is.EqualTo(labelName));
+        Assert.That(rightLabel.Color, Is.EqualTo("#ff0099").IgnoreCase);
+
+        Assert.That(wrongLabel, Is.Null);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task DeleteProjectLabelById()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var labelClient = context.Client.Labels;
+        var labelName = Guid.NewGuid().ToString();
+
+        var createdLabel = labelClient.CreateProjectLabel(project.Id, new ProjectLabelCreate { Name = labelName, Color = "#ff0099" });
+
+        // Act
+        await labelClient.DeleteProjectLabelAsync(project.Id, createdLabel.Id);
+
+        // Assert
+        Assert.That(labelClient.GetProjectLabel(project.Id, labelName), Is.Null);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task DeleteProjectLabelByName()
+    {
+        // Arrange
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var labelClient = context.Client.Labels;
+        var labelName = Guid.NewGuid().ToString();
+
+        var createdLabel = labelClient.CreateProjectLabel(project.Id, new ProjectLabelCreate { Name = labelName, Color = "#ff0099" });
+
+        // Act
+        await labelClient.DeleteProjectLabelAsync(project.Id, createdLabel.Name);
+
+        // Assert
+        Assert.That(labelClient.GetProjectLabel(project.Id, labelName), Is.Null);
+    }
+}

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using NGitLab.Models;
 
 namespace NGitLab;
@@ -97,14 +100,25 @@ public interface ILabelClient
     [Obsolete("Use other EditGroupLabel instead")]
     Label EditGroupLabel(LabelEdit label);
 
-    /// <summary>
-    /// Delete a label from the project.
-    /// </summary>
-    /// <param name="projectId"></param>
-    /// <param name="label"></param>
-    /// <returns>True if "200", the success code for delete, was returned from the service.</returns>
+    [Obsolete("Use DeleteProjectLabelAsync instead")]
     Label DeleteProjectLabel(long projectId, ProjectLabelDelete label);
 
-    [Obsolete("Use DeleteProjectLabel instead")]
+    /// <summary>
+    /// Delete a project label using its ID.
+    /// </summary>
+    /// <param name="projectId">Project ID</param>
+    /// <param name="labelId">Label ID</param>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Internal requirement to have the CancellationToken optional")]
+    Task DeleteProjectLabelAsync(long projectId, long labelId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a project label using its name.
+    /// </summary>
+    /// <param name="projectId">Project ID</param>
+    /// <param name="labelName">Label Name</param>
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Internal requirement to have the CancellationToken optional")]
+    Task DeleteProjectLabelAsync(long projectId, string labelName, CancellationToken cancellationToken = default);
+
+    [Obsolete("Use DeleteProjectLabelAsync instead")]
     Label Delete(LabelDelete label);
 }

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Extensions;
 using NGitLab.Models;
 
 namespace NGitLab.Impl;
@@ -124,12 +128,25 @@ public class LabelClient : ILabelClient
         });
     }
 
+    [Obsolete("Use DeleteProjectLabelAsync instead")]
     public Label DeleteProjectLabel(long projectId, ProjectLabelDelete label)
     {
         return _api.Delete().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
     }
 
-    [Obsolete("Use DeleteProjectLabel instead")]
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Internal requirement to have the CancellationToken optional")]
+    public Task DeleteProjectLabelAsync(long projectId, long labelId, CancellationToken cancellationToken = default)
+    {
+        return _api.Delete().ExecuteAsync($"/projects/{projectId.ToStringInvariant()}/labels/{labelId.ToStringInvariant()}", cancellationToken);
+    }
+
+    [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Internal requirement to have the CancellationToken optional")]
+    public Task DeleteProjectLabelAsync(long projectId, string labelName, CancellationToken cancellationToken = default)
+    {
+        return _api.Delete().ExecuteAsync($"/projects/{projectId.ToStringInvariant()}/labels/{labelName}", cancellationToken);
+    }
+
+    [Obsolete("Use DeleteProjectLabelAsync instead")]
     public Label Delete(LabelDelete label)
     {
         return DeleteProjectLabel(label.Id, new ProjectLabelDelete

--- a/NGitLab/Models/Label.cs
+++ b/NGitLab/Models/Label.cs
@@ -4,6 +4,9 @@ namespace NGitLab.Models;
 
 public class Label
 {
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
     [JsonPropertyName("name")]
     public string Name { get; set; }
 

--- a/NGitLab/Models/ProjectLabelCreate.cs
+++ b/NGitLab/Models/ProjectLabelCreate.cs
@@ -5,10 +5,10 @@ namespace NGitLab.Models;
 public sealed class ProjectLabelCreate
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public required string Name { get; set; }
 
     [JsonPropertyName("color")]
-    public string Color { get; set; }
+    public required string Color { get; set; }
 
     [JsonPropertyName("description")]
     public string Description { get; set; }

--- a/NGitLab/Models/ProjectLabelDelete.cs
+++ b/NGitLab/Models/ProjectLabelDelete.cs
@@ -1,7 +1,9 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 
+[Obsolete]
 public sealed class ProjectLabelDelete
 {
     [JsonPropertyName("id")]

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -354,6 +354,8 @@ NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitL
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -663,6 +665,8 @@ NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> N
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -2623,6 +2627,8 @@ NGitLab.Models.Label.Color.get -> string
 NGitLab.Models.Label.Color.set -> void
 NGitLab.Models.Label.Description.get -> string
 NGitLab.Models.Label.Description.set -> void
+NGitLab.Models.Label.Id.get -> long
+NGitLab.Models.Label.Id.set -> void
 NGitLab.Models.Label.Label() -> void
 NGitLab.Models.Label.Name.get -> string
 NGitLab.Models.Label.Name.set -> void

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -353,6 +353,8 @@ NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitL
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -662,6 +664,8 @@ NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> N
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -2622,6 +2626,8 @@ NGitLab.Models.Label.Color.get -> string
 NGitLab.Models.Label.Color.set -> void
 NGitLab.Models.Label.Description.get -> string
 NGitLab.Models.Label.Description.set -> void
+NGitLab.Models.Label.Id.get -> long
+NGitLab.Models.Label.Id.set -> void
 NGitLab.Models.Label.Label() -> void
 NGitLab.Models.Label.Name.get -> string
 NGitLab.Models.Label.Name.set -> void

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -354,6 +354,8 @@ NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitL
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -663,6 +665,8 @@ NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> N
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
@@ -2623,6 +2627,8 @@ NGitLab.Models.Label.Color.get -> string
 NGitLab.Models.Label.Color.set -> void
 NGitLab.Models.Label.Description.get -> string
 NGitLab.Models.Label.Description.set -> void
+NGitLab.Models.Label.Id.get -> long
+NGitLab.Models.Label.Id.set -> void
 NGitLab.Models.Label.Label() -> void
 NGitLab.Models.Label.Name.get -> string
 NGitLab.Models.Label.Name.set -> void


### PR DESCRIPTION
- Add 2 `ILabelClient.DeleteProjectLabelAsync` methods, one to delete a label by its ID, the other by its name
- Use the
  `DELETE /projects/:id/labels/:label_id`
  endpoint, rather than the deprecated
  `DELETE /projects/:id/labels` with `name` query parameter
- Add `LabelClientTests`
