### PR TITLE
Add support for the "Get raw file" API

### DIFF
--- a/NGitLab.Mock/Clients/FileClient.cs
+++ b/NGitLab.Mock/Clients/FileClient.cs
@@ -156,14 +156,14 @@ internal sealed class FileClient : ClientBase, IFilesClient
         return Get(filePath, @ref);
     }
 
-    public void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null)
+    public async Task GetRawAsync(string filePath, Func<Stream, Task> parser, GetRawFileRequest request = null, CancellationToken cancellationToken = default)
     {
         using (Context.BeginOperationScope())
         {
             var fileSystemPath = WebUtility.UrlDecode(filePath);
 
             var project = GetProject(_projectId, ProjectPermission.View);
-            project.Repository.GetRawFile(fileSystemPath, parser, request);
+            await project.Repository.GetRawFileAsync(fileSystemPath, parser, request).ConfigureAwait(false);
         }
     }
 }

--- a/NGitLab.Mock/Clients/FileClient.cs
+++ b/NGitLab.Mock/Clients/FileClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -153,5 +154,16 @@ internal sealed class FileClient : ClientBase, IFilesClient
     {
         await Task.Yield();
         return Get(filePath, @ref);
+    }
+
+    public void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var fileSystemPath = WebUtility.UrlDecode(filePath);
+
+            var project = GetProject(_projectId, ProjectPermission.View);
+            project.Repository.GetRawFile(fileSystemPath, parser, request);
+        }
     }
 }

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -1071,6 +1071,7 @@ NGitLab.Mock.Repository.GetCommits() -> System.Collections.Generic.IEnumerable<L
 NGitLab.Mock.Repository.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<LibGit2Sharp.Commit>
 NGitLab.Mock.Repository.GetCommits(string ref) -> System.Collections.Generic.IEnumerable<LibGit2Sharp.Commit>
 NGitLab.Mock.Repository.GetFile(string filePath, string ref) -> NGitLab.Models.FileData
+NGitLab.Mock.Repository.GetRawFile(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request) -> void
 NGitLab.Mock.Repository.GetReleaseTag(string tagName) -> NGitLab.Mock.ReleaseTag
 NGitLab.Mock.Repository.GetTags() -> LibGit2Sharp.TagCollection
 NGitLab.Mock.Repository.IsEmpty.get -> bool

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -1071,7 +1071,7 @@ NGitLab.Mock.Repository.GetCommits() -> System.Collections.Generic.IEnumerable<L
 NGitLab.Mock.Repository.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<LibGit2Sharp.Commit>
 NGitLab.Mock.Repository.GetCommits(string ref) -> System.Collections.Generic.IEnumerable<LibGit2Sharp.Commit>
 NGitLab.Mock.Repository.GetFile(string filePath, string ref) -> NGitLab.Models.FileData
-NGitLab.Mock.Repository.GetRawFile(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request) -> void
+NGitLab.Mock.Repository.GetRawFileAsync(string filePath, System.Func<System.IO.Stream, System.Threading.Tasks.Task> parser, NGitLab.GetRawFileRequest request) -> System.Threading.Tasks.Task
 NGitLab.Mock.Repository.GetReleaseTag(string tagName) -> NGitLab.Mock.ReleaseTag
 NGitLab.Mock.Repository.GetTags() -> LibGit2Sharp.TagCollection
 NGitLab.Mock.Repository.IsEmpty.get -> bool

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -548,7 +548,7 @@ public sealed class Repository : GitLabObject, IDisposable
         }
         catch (LibGit2Sharp.NotFoundException)
         {
-            throw GitLabException.NotFound("File not found");
+            throw GitLabException.NotFound("Revision not found");
         }
 
         var fileCompletePath = Path.Combine(FullPath, filePath);

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using LibGit2Sharp;
 using NGitLab.Mock.Clients;
 using NGitLab.Models;
@@ -538,7 +539,7 @@ public sealed class Repository : GitLabObject, IDisposable
         };
     }
 
-    public void GetRawFile(string filePath, Action<Stream> parser, GetRawFileRequest request)
+    public async Task GetRawFileAsync(string filePath, Func<Stream, Task> parser, GetRawFileRequest request)
     {
         var repo = GetGitRepository();
         try
@@ -560,7 +561,7 @@ public sealed class Repository : GitLabObject, IDisposable
 
         using (var fileStream = System.IO.File.OpenRead(fileCompletePath))
         {
-            parser(fileStream);
+            await parser(fileStream).ConfigureAwait(false);
         }
     }
 

--- a/NGitLab.Tests/FilesTests.cs
+++ b/NGitLab.Tests/FilesTests.cs
@@ -109,7 +109,7 @@ public class FilesTests
 
     [Test]
     [NGitLabRetry]
-    public async Task Test_get_raw_file()
+    public async Task Test_get_raw_file_async()
     {
         using var context = await GitLabTestContext.CreateAsync();
         var project = context.CreateProject();
@@ -129,15 +129,15 @@ public class FilesTests
 
 
         string downloadedContent = null;
-        filesClient.GetRaw(fileName, stream =>
+        await filesClient.GetRawAsync(fileName, async stream =>
         {
             using var streamReader = new StreamReader(stream);
-            downloadedContent = streamReader.ReadToEnd();
+            downloadedContent = await streamReader.ReadToEndAsync();
         });
         Assert.That(downloadedContent, Is.Not.Null);
         Assert.That(downloadedContent, Is.EqualTo("test"));
 
-        Assert.Throws(Is.InstanceOf<GitLabException>(), () => filesClient.GetRaw("does-not-exist.md", _ => { }));
+        Assert.ThrowsAsync(Is.InstanceOf<GitLabException>(), () => filesClient.GetRawAsync("does-not-exist.md", _ => Task.CompletedTask));
     }
 
     [Test]

--- a/NGitLab.Tests/FilesTests.cs
+++ b/NGitLab.Tests/FilesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using NGitLab.Models;
 using NGitLab.Tests.Docker;
@@ -104,6 +105,39 @@ public class FilesTests
         Assert.That(exists, Is.False);
 
         Assert.ThrowsAsync(Is.InstanceOf<GitLabException>(), () => filesClient.GetAsync("testDelete.md", project.DefaultBranch));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task Test_get_raw_file()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var project = context.CreateProject();
+        var filesClient = context.Client.GetRepository(project.Id).Files;
+
+        // Don't use txt extensions: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790
+        var fileName = "test.md";
+        var fileUpsert = new FileUpsert
+        {
+            Branch = project.DefaultBranch,
+            CommitMessage = "Add SonarQube badges to README.md",
+            RawContent = "test",
+            Encoding = "base64",
+            Path = fileName,
+        };
+        await filesClient.CreateAsync(fileUpsert);
+
+
+        string downloadedContent = null;
+        filesClient.GetRaw(fileName, stream =>
+        {
+            using var streamReader = new StreamReader(stream);
+            downloadedContent = streamReader.ReadToEnd();
+        });
+        Assert.That(downloadedContent, Is.Not.Null);
+        Assert.That(downloadedContent, Is.EqualTo("test"));
+
+        Assert.Throws(Is.InstanceOf<GitLabException>(), () => filesClient.GetRaw("does-not-exist.md", _ => { }));
     }
 
     [Test]

--- a/NGitLab/GetRawFileRequest.cs
+++ b/NGitLab/GetRawFileRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace NGitLab;
+
+public class GetRawFileRequest
+{
+    /// <summary>
+    /// The revision of the file to get (name of the branch/tag or commit)
+    /// </summary>
+    public string Ref { get; set; } = null;
+
+    /// <summary>
+    /// Determines if the response should be Git LFS file contents, rather than the pointer
+    /// </summary>
+    public bool? Lfs { get; set; }
+}

--- a/NGitLab/GetRawFileRequest.cs
+++ b/NGitLab/GetRawFileRequest.cs
@@ -3,12 +3,12 @@
 public class GetRawFileRequest
 {
     /// <summary>
-    /// The revision of the file to get (name of the branch/tag or commit)
+    /// The branch name, tag or commit to get the file from. Default is the HEAD of the project.
     /// </summary>
-    public string Ref { get; set; } = null;
+    public string Ref { get; init; }
 
     /// <summary>
     /// Determines if the response should be Git LFS file contents, rather than the pointer
     /// </summary>
-    public bool? Lfs { get; set; }
+    public bool? Lfs { get; init; }
 }

--- a/NGitLab/IFilesClient.cs
+++ b/NGitLab/IFilesClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
 
@@ -21,6 +23,8 @@ public interface IFilesClient
     FileData Get(string filePath, string @ref);
 
     Task<FileData> GetAsync(string filePath, string @ref, CancellationToken cancellationToken = default);
+
+    void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null);
 
     bool FileExists(string filePath, string @ref);
 

--- a/NGitLab/IFilesClient.cs
+++ b/NGitLab/IFilesClient.cs
@@ -24,7 +24,7 @@ public interface IFilesClient
 
     Task<FileData> GetAsync(string filePath, string @ref, CancellationToken cancellationToken = default);
 
-    void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null);
+    Task GetRawAsync(string filePath, Func<Stream, Task> parser, GetRawFileRequest request = null, CancellationToken cancellationToken = default);
 
     bool FileExists(string filePath, string @ref);
 

--- a/NGitLab/Impl/FilesClient.cs
+++ b/NGitLab/Impl/FilesClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,6 +56,23 @@ public class FilesClient : IFilesClient
     public Task<FileData> GetAsync(string filePath, string @ref, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<FileData>(_repoPath + $"/files/{EncodeFilePath(filePath)}?ref={Uri.EscapeDataString(@ref)}", cancellationToken);
+    }
+
+    public void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null)
+    {
+        var url = _repoPath + $"/files/{EncodeFilePath(filePath)}/raw/";
+
+        if (!String.IsNullOrWhiteSpace(request?.Ref))
+        {
+            url = Utils.AddParameter(url, "ref", Uri.EscapeDataString(request?.Ref));
+        }
+
+        if (request is not null && request.Lfs.HasValue)
+        {
+            url = Utils.AddParameter(url, "lfs", request?.Lfs.Value);
+        }
+
+        _api.Get().Stream(url, parser);
     }
 
     public bool FileExists(string filePath, string @ref)

--- a/NGitLab/Impl/FilesClient.cs
+++ b/NGitLab/Impl/FilesClient.cs
@@ -60,16 +60,16 @@ public class FilesClient : IFilesClient
 
     public void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null)
     {
-        var url = _repoPath + $"/files/{EncodeFilePath(filePath)}/raw/";
+        var url = _repoPath + $"/files/{EncodeFilePath(filePath)}/raw";
 
-        if (!String.IsNullOrWhiteSpace(request?.Ref))
+        if (!string.IsNullOrWhiteSpace(request?.Ref))
         {
-            url = Utils.AddParameter(url, "ref", Uri.EscapeDataString(request?.Ref));
+            url = Utils.AddParameter(url, "ref", Uri.EscapeDataString(request.Ref));
         }
 
         if (request is not null && request.Lfs.HasValue)
         {
-            url = Utils.AddParameter(url, "lfs", request?.Lfs.Value);
+            url = Utils.AddParameter(url, "lfs", request.Lfs.Value);
         }
 
         _api.Get().Stream(url, parser);

--- a/NGitLab/Impl/FilesClient.cs
+++ b/NGitLab/Impl/FilesClient.cs
@@ -58,7 +58,7 @@ public class FilesClient : IFilesClient
         return _api.Get().ToAsync<FileData>(_repoPath + $"/files/{EncodeFilePath(filePath)}?ref={Uri.EscapeDataString(@ref)}", cancellationToken);
     }
 
-    public void GetRaw(string filePath, Action<Stream> parser, GetRawFileRequest request = null)
+    public Task GetRawAsync(string filePath, Func<Stream, Task> parser, GetRawFileRequest request = null, CancellationToken cancellationToken = default)
     {
         var url = _repoPath + $"/files/{EncodeFilePath(filePath)}/raw";
 
@@ -72,7 +72,7 @@ public class FilesClient : IFilesClient
             url = Utils.AddParameter(url, "lfs", request.Lfs.Value);
         }
 
-        _api.Get().Stream(url, parser);
+        return _api.Get().StreamAsync(url, parser, cancellationToken);
     }
 
     public bool FileExists(string filePath, string @ref)

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -47,9 +47,9 @@ NGitLab.GetCommitsRequest.Until.set -> void
 NGitLab.GetRawFileRequest
 NGitLab.GetRawFileRequest.GetRawFileRequest() -> void
 NGitLab.GetRawFileRequest.Lfs.get -> bool?
-NGitLab.GetRawFileRequest.Lfs.set -> void
+NGitLab.GetRawFileRequest.Lfs.init -> void
 NGitLab.GetRawFileRequest.Ref.get -> string
-NGitLab.GetRawFileRequest.Ref.set -> void
+NGitLab.GetRawFileRequest.Ref.init -> void
 NGitLab.GitLabClient
 NGitLab.GitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.GitLabClient.Deployments.get -> NGitLab.IDeploymentClient

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -178,7 +178,7 @@ NGitLab.IFilesClient.FileExists(string filePath, string ref) -> bool
 NGitLab.IFilesClient.FileExistsAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
 NGitLab.IFilesClient.Get(string filePath, string ref) -> NGitLab.Models.FileData
 NGitLab.IFilesClient.GetAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.FileData>
-NGitLab.IFilesClient.GetRaw(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request = null) -> void
+NGitLab.IFilesClient.GetRawAsync(string filePath, System.Func<System.IO.Stream, System.Threading.Tasks.Task> parser, NGitLab.GetRawFileRequest request = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IFilesClient.Update(NGitLab.Models.FileUpsert file) -> void
 NGitLab.IFilesClient.UpdateAsync(NGitLab.Models.FileUpsert file, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IGitLabClient
@@ -544,7 +544,7 @@ NGitLab.Impl.FilesClient.FileExistsAsync(string filePath, string ref, System.Thr
 NGitLab.Impl.FilesClient.FilesClient(NGitLab.Impl.API api, string repoPath) -> void
 NGitLab.Impl.FilesClient.Get(string filePath, string ref) -> NGitLab.Models.FileData
 NGitLab.Impl.FilesClient.GetAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.FileData>
-NGitLab.Impl.FilesClient.GetRaw(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request = null) -> void
+NGitLab.Impl.FilesClient.GetRawAsync(string filePath, System.Func<System.IO.Stream, System.Threading.Tasks.Task> parser, NGitLab.GetRawFileRequest request = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.FilesClient.Update(NGitLab.Models.FileUpsert file) -> void
 NGitLab.Impl.FilesClient.UpdateAsync(NGitLab.Models.FileUpsert file, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.GitLabChangeDiffCounter

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -44,6 +44,12 @@ NGitLab.GetCommitsRequest.Since.get -> System.DateTime?
 NGitLab.GetCommitsRequest.Since.set -> void
 NGitLab.GetCommitsRequest.Until.get -> System.DateTime?
 NGitLab.GetCommitsRequest.Until.set -> void
+NGitLab.GetRawFileRequest
+NGitLab.GetRawFileRequest.GetRawFileRequest() -> void
+NGitLab.GetRawFileRequest.Lfs.get -> bool?
+NGitLab.GetRawFileRequest.Lfs.set -> void
+NGitLab.GetRawFileRequest.Ref.get -> string
+NGitLab.GetRawFileRequest.Ref.set -> void
 NGitLab.GitLabClient
 NGitLab.GitLabClient.AdvancedSearch.get -> NGitLab.ISearchClient
 NGitLab.GitLabClient.Deployments.get -> NGitLab.IDeploymentClient
@@ -172,6 +178,7 @@ NGitLab.IFilesClient.FileExists(string filePath, string ref) -> bool
 NGitLab.IFilesClient.FileExistsAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
 NGitLab.IFilesClient.Get(string filePath, string ref) -> NGitLab.Models.FileData
 NGitLab.IFilesClient.GetAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.FileData>
+NGitLab.IFilesClient.GetRaw(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request = null) -> void
 NGitLab.IFilesClient.Update(NGitLab.Models.FileUpsert file) -> void
 NGitLab.IFilesClient.UpdateAsync(NGitLab.Models.FileUpsert file, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.IGitLabClient
@@ -537,6 +544,7 @@ NGitLab.Impl.FilesClient.FileExistsAsync(string filePath, string ref, System.Thr
 NGitLab.Impl.FilesClient.FilesClient(NGitLab.Impl.API api, string repoPath) -> void
 NGitLab.Impl.FilesClient.Get(string filePath, string ref) -> NGitLab.Models.FileData
 NGitLab.Impl.FilesClient.GetAsync(string filePath, string ref, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.FileData>
+NGitLab.Impl.FilesClient.GetRaw(string filePath, System.Action<System.IO.Stream> parser, NGitLab.GetRawFileRequest request = null) -> void
 NGitLab.Impl.FilesClient.Update(NGitLab.Models.FileUpsert file) -> void
 NGitLab.Impl.FilesClient.UpdateAsync(NGitLab.Models.FileUpsert file, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.GitLabChangeDiffCounter


### PR DESCRIPTION
Add support for downloading the content's of a file via GitLabs "Get raw file" API. 

In contrast to the existing "Get" method that gets a file's content and its metadata, the "GetRaw" method gives access to the file stream. 
This avoids having to loads the contents of the entire file into memory. 
Additionally, this API allows getting the content of the file if the file was commited via Git LFS ("Get()" will just return the pointer to the LFS file in this case)

See Also [Get raw file from repository (GitLab Docs)](https://docs.gitlab.com/api/repository_files/#get-raw-file-from-repository)