### PR TITLE
Added proxy support

### DIFF
--- a/NGitLab.Tests/GitLabClientTests.cs
+++ b/NGitLab.Tests/GitLabClientTests.cs
@@ -12,7 +12,6 @@ public sealed class GitLabClientTests
         const long GitLabProjectId = 278964;
 
         var client = new GitLabClient("https://gitlab.com");
-        //client.Options.Proxy = new System.Net.WebProxy("http://127.0.0.1:7890");
         var project = await client.Projects.GetByIdAsync(GitLabProjectId, new Models.SingleProjectQuery { Statistics = false});
 
         Assert.That(project, Is.Not.Null);

--- a/NGitLab.Tests/GitLabClientTests.cs
+++ b/NGitLab.Tests/GitLabClientTests.cs
@@ -12,6 +12,7 @@ public sealed class GitLabClientTests
         const long GitLabProjectId = 278964;
 
         var client = new GitLabClient("https://gitlab.com");
+        //client.Options.Proxy = new System.Net.WebProxy("http://127.0.0.1:7890");
         var project = await client.Projects.GetByIdAsync(GitLabProjectId, new Models.SingleProjectQuery { Statistics = false});
 
         Assert.That(project, Is.Not.Null);

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -168,7 +168,7 @@ public partial class HttpRequestor
             request.AutomaticDecompression = DecompressionMethods.GZip;
             request.Timeout = (int)options.HttpClientTimeout.TotalMilliseconds;
             request.ReadWriteTimeout = (int)options.HttpClientTimeout.TotalMilliseconds;
-
+            if (options.Proxy!=null) request.Proxy=options.Proxy;
             if (HasOutput)
             {
                 if (FormData != null)

--- a/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
+++ b/NGitLab/Impl/HttpRequestor.GitLabRequest.cs
@@ -168,7 +168,10 @@ public partial class HttpRequestor
             request.AutomaticDecompression = DecompressionMethods.GZip;
             request.Timeout = (int)options.HttpClientTimeout.TotalMilliseconds;
             request.ReadWriteTimeout = (int)options.HttpClientTimeout.TotalMilliseconds;
-            if (options.Proxy!=null) request.Proxy=options.Proxy;
+            if (options.Proxy != null)
+            {
+                request.Proxy = options.Proxy;
+            }
             if (HasOutput)
             {
                 if (FormData != null)

--- a/NGitLab/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI.Unshipped.txt
@@ -4922,6 +4922,8 @@ NGitLab.RequestOptions.HttpClientTimeout.get -> System.TimeSpan
 NGitLab.RequestOptions.HttpClientTimeout.set -> void
 NGitLab.RequestOptions.IsIncremental.get -> bool
 NGitLab.RequestOptions.IsIncremental.set -> void
+NGitLab.RequestOptions.Proxy.get -> System.Net.WebProxy
+NGitLab.RequestOptions.Proxy.set -> void
 NGitLab.RequestOptions.RequestOptions(int retryCount, System.TimeSpan retryInterval, bool isIncremental = true) -> void
 NGitLab.RequestOptions.RetryCount.get -> int
 NGitLab.RequestOptions.RetryCount.set -> void

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -32,6 +32,7 @@ public class RequestOptions
     public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     public string UserAgent { get; set; }
+    public WebProxy Proxy { get; set; } =null;
 
     public RequestOptions(int retryCount, TimeSpan retryInterval, bool isIncremental = true)
     {

--- a/NGitLab/RequestOptions.cs
+++ b/NGitLab/RequestOptions.cs
@@ -32,7 +32,8 @@ public class RequestOptions
     public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     public string UserAgent { get; set; }
-    public WebProxy Proxy { get; set; } =null;
+
+    public WebProxy Proxy { get; set; }
 
     public RequestOptions(int retryCount, TimeSpan retryInterval, bool isIncremental = true)
     {


### PR DESCRIPTION
```
    [Test]
    public async Task ShouldWorkWithoutToken()
    {
        // https://gitlab.com/gitlab-org/gitlab
        const long GitLabProjectId = 278964;

        var client = new GitLabClient("https://gitlab.com");
        client.Options.Proxy = new System.Net.WebProxy("http://127.0.0.1:7890");
        var project = await client.Projects.GetByIdAsync(GitLabProjectId, new Models.SingleProjectQuery { Statistics = false});

        Assert.That(project, Is.Not.Null);
        Assert.That(project.Id, Is.EqualTo(GitLabProjectId));
        Assert.That(project.Name, Is.EqualTo("GitLab"));
    }
```