### PR TITLE
fix!: Job Artifact-related API inconsistencies

### DIFF
--- a/NGitLab.Mock/Clients/JobClient.cs
+++ b/NGitLab.Mock/Clients/JobClient.cs
@@ -127,7 +127,8 @@ internal sealed class JobClient : ClientBase, IJobClient
                     job.Status = JobStatus.Canceled;
                     break;
                 case JobAction.Erase:
-                    job.Artifacts = null;
+                    job.ArtifactsFile = null;
+                    job.Artifacts.Clear();
                     job.Trace = null;
                     break;
                 case JobAction.Play:

--- a/NGitLab.Mock/Job.cs
+++ b/NGitLab.Mock/Job.cs
@@ -1,11 +1,17 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using NGitLab.Models;
 
 namespace NGitLab.Mock;
 
 public sealed class Job : GitLabObject
 {
+    public Job()
+    {
+        Artifacts = new JobArtifactCollection(this);
+    }
+
     public string Name { get; set; }
 
     public long Id { get; set; }
@@ -24,7 +30,9 @@ public sealed class Job : GitLabObject
 
     public double? Coverage { get; set; }
 
-    public Models.Job.JobArtifact Artifacts { get; set; }
+    public Models.Job.JobArtifact ArtifactsFile { get; set; }
+
+    public JobArtifactCollection Artifacts { get; set; }
 
     public Models.Job.JobRunner Runner { get; set; }
 
@@ -103,7 +111,8 @@ public sealed class Job : GitLabObject
             FinishedAt = FinishedAt,
             Stage = Stage,
             Coverage = Coverage,
-            Artifacts = Artifacts,
+            ArtifactsFile = ArtifactsFile,
+            Artifacts = [.. Artifacts.Select(mockArtifact => new Models.Job.JobArtifact { Filename = mockArtifact.Filename, Size = mockArtifact.Size })],
             Runner = Runner,
             Pipeline = new JobBasic.JobPipeline
             {
@@ -144,6 +153,7 @@ public sealed class Job : GitLabObject
             FinishedAt = FinishedAt,
             Stage = Stage,
             Coverage = Coverage,
+            ArtifactsFile = ArtifactsFile,
             Artifacts = Artifacts,
             Runner = Runner,
             Pipeline = Pipeline,

--- a/NGitLab.Mock/JobArtifact.cs
+++ b/NGitLab.Mock/JobArtifact.cs
@@ -1,0 +1,8 @@
+﻿namespace NGitLab.Mock;
+
+public sealed class JobArtifact : GitLabObject
+{
+    public string Filename { get; set; }
+
+    public long Size { get; set; }
+}

--- a/NGitLab.Mock/JobArtifactCollection.cs
+++ b/NGitLab.Mock/JobArtifactCollection.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+
+namespace NGitLab.Mock;
+
+public sealed class JobArtifactCollection(GitLabObject container)
+    : Collection<JobArtifact>(container)
+{
+    public override void Add(JobArtifact artifact)
+    {
+        if (artifact is null)
+            throw new ArgumentNullException(nameof(artifact));
+
+        if (string.IsNullOrEmpty(artifact.Filename))
+            throw new ArgumentException("Filename must be set", nameof(artifact));
+
+        if (artifact.Size < 1)
+            throw new ArgumentException("Size must be set", nameof(artifact));
+
+        if (this.Any(g => StringComparer.Ordinal.Equals(g.Filename, artifact.Filename)))
+            throw new NotSupportedException($"Artifact '{artifact.Filename}' already added");
+
+        base.Add(artifact);
+    }
+
+    public new void Clear()
+    {
+        foreach (var item in this)
+        {
+            item.Parent = null;
+        }
+
+        base.Clear();
+    }
+}

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -550,8 +550,10 @@ NGitLab.Mock.IssueState.opened = 0 -> NGitLab.Mock.IssueState
 NGitLab.Mock.Job
 NGitLab.Mock.Job.AllowFailure.get -> bool
 NGitLab.Mock.Job.AllowFailure.set -> void
-NGitLab.Mock.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Mock.Job.Artifacts.get -> NGitLab.Mock.JobArtifactCollection
 NGitLab.Mock.Job.Artifacts.set -> void
+NGitLab.Mock.Job.ArtifactsFile.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Mock.Job.ArtifactsFile.set -> void
 NGitLab.Mock.Job.Commit.get -> NGitLab.Models.Commit
 NGitLab.Mock.Job.Commit.set -> void
 NGitLab.Mock.Job.Coverage.get -> double?
@@ -597,6 +599,15 @@ NGitLab.Mock.Job.Trace.set -> void
 NGitLab.Mock.Job.User.get -> NGitLab.Mock.User
 NGitLab.Mock.Job.User.set -> void
 NGitLab.Mock.Job.WebUrl.get -> string
+NGitLab.Mock.JobArtifact
+NGitLab.Mock.JobArtifact.Filename.get -> string
+NGitLab.Mock.JobArtifact.Filename.set -> void
+NGitLab.Mock.JobArtifact.JobArtifact() -> void
+NGitLab.Mock.JobArtifact.Size.get -> long
+NGitLab.Mock.JobArtifact.Size.set -> void
+NGitLab.Mock.JobArtifactCollection
+NGitLab.Mock.JobArtifactCollection.Clear() -> void
+NGitLab.Mock.JobArtifactCollection.JobArtifactCollection(NGitLab.Mock.GitLabObject container) -> void
 NGitLab.Mock.JobCollection
 NGitLab.Mock.JobCollection.Add(NGitLab.Mock.Job job, NGitLab.Mock.Pipeline pipeline) -> NGitLab.Mock.Job
 NGitLab.Mock.JobCollection.AddNew() -> NGitLab.Mock.Job
@@ -1264,6 +1275,7 @@ override NGitLab.Mock.EventCollection.Add(NGitLab.Mock.Event item) -> void
 override NGitLab.Mock.GroupCollection.Add(NGitLab.Mock.Group group) -> void
 override NGitLab.Mock.GroupHookCollection.Add(NGitLab.Mock.GroupHook item) -> void
 override NGitLab.Mock.IssueCollection.Add(NGitLab.Mock.Issue item) -> void
+override NGitLab.Mock.JobArtifactCollection.Add(NGitLab.Mock.JobArtifact artifact) -> void
 override NGitLab.Mock.JobCollection.Add(NGitLab.Mock.Job job) -> void
 override NGitLab.Mock.LabelsCollection.Add(NGitLab.Mock.Label label) -> void
 override NGitLab.Mock.MergeRequestCollection.Add(NGitLab.Mock.MergeRequest mergeRequest) -> void

--- a/NGitLab.Tests/FodyWeavers.xml
+++ b/NGitLab.Tests/FodyWeavers.xml
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Weavers>
-  <MethodTimer />
-</Weavers>

--- a/NGitLab.Tests/JobTests.cs
+++ b/NGitLab.Tests/JobTests.cs
@@ -222,14 +222,16 @@ public class JobTests
         AddGitLabCiFile(context.Client, project);
         var jobs = await GitLabTestContext.RetryUntilAsync(() => jobsClient.GetJobs(JobScopeMask.Success), jobs => jobs.Any(), TimeSpan.FromMinutes(2));
         var job = jobs.Single();
-        Assert.That(job.Artifacts, Is.Not.Null);
+        Assert.That(job.ArtifactsFile, Is.Not.Null);
+        Assert.That(job.Artifacts, Is.Not.Empty);
 
         // Act
         await jobsClient.DeleteJobArtifactsAsync(job.Id);
 
         // Assert
         job = await jobsClient.GetAsync(job.Id);
-        Assert.That(job.Artifacts, Is.Null);
+        Assert.That(job.ArtifactsFile, Is.Null);
+        Assert.That(job.Artifacts, Is.Empty);
     }
 
     [Test]

--- a/NGitLab.Tests/NGitLab.Tests.csproj
+++ b/NGitLab.Tests/NGitLab.Tests.csproj
@@ -1,13 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NGitLab\NGitLab.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -6,7 +6,10 @@ namespace NGitLab.Models;
 public class Job : JobBasic
 {
     [JsonPropertyName("artifacts_file")]
-    public JobArtifact Artifacts { get; set; }
+    public JobArtifact ArtifactsFile { get; set; }
+
+    [JsonPropertyName("artifacts")]
+    public JobArtifact[] Artifacts { get; set; }
 
     [JsonPropertyName("runner")]
     public JobRunner Runner { get; set; }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -2482,8 +2482,10 @@ NGitLab.Models.IssueType.incident = 1 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.issue = 0 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.test_case = 2 -> NGitLab.Models.IssueType
 NGitLab.Models.Job
-NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact[]
 NGitLab.Models.Job.Artifacts.set -> void
+NGitLab.Models.Job.ArtifactsFile.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.ArtifactsFile.set -> void
 NGitLab.Models.Job.Job() -> void
 NGitLab.Models.Job.JobArtifact
 NGitLab.Models.Job.JobArtifact.Filename.get -> string

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2481,8 +2481,10 @@ NGitLab.Models.IssueType.incident = 1 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.issue = 0 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.test_case = 2 -> NGitLab.Models.IssueType
 NGitLab.Models.Job
-NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact[]
 NGitLab.Models.Job.Artifacts.set -> void
+NGitLab.Models.Job.ArtifactsFile.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.ArtifactsFile.set -> void
 NGitLab.Models.Job.Job() -> void
 NGitLab.Models.Job.JobArtifact
 NGitLab.Models.Job.JobArtifact.Filename.get -> string

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2482,8 +2482,10 @@ NGitLab.Models.IssueType.incident = 1 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.issue = 0 -> NGitLab.Models.IssueType
 NGitLab.Models.IssueType.test_case = 2 -> NGitLab.Models.IssueType
 NGitLab.Models.Job
-NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.Artifacts.get -> NGitLab.Models.Job.JobArtifact[]
 NGitLab.Models.Job.Artifacts.set -> void
+NGitLab.Models.Job.ArtifactsFile.get -> NGitLab.Models.Job.JobArtifact
+NGitLab.Models.Job.ArtifactsFile.set -> void
 NGitLab.Models.Job.Job() -> void
 NGitLab.Models.Job.JobArtifact
 NGitLab.Models.Job.JobArtifact.Filename.get -> string


### PR DESCRIPTION
When retrieving a job's data, GitLab can return both `artifacts_file` and `artifacts`

```json
{
  "artifacts_file": {
    "filename": "artifacts.zip",
    "size": 1000
  },
  "artifacts": [
    {
      "file_type": "archive",
      "size": 1000,
      "filename": "artifacts.zip",
      "file_format": "zip"
    },
    {
      "file_type": "metadata",
      "size": 186,
      "filename": "metadata.gz",
      "file_format": "gzip"
    },
    {
      "file_type": "trace",
      "size": 1500,
      "filename": "job.log",
      "file_format": "raw"
    },
    {
      "file_type": "junit",
      "size": 750,
      "filename": "junit.xml.gz",
      "file_format": "gzip"
    }
  ]
}
```

- Rename `NGitLab.Models.Artifacts` to `NGitLab.Models.Artifacts.ArtifactsFile`
- Add the `NGitLab.Models.Artifacts` array
- Adapt Mocks and Tests accordingly