### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
@@ -101,6 +104,9 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     needs: [create_nuget, build_and_test]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/ubisoft/NGitLab/security/code-scanning/3](https://github.com/ubisoft/NGitLab/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow:
- The `create_nuget` and `build_and_test` jobs primarily involve reading repository contents and uploading artifacts, so they only need `contents: read`.
- The `deploy` job interacts with NuGet packages and uses secrets, so it requires `contents: read` and possibly `packages: write` for publishing.

We will add a `permissions` block at the workflow level to apply to all jobs, and override it for the `deploy` job if additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
