### PR TITLE
feat: add job runner manager property

### DIFF
--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -10,6 +10,9 @@ public class Job : JobBasic
     [JsonPropertyName("runner")]
     public JobRunner Runner { get; set; }
 
+    [JsonPropertyName("runner_manager")]
+    public JobRunner Runner { get; set; }
+
     [JsonPropertyName("project")]
     public JobProject Project { get; set; }
 
@@ -29,6 +32,39 @@ public class Job : JobBasic
 
         [JsonPropertyName("is_shared")]
         public bool IsShared { get; set; }
+    }
+
+    public class JobRunnerManager
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    
+        [JsonPropertyName("system_id")]
+        public string SystemId { get; set; }
+    
+        [JsonPropertyName("version")]
+        public string Version { get; set; }
+    
+        [JsonPropertyName("revision")]
+        public string Revision { get; set; }
+    
+        [JsonPropertyName("platform")]
+        public string Platform { get; set; }
+    
+        [JsonPropertyName("architecture")]
+        public string Architecture { get; set; }
+    
+        [JsonPropertyName("created_at")]
+        public DateTime CreatedAt { get; set; }
+    
+        [JsonPropertyName("contacted_at")]
+        public DateTime ContactedAt { get; set; }
+    
+        [JsonPropertyName("ip_address")]
+        public string IpAddress { get; set; }
+    
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
     }
 
     public class JobArtifact

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -11,7 +11,7 @@ public class Job : JobBasic
     public JobRunner Runner { get; set; }
 
     [JsonPropertyName("runner_manager")]
-    public JobRunner Runner { get; set; }
+    public JobRunner RunnerManager { get; set; }
 
     [JsonPropertyName("project")]
     public JobProject Project { get; set; }

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -39,31 +39,31 @@ public class Job : JobBasic
     {
         [JsonPropertyName("id")]
         public long Id { get; set; }
-    
+
         [JsonPropertyName("system_id")]
         public string SystemId { get; set; }
-    
+
         [JsonPropertyName("version")]
         public string Version { get; set; }
-    
+
         [JsonPropertyName("revision")]
         public string Revision { get; set; }
-    
+
         [JsonPropertyName("platform")]
         public string Platform { get; set; }
-    
+
         [JsonPropertyName("architecture")]
         public string Architecture { get; set; }
-    
+
         [JsonPropertyName("created_at")]
         public DateTime CreatedAt { get; set; }
-    
+
         [JsonPropertyName("contacted_at")]
         public DateTime ContactedAt { get; set; }
-    
+
         [JsonPropertyName("ip_address")]
         public string IpAddress { get; set; }
-    
+
         [JsonPropertyName("status")]
         public string Status { get; set; }
     }

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -12,7 +12,7 @@ public class Job : JobBasic
     public JobRunner Runner { get; set; }
 
     [JsonPropertyName("runner_manager")]
-    public JobRunner RunnerManager { get; set; }
+    public JobRunnerManager RunnerManager { get; set; }
 
     [JsonPropertyName("project")]
     public JobProject Project { get; set; }

--- a/NGitLab/Models/Job.cs
+++ b/NGitLab/Models/Job.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+using System;
+using System.Text.Json.Serialization;
 
 namespace NGitLab.Models;
 

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -2511,10 +2511,34 @@ NGitLab.Models.Job.JobRunner.IsShared.set -> void
 NGitLab.Models.Job.JobRunner.JobRunner() -> void
 NGitLab.Models.Job.JobRunner.Name.get -> string
 NGitLab.Models.Job.JobRunner.Name.set -> void
+NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.JobRunnerManager.Architecture.get -> string
+NGitLab.Models.Job.JobRunnerManager.Architecture.set -> void
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.Id.get -> long
+NGitLab.Models.Job.JobRunnerManager.Id.set -> void
+NGitLab.Models.Job.JobRunnerManager.IpAddress.get -> string
+NGitLab.Models.Job.JobRunnerManager.IpAddress.set -> void
+NGitLab.Models.Job.JobRunnerManager.JobRunnerManager() -> void
+NGitLab.Models.Job.JobRunnerManager.Platform.get -> string
+NGitLab.Models.Job.JobRunnerManager.Platform.set -> void
+NGitLab.Models.Job.JobRunnerManager.Revision.get -> string
+NGitLab.Models.Job.JobRunnerManager.Revision.set -> void
+NGitLab.Models.Job.JobRunnerManager.Status.get -> string
+NGitLab.Models.Job.JobRunnerManager.Status.set -> void
+NGitLab.Models.Job.JobRunnerManager.SystemId.get -> string
+NGitLab.Models.Job.JobRunnerManager.SystemId.set -> void
+NGitLab.Models.Job.JobRunnerManager.Version.get -> string
+NGitLab.Models.Job.JobRunnerManager.Version.set -> void
 NGitLab.Models.Job.Project.get -> NGitLab.Models.Job.JobProject
 NGitLab.Models.Job.Project.set -> void
 NGitLab.Models.Job.Runner.get -> NGitLab.Models.Job.JobRunner
 NGitLab.Models.Job.Runner.set -> void
+NGitLab.Models.Job.RunnerManager.get -> NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.RunnerManager.set -> void
 NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Cancel = 0 -> NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Erase = 2 -> NGitLab.Models.JobAction

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2510,10 +2510,34 @@ NGitLab.Models.Job.JobRunner.IsShared.set -> void
 NGitLab.Models.Job.JobRunner.JobRunner() -> void
 NGitLab.Models.Job.JobRunner.Name.get -> string
 NGitLab.Models.Job.JobRunner.Name.set -> void
+NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.JobRunnerManager.Architecture.get -> string
+NGitLab.Models.Job.JobRunnerManager.Architecture.set -> void
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.Id.get -> long
+NGitLab.Models.Job.JobRunnerManager.Id.set -> void
+NGitLab.Models.Job.JobRunnerManager.IpAddress.get -> string
+NGitLab.Models.Job.JobRunnerManager.IpAddress.set -> void
+NGitLab.Models.Job.JobRunnerManager.JobRunnerManager() -> void
+NGitLab.Models.Job.JobRunnerManager.Platform.get -> string
+NGitLab.Models.Job.JobRunnerManager.Platform.set -> void
+NGitLab.Models.Job.JobRunnerManager.Revision.get -> string
+NGitLab.Models.Job.JobRunnerManager.Revision.set -> void
+NGitLab.Models.Job.JobRunnerManager.Status.get -> string
+NGitLab.Models.Job.JobRunnerManager.Status.set -> void
+NGitLab.Models.Job.JobRunnerManager.SystemId.get -> string
+NGitLab.Models.Job.JobRunnerManager.SystemId.set -> void
+NGitLab.Models.Job.JobRunnerManager.Version.get -> string
+NGitLab.Models.Job.JobRunnerManager.Version.set -> void
 NGitLab.Models.Job.Project.get -> NGitLab.Models.Job.JobProject
 NGitLab.Models.Job.Project.set -> void
 NGitLab.Models.Job.Runner.get -> NGitLab.Models.Job.JobRunner
 NGitLab.Models.Job.Runner.set -> void
+NGitLab.Models.Job.RunnerManager.get -> NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.RunnerManager.set -> void
 NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Cancel = 0 -> NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Erase = 2 -> NGitLab.Models.JobAction

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2511,10 +2511,34 @@ NGitLab.Models.Job.JobRunner.IsShared.set -> void
 NGitLab.Models.Job.JobRunner.JobRunner() -> void
 NGitLab.Models.Job.JobRunner.Name.get -> string
 NGitLab.Models.Job.JobRunner.Name.set -> void
+NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.JobRunnerManager.Architecture.get -> string
+NGitLab.Models.Job.JobRunnerManager.Architecture.set -> void
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.ContactedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.get -> System.DateTime
+NGitLab.Models.Job.JobRunnerManager.CreatedAt.set -> void
+NGitLab.Models.Job.JobRunnerManager.Id.get -> long
+NGitLab.Models.Job.JobRunnerManager.Id.set -> void
+NGitLab.Models.Job.JobRunnerManager.IpAddress.get -> string
+NGitLab.Models.Job.JobRunnerManager.IpAddress.set -> void
+NGitLab.Models.Job.JobRunnerManager.JobRunnerManager() -> void
+NGitLab.Models.Job.JobRunnerManager.Platform.get -> string
+NGitLab.Models.Job.JobRunnerManager.Platform.set -> void
+NGitLab.Models.Job.JobRunnerManager.Revision.get -> string
+NGitLab.Models.Job.JobRunnerManager.Revision.set -> void
+NGitLab.Models.Job.JobRunnerManager.Status.get -> string
+NGitLab.Models.Job.JobRunnerManager.Status.set -> void
+NGitLab.Models.Job.JobRunnerManager.SystemId.get -> string
+NGitLab.Models.Job.JobRunnerManager.SystemId.set -> void
+NGitLab.Models.Job.JobRunnerManager.Version.get -> string
+NGitLab.Models.Job.JobRunnerManager.Version.set -> void
 NGitLab.Models.Job.Project.get -> NGitLab.Models.Job.JobProject
 NGitLab.Models.Job.Project.set -> void
 NGitLab.Models.Job.Runner.get -> NGitLab.Models.Job.JobRunner
 NGitLab.Models.Job.Runner.set -> void
+NGitLab.Models.Job.RunnerManager.get -> NGitLab.Models.Job.JobRunnerManager
+NGitLab.Models.Job.RunnerManager.set -> void
 NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Cancel = 0 -> NGitLab.Models.JobAction
 NGitLab.Models.JobAction.Erase = 2 -> NGitLab.Models.JobAction


### PR DESCRIPTION
Currently only `runner` information is set to `Job.Runner`. This PR also processes `runner_manager` and introduces a new property `Job.RunnerManager`.