### PR TITLE
Make NGitLab.Mock.Clients.ClientContext lock `async`-friendly

### DIFF
--- a/NGitLab.Mock.Tests/FileTests.cs
+++ b/NGitLab.Mock.Tests/FileTests.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NUnit.Framework;
+
+namespace NGitLab.Mock.Tests;
+
+public class FileTests
+{
+    [TestCase("README.md", true)]
+    [TestCase("does-not-exist.md", false)]
+    public async Task Test_get_raw_file_async(string fileToLookUp, bool expectSuccess)
+    {
+        // Arrange
+        using var server = new GitLabServer();
+        var user = server.Users.AddNew();
+        var project = user.Namespace.Projects.AddNew(project => project.Visibility = VisibilityLevel.Internal);
+        var initCommit = project.Repository.Commit(user, "Initial commit",
+        [
+            File.CreateFromText("README.md", "This is the initial content"),
+        ]);
+
+        var client = server.CreateClient(user);
+        var filesClient = client.GetRepository(project.Id).Files;
+
+        string downloadedContent = null;
+
+        // Act/Assert
+        if (expectSuccess)
+        {
+            await filesClient.GetRawAsync(fileToLookUp, async stream =>
+            {
+                using var streamReader = new StreamReader(stream);
+                downloadedContent = await streamReader.ReadToEndAsync().ConfigureAwait(false);
+            });
+            Assert.That(downloadedContent, Is.EqualTo("This is the initial content"));
+        }
+        else
+        {
+            Assert.ThrowsAsync<GitLabException>(async () => await filesClient.GetRawAsync(fileToLookUp, _ => Task.CompletedTask).ConfigureAwait(false));
+        }
+    }
+}

--- a/NGitLab.Mock/Clients/ClientContext.cs
+++ b/NGitLab.Mock/Clients/ClientContext.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Threading;
 
 namespace NGitLab.Mock.Clients;
 
 internal sealed class ClientContext
 {
-    private readonly object _operationLock = new();
-
     public ClientContext(GitLabServer server, User user)
     {
         Server = server;
@@ -22,22 +19,17 @@ internal sealed class ClientContext
     public IDisposable BeginOperationScope()
     {
         Server.RaiseOnClientOperation();
-        Monitor.Enter(_operationLock);
-        return new Releaser(_operationLock);
+        return new Releaser();
     }
 
     private sealed class Releaser : IDisposable
     {
-        private readonly object _operationLock;
-
-        public Releaser(object operationLock)
+        public Releaser()
         {
-            _operationLock = operationLock;
         }
 
         public void Dispose()
         {
-            Monitor.Exit(_operationLock);
         }
     }
 }

--- a/NGitLab.Mock/Clients/ClientContext.cs
+++ b/NGitLab.Mock/Clients/ClientContext.cs
@@ -1,35 +1,40 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Threading;
 
 namespace NGitLab.Mock.Clients;
 
-internal sealed class ClientContext
+internal sealed class ClientContext(GitLabServer server, User user)
 {
-    public ClientContext(GitLabServer server, User user)
-    {
-        Server = server;
-        User = user;
-    }
+    private readonly SemaphoreSlim _operationLock = new(1, 1);
 
-    public GitLabServer Server { get; }
+    public GitLabServer Server { get; } = server;
 
-    public User User { get; }
+    public User User { get; } = user;
 
     public bool IsAuthenticated => User != null;
 
     public IDisposable BeginOperationScope()
     {
         Server.RaiseOnClientOperation();
-        return new Releaser();
+        return new Releaser(_operationLock);
     }
 
     private sealed class Releaser : IDisposable
     {
-        public Releaser()
+        private readonly SemaphoreSlim _operationLock;
+
+        public Releaser(SemaphoreSlim operationLock)
         {
+            _operationLock = operationLock;
+            if (Debugger.IsAttached && _operationLock.CurrentCount == 0)
+                Debugger.Break();
+            _operationLock.Wait();
         }
 
         public void Dispose()
         {
+            _operationLock.Release();
         }
     }
 }

--- a/NGitLab.Mock/Clients/GroupHooksClient.cs
+++ b/NGitLab.Mock/Clients/GroupHooksClient.cs
@@ -20,10 +20,15 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
         {
             using (Context.BeginOperationScope())
             {
-                var hooks = GetGroup(_groupId, GroupPermission.Edit).Hooks;
-                return ToClientGroupHooks(hooks).ToList();
+                return GetAllLockless();
             }
         }
+    }
+
+    private List<Models.GroupHook> GetAllLockless()
+    {
+        var hooks = GetGroup(_groupId, GroupPermission.Edit).Hooks;
+        return ToClientGroupHooks(hooks).ToList();
     }
 
     public Models.GroupHook this[long hookId]
@@ -32,7 +37,7 @@ internal sealed class GroupHooksClient : ClientBase, IGroupHooksClient
         {
             using (Context.BeginOperationScope())
             {
-                var hook = All.FirstOrDefault(h => h.Id == hookId) ?? throw GitLabException.NotFound();
+                var hook = GetAllLockless().FirstOrDefault(h => h.Id == hookId) ?? throw GitLabException.NotFound();
                 return hook;
             }
         }


### PR DESCRIPTION
The locking mechanism was reported as throwing a `System.Threading.SynchronizationLockException` when used in an `async` context. This is because continuation of an `await`ed Task may occur on a different thread than the initial one, which means an attempt to release the lock from a different thread than the one that "owns" it.

- Add `NGitLab.Mock.Tests.FileTests` to reproduce the issue
- Implement the solution from #902, **but this causes another issue when all tests are run: a deadlock!**
- ~But wait, is that locking scheme even required? Let's remove it and see what happens...~
- Determine where reentrant locks are attempted and adapt code so we use "lockless" logic within locked scopes