### PR TITLE
Manually bump analyzers and tweak stuff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
       - dependency-name: "Microsoft.AspNetCore.WebUtilities"
       - dependency-name: "Microsoft.Bcl.AsyncInterfaces"
       - dependency-name: "System.Text.Json"
+      # The following should not be bumped until we use .NET 9+, otherwise we'll get
+      #   error CS8032: Could not load file or assembly 'System.Collections.Immutable, Version=9.0.0.0
+      - dependency-name: "Microsoft.CodeAnalysis.BannedApiAnalyzers"
+      - dependency-name: "Microsoft.CodeAnalysis.PublicApiAnalyzers"
       # LibGit2Sharp 0.31.0+ no longer targets net6.0
       - dependency-name: "LibGit2Sharp"
     rebase-strategy: auto

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.201">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
+++ b/NGitLab.Mock.Tests/NGitLab.Mock.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Bump
  - `Meziantou.Analyzer` from 2.0.201 to 2.0.202
  - `NUnit.Analyzers` from 4.8.1 to 4.9.2
- Disable update of `Microsoft.CodeAnalysis.BannedApiAnalyzers` and `Microsoft.CodeAnalysis.PublicApiAnalyzers`, as it causes issues in .NET 8 context

This PR replaces #915