### PR TITLE
Implement Get merge request diffs in MergeRequestClient & Merge base from refs

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -717,6 +717,11 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         throw new NotImplementedException();
     }
 
+    public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid)
+    {
+        throw new NotImplementedException();
+    }
+
     public Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -566,6 +566,11 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
+    public Task<VersionedDiffResult> GetDiffsAsync(long mergeRequestIid, long versionId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
     public IEnumerable<PipelineBasic> GetPipelines(long mergeRequestIid)
     {
         AssertProjectId();

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -4,8 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using NGitLab.Mock.Internals;
 using NGitLab.Models;
+using Commit = NGitLab.Models.Commit;
+using Diff = NGitLab.Models.Diff;
+using Tree = NGitLab.Models.Tree;
 
 namespace NGitLab.Mock.Clients;
 
@@ -136,11 +140,30 @@ internal sealed class RepositoryClient : ClientBase, IRepositoryClient
 
     public CompareResults Compare(CompareQuery query)
     {
-        throw new NotImplementedException();
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(_projectId, ProjectPermission.View);
+            var treeChanges = project.Repository.Compare(query.From, query.To);
+            return new CompareResults()
+            {
+                Diff = treeChanges.Select(change
+                    => new Diff()
+                    {
+                        NewPath = change.Path,
+                        OldPath = change.OldPath,
+                        IsNewFile = change.Status is ChangeKind.Added,
+                        IsDeletedFile = change.Status is ChangeKind.Deleted,
+                        IsRenamedFile = change.Status is ChangeKind.Renamed,
+                    }).ToArray(),
+            };
+        }
     }
 
     public Task<CompareResults> CompareAsync(CompareQuery query, CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException();
+        using (Context.BeginOperationScope())
+        {
+            return Task.FromResult(Compare(query));
+        }
     }
 }

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -109,6 +109,11 @@ internal sealed class RepositoryClient : ClientBase, IRepositoryClient
         }
     }
 
+    public Task<Commit> GetMergeBaseAsync(string[] refs, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
     public Commit GetCommit(Sha1 sha)
     {
         throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/RepositoryClient.cs
+++ b/NGitLab.Mock/Clients/RepositoryClient.cs
@@ -4,12 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using NGitLab.Mock.Internals;
 using NGitLab.Models;
-using Commit = NGitLab.Models.Commit;
-using Diff = NGitLab.Models.Diff;
-using Tree = NGitLab.Models.Tree;
 
 namespace NGitLab.Mock.Clients;
 
@@ -140,30 +136,11 @@ internal sealed class RepositoryClient : ClientBase, IRepositoryClient
 
     public CompareResults Compare(CompareQuery query)
     {
-        using (Context.BeginOperationScope())
-        {
-            var project = GetProject(_projectId, ProjectPermission.View);
-            var treeChanges = project.Repository.Compare(query.From, query.To);
-            return new CompareResults()
-            {
-                Diff = treeChanges.Select(change
-                    => new Diff()
-                    {
-                        NewPath = change.Path,
-                        OldPath = change.OldPath,
-                        IsNewFile = change.Status is ChangeKind.Added,
-                        IsDeletedFile = change.Status is ChangeKind.Deleted,
-                        IsRenamedFile = change.Status is ChangeKind.Renamed,
-                    }).ToArray(),
-            };
-        }
+        throw new NotImplementedException();
     }
 
     public Task<CompareResults> CompareAsync(CompareQuery query, CancellationToken cancellationToken = default)
     {
-        using (Context.BeginOperationScope())
-        {
-            return Task.FromResult(Compare(query));
-        }
+        throw new NotImplementedException();
     }
 }

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -810,19 +810,6 @@ public sealed class Repository : GitLabObject, IDisposable
         return divergence;
     }
 
-    internal TreeChanges Compare(string fromRef, string toRef)
-    {
-        var repository = GetGitRepository();
-        var fromCommit = repository.Lookup<Commit>(fromRef);
-        var toCommit = repository.Lookup<Commit>(toRef);
-
-        if (fromCommit is null || toCommit is null)
-            throw GitLabException.NotFound("One of the commits does not exist");
-
-        var changes = repository.Diff.Compare<TreeChanges>(fromCommit.Tree, toCommit.Tree);
-        return changes;
-    }
-
     internal void GetRawBlob(string sha, Action<Stream> parser)
     {
         var repository = GetGitRepository();

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -810,6 +810,19 @@ public sealed class Repository : GitLabObject, IDisposable
         return divergence;
     }
 
+    internal TreeChanges Compare(string fromRef, string toRef)
+    {
+        var repository = GetGitRepository();
+        var fromCommit = repository.Lookup<Commit>(fromRef);
+        var toCommit = repository.Lookup<Commit>(toRef);
+
+        if (fromCommit is null || toCommit is null)
+            throw GitLabException.NotFound("One of the commits does not exist");
+
+        var changes = repository.Diff.Compare<TreeChanges>(fromCommit.Tree, toCommit.Tree);
+        return changes;
+    }
+
     internal void GetRawBlob(string sha, Action<Stream> parser)
     {
         var repository = GetGitRepository();

--- a/NGitLab.Mock/Repository.cs
+++ b/NGitLab.Mock/Repository.cs
@@ -810,6 +810,21 @@ public sealed class Repository : GitLabObject, IDisposable
         return divergence;
     }
 
+    internal TreeChanges Compare(string fromRef, string toRef)
+    {
+        var repository = GetGitRepository();
+        var fromCommit = repository.Lookup<Commit>(fromRef);
+        var toCommit = repository.Lookup<Commit>(toRef);
+
+        var mergeBase = repository.ObjectDatabase.FindMergeBase(fromCommit, toCommit);
+
+        if (fromCommit is null || toCommit is null)
+            throw GitLabException.NotFound("One of the commits does not exist");
+
+        var changes = repository.Diff.Compare<TreeChanges>(mergeBase.Tree, toCommit.Tree);
+        return changes;
+    }
+
     internal void GetRawBlob(string sha, Action<Stream> parser)
     {
         var repository = GetGitRepository();

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -45,6 +45,8 @@ public interface IMergeRequestClient
 
     IEnumerable<Author> GetParticipants(long mergeRequestIid);
 
+    Task<VersionedDiffResult> GetDiffsAsync(long mergeRequestIid, long versionId, CancellationToken cancellationToken = default);
+
     GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(long mergeRequestIid);
 
     GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid);

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -47,6 +47,8 @@ public interface IMergeRequestClient
 
     GitLabCollectionResponse<MergeRequestVersion> GetVersionsAsync(long mergeRequestIid);
 
+    GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid);
+
     IMergeRequestCommentClient Comments(long mergeRequestIid);
 
     IMergeRequestDiscussionClient Discussions(long mergeRequestIid);

--- a/NGitLab/IRepositoryClient.cs
+++ b/NGitLab/IRepositoryClient.cs
@@ -39,6 +39,8 @@ public interface IRepositoryClient
     /// </summary>
     IEnumerable<Commit> GetCommits(GetCommitsRequest request);
 
+    Task<Commit> GetMergeBaseAsync(string[] refs, CancellationToken cancellationToken = default);
+
     Commit GetCommit(Sha1 sha);
 
     IEnumerable<Diff> GetCommitDiff(Sha1 sha);

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -161,6 +161,11 @@ public class MergeRequestClient : IMergeRequestClient
         return _api.Get().GetAllAsync<MergeRequestVersion>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions");
     }
 
+    public Task<VersionedDiffResult> GetDiffsAsync(long mergeRequestIid, long versionId, CancellationToken cancellationToken = default)
+    {
+        return _api.Get().ToAsync<VersionedDiffResult>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions/" + versionId.ToString(CultureInfo.InvariantCulture), cancellationToken);
+    }
+
     public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid)
     {
         return _api.Get().GetAllAsync<Diff>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/diffs");

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -161,6 +161,11 @@ public class MergeRequestClient : IMergeRequestClient
         return _api.Get().GetAllAsync<MergeRequestVersion>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/versions");
     }
 
+    public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid)
+    {
+        return _api.Get().GetAllAsync<Diff>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/diffs");
+    }
+
     public Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<TimeStats>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/time_stats", cancellationToken);

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -143,7 +143,9 @@ public class RepositoryClient : IRepositoryClient
 
     private string BuildCompareUrl(CompareQuery query)
     {
-        var url = _repoPath + $"/compare?from={query.Source}&to={query.Target}";
+        var from = query.From ?? query.Target;
+        var to = query.To ?? query.Source;
+        var url = _repoPath + $"/compare?from={from}&to={to}";
         url = Utils.AddParameter(url, "from_project_id", query.FromProjectId);
         url = Utils.AddParameter(url, "straight", query.Straight);
         url = Utils.AddParameter(url, "unidiff", query.Unidiff);

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -124,6 +124,13 @@ public class RepositoryClient : IRepositoryClient
     public IEnumerable<Ref> GetCommitRefs(Sha1 sha, CommitRefType type = CommitRefType.All) =>
         _api.Get().GetAll<Ref>($"{_repoPath}/commits/{sha}/refs?type={type.ToString().ToLowerInvariant()}");
 
+    public Task<Commit> GetMergeBaseAsync(string[] refs, CancellationToken cancellationToken = default)
+    {
+        var url = _repoPath + "/merge_base";
+        url = Utils.AddArrayParameter(url, "refs", refs);
+        return _api.Get().ToAsync<Commit>(url, cancellationToken);
+    }
+
     public IFilesClient Files => new FilesClient(_api, _repoPath);
 
     public IBranchClient Branches => new BranchClient(_api, _repoPath);
@@ -143,8 +150,8 @@ public class RepositoryClient : IRepositoryClient
 
     private string BuildCompareUrl(CompareQuery query)
     {
-        var from = query.From ?? query.Target;
-        var to = query.To ?? query.Source;
+        var from = query.From ?? query.Source;
+        var to = query.To ?? query.Target;
         var url = _repoPath + $"/compare?from={from}&to={to}";
         url = Utils.AddParameter(url, "from_project_id", query.FromProjectId);
         url = Utils.AddParameter(url, "straight", query.Straight);

--- a/NGitLab/Models/CompareQuery.cs
+++ b/NGitLab/Models/CompareQuery.cs
@@ -1,4 +1,6 @@
-﻿namespace NGitLab.Models;
+﻿using System;
+
+namespace NGitLab.Models;
 
 /// <summary>
 /// Query details for comparison of branches/tags/commit hashes
@@ -8,12 +10,24 @@ public class CompareQuery
     /// <summary>
     /// The source for comparison, can be a branch, tag or a commit hash.
     /// </summary>
+    [Obsolete("Use 'From' instead.")]
     public string Source { get; set; }
+
+    /// <summary>
+    /// The most recent reference for comparison, can be a branch, tag or a commit hash.
+    /// </summary>
+    public string From { get; set; }
 
     /// <summary>
     /// The target for comparison, can be a branch, tag or a commit hash.
     /// </summary>
+    [Obsolete("Use 'To' instead.")]
     public string Target { get; set; }
+
+    /// <summary>
+    /// The reference to compare against, can be a branch, tag or a commit hash.
+    /// </summary>
+    public string To { get; set; }
 
     /// <summary>
     /// Comparison method: true for direct comparison between from and to (from..to), false to compare using merge base (from…to)’. Default is false.

--- a/NGitLab/Models/CompareQuery.cs
+++ b/NGitLab/Models/CompareQuery.cs
@@ -48,5 +48,7 @@ public class CompareQuery
     {
         Source = source;
         Target = target;
+        From = source;
+        To = target;
     }
 }

--- a/NGitLab/Models/VersionedDiffResult.cs
+++ b/NGitLab/Models/VersionedDiffResult.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace NGitLab.Models;
+
+public class VersionedDiffResult
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("base_commit_sha")]
+    public long BaseCommitSha { get; set; }
+
+    [JsonPropertyName("commits")]
+    public Commit[] Commits { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("diffs")]
+    public Diff[] Diff { get; set; }
+
+    [JsonPropertyName("head_commit_sha")]
+    public string HeadCommitSha { get; set; }
+
+    [JsonPropertyName("merge_request_id")]
+    public long MergeRequestId { get; set; }
+
+    [JsonPropertyName("patch_id_sha")]
+    public string PatchIdSha { get; set; }
+
+    [JsonPropertyName("real_size")]
+    public string RealSize { get; set; }
+
+    [JsonPropertyName("start_commit_sha")]
+    public string StartCommitSha { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; }
+}

--- a/NGitLab/Models/VersionedDiffResult.cs
+++ b/NGitLab/Models/VersionedDiffResult.cs
@@ -9,7 +9,7 @@ public class VersionedDiffResult
     public long Id { get; set; }
 
     [JsonPropertyName("base_commit_sha")]
-    public long BaseCommitSha { get; set; }
+    public string BaseCommitSha { get; set; }
 
     [JsonPropertyName("commits")]
     public Commit[] Commits { get; set; }
@@ -18,7 +18,7 @@ public class VersionedDiffResult
     public DateTime CreatedAt { get; set; }
 
     [JsonPropertyName("diffs")]
-    public Diff[] Diff { get; set; }
+    public Diff[] Diffs { get; set; }
 
     [JsonPropertyName("head_commit_sha")]
     public string HeadCommitSha { get; set; }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4935,6 +4935,30 @@ NGitLab.Models.VariableUpdate.Type.set -> void
 NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
+NGitLab.Models.VersionedDiffResult
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
+NGitLab.Models.VersionedDiffResult.Commits.set -> void
+NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
+NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
+NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Id.get -> long
+NGitLab.Models.VersionedDiffResult.Id.set -> void
+NGitLab.Models.VersionedDiffResult.MergeRequestId.get -> long
+NGitLab.Models.VersionedDiffResult.MergeRequestId.set -> void
+NGitLab.Models.VersionedDiffResult.PatchIdSha.get -> string
+NGitLab.Models.VersionedDiffResult.PatchIdSha.set -> void
+NGitLab.Models.VersionedDiffResult.RealSize.get -> string
+NGitLab.Models.VersionedDiffResult.RealSize.set -> void
+NGitLab.Models.VersionedDiffResult.StartCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.StartCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.State.get -> string
+NGitLab.Models.VersionedDiffResult.State.set -> void
+NGitLab.Models.VersionedDiffResult.VersionedDiffResult() -> void
 NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Internal = 10 -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Private = 0 -> NGitLab.Models.VisibilityLevel

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1671,6 +1671,8 @@ NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
 NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.From.get -> string
+NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
 NGitLab.Models.CompareQuery.Source.get -> string
@@ -1679,6 +1681,8 @@ NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
 NGitLab.Models.CompareQuery.Target.get -> string
 NGitLab.Models.CompareQuery.Target.set -> void
+NGitLab.Models.CompareQuery.To.get -> string
+NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?
 NGitLab.Models.CompareQuery.Unidiff.set -> void
 NGitLab.Models.CompareResults

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4942,14 +4942,14 @@ NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
 NGitLab.Models.VersionedDiffResult
-NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
 NGitLab.Models.VersionedDiffResult.Commits.set -> void
 NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
 NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
-NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
-NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.Diffs.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diffs.set -> void
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Id.get -> long

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -903,6 +903,7 @@ NGitLab.Impl.RepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collecti
 NGitLab.Impl.RepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.Impl.RepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.Impl.RepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.RepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
@@ -1138,6 +1139,7 @@ NGitLab.IRepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collections.
 NGitLab.IRepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.IRepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.IRepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.IRepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.IRepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -423,6 +423,7 @@ NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeR
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -737,6 +738,7 @@ NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMe
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -422,6 +422,7 @@ NGitLab.IMergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -735,6 +736,7 @@ NGitLab.Impl.MergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4941,14 +4941,14 @@ NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
 NGitLab.Models.VersionedDiffResult
-NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
 NGitLab.Models.VersionedDiffResult.Commits.set -> void
 NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
 NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
-NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
-NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.Diffs.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diffs.set -> void
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Id.get -> long

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -902,6 +902,7 @@ NGitLab.Impl.RepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collecti
 NGitLab.Impl.RepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.Impl.RepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.Impl.RepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.RepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
@@ -1137,6 +1138,7 @@ NGitLab.IRepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collections.
 NGitLab.IRepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.IRepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.IRepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.IRepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.IRepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1670,6 +1670,8 @@ NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
 NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.From.get -> string
+NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
 NGitLab.Models.CompareQuery.Source.get -> string
@@ -1678,6 +1680,8 @@ NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
 NGitLab.Models.CompareQuery.Target.get -> string
 NGitLab.Models.CompareQuery.Target.set -> void
+NGitLab.Models.CompareQuery.To.get -> string
+NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?
 NGitLab.Models.CompareQuery.Unidiff.set -> void
 NGitLab.Models.CompareResults

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -421,6 +421,7 @@ NGitLab.IMergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -734,6 +735,7 @@ NGitLab.Impl.MergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -422,6 +422,7 @@ NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeR
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -736,6 +737,7 @@ NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMe
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -4932,6 +4934,30 @@ NGitLab.Models.VariableUpdate.Type.set -> void
 NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
+NGitLab.Models.VersionedDiffResult
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
+NGitLab.Models.VersionedDiffResult.Commits.set -> void
+NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
+NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
+NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Id.get -> long
+NGitLab.Models.VersionedDiffResult.Id.set -> void
+NGitLab.Models.VersionedDiffResult.MergeRequestId.get -> long
+NGitLab.Models.VersionedDiffResult.MergeRequestId.set -> void
+NGitLab.Models.VersionedDiffResult.PatchIdSha.get -> string
+NGitLab.Models.VersionedDiffResult.PatchIdSha.set -> void
+NGitLab.Models.VersionedDiffResult.RealSize.get -> string
+NGitLab.Models.VersionedDiffResult.RealSize.set -> void
+NGitLab.Models.VersionedDiffResult.StartCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.StartCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.State.get -> string
+NGitLab.Models.VersionedDiffResult.State.set -> void
+NGitLab.Models.VersionedDiffResult.VersionedDiffResult() -> void
 NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Internal = 10 -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Private = 0 -> NGitLab.Models.VisibilityLevel

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4934,6 +4934,30 @@ NGitLab.Models.VariableUpdate.Type.set -> void
 NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
+NGitLab.Models.VersionedDiffResult
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
+NGitLab.Models.VersionedDiffResult.Commits.set -> void
+NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
+NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
+NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.Id.get -> long
+NGitLab.Models.VersionedDiffResult.Id.set -> void
+NGitLab.Models.VersionedDiffResult.MergeRequestId.get -> long
+NGitLab.Models.VersionedDiffResult.MergeRequestId.set -> void
+NGitLab.Models.VersionedDiffResult.PatchIdSha.get -> string
+NGitLab.Models.VersionedDiffResult.PatchIdSha.set -> void
+NGitLab.Models.VersionedDiffResult.RealSize.get -> string
+NGitLab.Models.VersionedDiffResult.RealSize.set -> void
+NGitLab.Models.VersionedDiffResult.StartCommitSha.get -> string
+NGitLab.Models.VersionedDiffResult.StartCommitSha.set -> void
+NGitLab.Models.VersionedDiffResult.State.get -> string
+NGitLab.Models.VersionedDiffResult.State.set -> void
+NGitLab.Models.VersionedDiffResult.VersionedDiffResult() -> void
 NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Internal = 10 -> NGitLab.Models.VisibilityLevel
 NGitLab.Models.VisibilityLevel.Private = 0 -> NGitLab.Models.VisibilityLevel

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -738,6 +738,7 @@ NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMe
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -902,6 +903,7 @@ NGitLab.Impl.RepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collecti
 NGitLab.Impl.RepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.Impl.RepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.Impl.RepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.Impl.RepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.Impl.RepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.Impl.RepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
@@ -1137,6 +1139,7 @@ NGitLab.IRepositoryClient.GetCommitDiff(NGitLab.Sha1 sha) -> System.Collections.
 NGitLab.IRepositoryClient.GetCommitRefs(NGitLab.Sha1 sha, NGitLab.Models.CommitRefType type = NGitLab.Models.CommitRefType.All) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Ref>
 NGitLab.IRepositoryClient.GetCommits(NGitLab.GetCommitsRequest request) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetCommits(string refName, int maxResults = 0) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Commit>
+NGitLab.IRepositoryClient.GetMergeBaseAsync(string[] refs, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Commit>
 NGitLab.IRepositoryClient.GetRawBlob(string sha, System.Action<System.IO.Stream> parser) -> void
 NGitLab.IRepositoryClient.GetTree(NGitLab.Models.RepositoryGetTreeOptions options) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>
 NGitLab.IRepositoryClient.GetTree(string path) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Tree>

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4942,14 +4942,14 @@ NGitLab.Models.VariableUpdate.Value.get -> string
 NGitLab.Models.VariableUpdate.Value.set -> void
 NGitLab.Models.VariableUpdate.VariableUpdate() -> void
 NGitLab.Models.VersionedDiffResult
-NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> long
+NGitLab.Models.VersionedDiffResult.BaseCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.BaseCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Commits.get -> NGitLab.Models.Commit[]
 NGitLab.Models.VersionedDiffResult.Commits.set -> void
 NGitLab.Models.VersionedDiffResult.CreatedAt.get -> System.DateTime
 NGitLab.Models.VersionedDiffResult.CreatedAt.set -> void
-NGitLab.Models.VersionedDiffResult.Diff.get -> NGitLab.Models.Diff[]
-NGitLab.Models.VersionedDiffResult.Diff.set -> void
+NGitLab.Models.VersionedDiffResult.Diffs.get -> NGitLab.Models.Diff[]
+NGitLab.Models.VersionedDiffResult.Diffs.set -> void
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.get -> string
 NGitLab.Models.VersionedDiffResult.HeadCommitSha.set -> void
 NGitLab.Models.VersionedDiffResult.Id.get -> long

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1670,6 +1670,8 @@ NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
 NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.From.get -> string
+NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
 NGitLab.Models.CompareQuery.Source.get -> string
@@ -1678,6 +1680,8 @@ NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
 NGitLab.Models.CompareQuery.Target.get -> string
 NGitLab.Models.CompareQuery.Target.set -> void
+NGitLab.Models.CompareQuery.To.get -> string
+NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?
 NGitLab.Models.CompareQuery.Unidiff.set -> void
 NGitLab.Models.CompareResults

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -423,6 +423,7 @@ NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeR
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, long versionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.VersionedDiffResult>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -422,6 +422,7 @@ NGitLab.IMergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.IMergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.IMergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.IMergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.IMergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.IMergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.IMergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>
@@ -735,6 +736,7 @@ NGitLab.Impl.MergeRequestClient.Delete(long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestClient.Discussions(long mergeRequestIid) -> NGitLab.IMergeRequestDiscussionClient
 NGitLab.Impl.MergeRequestClient.Get(NGitLab.Models.MergeRequestQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.MergeRequest>
 NGitLab.Impl.MergeRequestClient.GetByIidAsync(long iid, NGitLab.Models.SingleMergeRequestQuery options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.MergeRequest>
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
 NGitLab.Impl.MergeRequestClient.GetParticipants(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Author>
 NGitLab.Impl.MergeRequestClient.GetPipelines(long mergeRequestIid) -> System.Collections.Generic.IEnumerable<NGitLab.Models.PipelineBasic>
 NGitLab.Impl.MergeRequestClient.GetVersionsAsync(long mergeRequestIid) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.MergeRequestVersion>


### PR DESCRIPTION
Implementations:
- Get merge request diff (https://docs.gitlab.com/api/merge_requests/#list-merge-request-diffs)
- Get versioned merge request diff (https://docs.gitlab.com/api/merge_requests/#get-a-single-merge-request-diff-version)
- Get merge base commit from refs (https://docs.gitlab.com/api/repositories/#get-merge-base)