### PR TITLE
feat: add WithMergeStatusRecheck property

### DIFF
--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -62,7 +62,7 @@ public class MergeRequestClient : IMergeRequestClient
         url = Utils.AddParameter(url, "target_branch", query.TargetBranch);
         url = Utils.AddParameter(url, "search", query.Search);
         url = Utils.AddParameter(url, "wip", query.Wip.HasValue ? (query.Wip.Value ? "yes" : "no") : null);
-        url = Utils.AddParameter(url, "with_merge_status_recheck", query.WithMergeStatusRecheck.HasValue ? query.WithMergeStatusRecheck.Value.ToString().ToLower() : null));
+        url = Utils.AddParameter(url, "with_merge_status_recheck", query.WithMergeStatusRecheck?.ToString().ToLowerInvariant());
 
         return _api.Get().GetAll<MergeRequest>(url);
     }

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -62,6 +62,7 @@ public class MergeRequestClient : IMergeRequestClient
         url = Utils.AddParameter(url, "target_branch", query.TargetBranch);
         url = Utils.AddParameter(url, "search", query.Search);
         url = Utils.AddParameter(url, "wip", query.Wip.HasValue ? (query.Wip.Value ? "yes" : "no") : null);
+        url = Utils.AddParameter(url, "with_merge_status_recheck", query.WithMergeStatusRecheck.HasValue ? query.WithMergeStatusRecheck.Value.ToString().ToLower() : null));
 
         return _api.Get().GetAll<MergeRequest>(url);
     }

--- a/NGitLab/Models/MergeRequestQuery.cs
+++ b/NGitLab/Models/MergeRequestQuery.cs
@@ -107,4 +107,9 @@ public class MergeRequestQuery
     /// Filter merge requests against their wip status. yes to return only WIP merge requests, no to return non WIP merge requests
     /// </summary>
     public bool? Wip { get; set; }
+
+    /// <summary>
+    /// Listing merge requests might not proactively update <see cref="MergeRequest.MergeStatus"/> (which also affects <see cref="MergeRequest.HasConflicts"/>), as this can be an expensive operation. If you need the value of these fields from this endpoint, set this parameter to true.
+    /// </summary>
+    public bool? WithMergeStatusRecheck { get; set; }
 }


### PR DESCRIPTION
Add missing property `WithMergeStatusRecheck` to `MergeRequestQuery`.

From GitLab documentation
> Listing merge requests might not proactively update merge_status (which also affects the has_conflicts), as this can be an expensive operation. If you need the value of these fields from this endpoint, set the with_merge_status_recheck parameter to true in the query.