### PR TITLE
Make Dependabot run updates at a specific time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# See documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
@@ -19,7 +17,10 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Montreal"
     ignore:
       # Don't bump these to 9.x.y, as those versions may not be totally compatible with .NET 6 or 8
       - dependency-name: "Microsoft.AspNetCore.WebUtilities"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is NGitLab?
 
-`NGitLab` is a .NET REST client implementation for the GitLab API.
+`NGitLab` is a .NET client implementation for the GitLab REST API.
 
 ## Usage
 
@@ -14,7 +14,7 @@ var client = new GitLabClient("https://mygitlab.example.com", "your_private_toke
 
 Then use its properties. You can obtain the private token in your account page. You may want to create a custom user for the API usage.
 
-For further info about the GitLab API, refer to [the official documentation](https://docs.gitlab.com/ee/api/rest/)
+For further info about the GitLab API, refer to [the official documentation](https://docs.gitlab.com/api/rest/)
 
 ## Where can I get it?
 
@@ -27,9 +27,9 @@ dotnet add package NGitLab
 ## Running Unit Tests locally
 
 - Install Docker on your machine
-- It's recommended to use WSL version 2: https://docs.microsoft.com/en-us/windows/wsl/install-win10
-- Executing tests under Linux requires PowerShell to be installed. (https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux)
+- It's recommended to use WSL version 2 _(see [here](https://learn.microsoft.com/en-us/windows/wsl/install))_
+- Executing tests under Linux requires PowerShell to be installed _(see [here](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux))_
 
 ## Thanks
 
-Thanks to [Scooletz](https://github.com/Scooletz) for initiating the original project.
+Thanks to [Scooletz](https://github.com/Scooletz) for creating the original project.


### PR DESCRIPTION
By default, Dependabot randomizes the time at which it performs updates. This is rather inconvenient for us.