### PR TITLE
fix!: Make SearchBlob.Ref a string rather than a Sha1

### DIFF
--- a/NGitLab/Models/SearchBlob.cs
+++ b/NGitLab/Models/SearchBlob.cs
@@ -17,7 +17,7 @@ public class SearchBlob
     public string FileName { get; set; }
 
     [JsonPropertyName("ref")]
-    public Sha1 Ref { get; set; }
+    public string Ref { get; set; }
 
     [JsonPropertyName("startline")]
     public int StartLine { get; set; }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4378,7 +4378,7 @@ NGitLab.Models.SearchBlob.Path.get -> string
 NGitLab.Models.SearchBlob.Path.set -> void
 NGitLab.Models.SearchBlob.ProjectId.get -> long
 NGitLab.Models.SearchBlob.ProjectId.set -> void
-NGitLab.Models.SearchBlob.Ref.get -> NGitLab.Sha1
+NGitLab.Models.SearchBlob.Ref.get -> string
 NGitLab.Models.SearchBlob.Ref.set -> void
 NGitLab.Models.SearchBlob.SearchBlob() -> void
 NGitLab.Models.SearchBlob.StartLine.get -> int

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4377,7 +4377,7 @@ NGitLab.Models.SearchBlob.Path.get -> string
 NGitLab.Models.SearchBlob.Path.set -> void
 NGitLab.Models.SearchBlob.ProjectId.get -> long
 NGitLab.Models.SearchBlob.ProjectId.set -> void
-NGitLab.Models.SearchBlob.Ref.get -> NGitLab.Sha1
+NGitLab.Models.SearchBlob.Ref.get -> string
 NGitLab.Models.SearchBlob.Ref.set -> void
 NGitLab.Models.SearchBlob.SearchBlob() -> void
 NGitLab.Models.SearchBlob.StartLine.get -> int

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4378,7 +4378,7 @@ NGitLab.Models.SearchBlob.Path.get -> string
 NGitLab.Models.SearchBlob.Path.set -> void
 NGitLab.Models.SearchBlob.ProjectId.get -> long
 NGitLab.Models.SearchBlob.ProjectId.set -> void
-NGitLab.Models.SearchBlob.Ref.get -> NGitLab.Sha1
+NGitLab.Models.SearchBlob.Ref.get -> string
 NGitLab.Models.SearchBlob.Ref.set -> void
 NGitLab.Models.SearchBlob.SearchBlob() -> void
 NGitLab.Models.SearchBlob.StartLine.get -> int


### PR DESCRIPTION
From the [GitLab API doc](https://docs.gitlab.com/api/search/#scope-blobs-1) here's an example of what  

```sh
curl --header "PRIVATE-TOKEN: <your_access_token>" "https://gitlab.example.com/api/v4/groups/6/search?scope=blobs&search=installation"
```

might return:

```json
[
  {
    "basename": "README",
    "data": "```\n\n## Installation\n\nQuick start using the [pre-built",
    "path": "README.md",
    "filename": "README.md",
    "id": null,
    "ref": "main",
    "startline": 46,
    "project_id": 6
  }
]
```

Currently, this would throw as `ref` is being deserialized as a `Sha1`. We need to keep it as a `string`.

Closes #927