### PR TITLE
Use NeoSmart.AsyncLock in NGitLab.Mock.Clients.ClientContext

### DIFF
--- a/NGitLab.Mock/Clients/ClientContext.cs
+++ b/NGitLab.Mock/Clients/ClientContext.cs
@@ -1,58 +1,21 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Threading;
+using NeoSmart.AsyncLock;
 
 namespace NGitLab.Mock.Clients;
 
 internal sealed class ClientContext(GitLabServer server, User user)
 {
-    private readonly SemaphoreSlim _operationLock = new(1, 1);
+    private readonly AsyncLock _operationLock = new();
 
     public GitLabServer Server { get; } = server;
 
     public User User { get; } = user;
 
-    public bool IsAuthenticated => User != null;
+    public bool IsAuthenticated => User is not null;
 
-    public IDisposable BeginOperationScope(
-        [CallerMemberName] string callingMethod = null,
-        [CallerFilePath] string callingFilePath = null,
-        [CallerLineNumber] int callingLineNumber = -1)
+    public IDisposable BeginOperationScope()
     {
         Server.RaiseOnClientOperation();
-        var releaser = new Releaser(_operationLock);
-
-        // Store caller info for debugging purposes
-        Releaser.MethodWhereLockWasTaken = callingMethod;
-        Releaser.FilePathWhereLockWasTaken = callingFilePath;
-        Releaser.LineNumberWhereLockWasTaken = callingLineNumber;
-
-        return releaser;
-    }
-
-    private sealed class Releaser : IDisposable
-    {
-        private readonly SemaphoreSlim _operationLock;
-
-        public Releaser(SemaphoreSlim operationLock)
-        {
-            _operationLock = operationLock;
-            if (_operationLock.CurrentCount == 0 && Debugger.IsAttached)
-                Debugger.Break();
-            _operationLock.Wait();
-        }
-
-        // The following is for debugging purposes only. It stores info about where the active lock was taken.
-        public static string MethodWhereLockWasTaken { get; set; }
-
-        public static string FilePathWhereLockWasTaken { get; set; }
-
-        public static int LineNumberWhereLockWasTaken { get; set; }
-
-        public void Dispose()
-        {
-            _operationLock.Release();
-        }
+        return _operationLock.Lock();
     }
 }

--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
After a few attempts at fixing the `SemaphoreSlim`-based `ClientContext`, which caused problems because it did not support reentrancy, use something that does: `NeoSmart.AsyncLock`. It is said to be an `async`/`await`-friendly replacement for the `lock` implementation.

See https://neosmart.net/blog/asynclock-an-asyncawait-friendly-locking-library-for-c-and-net/