### PR TITLE
Tag MergeRequest.MergeStatus as Obsolete + tweak other obsolescence

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -84,6 +84,7 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         }
     }
 
+    [Obsolete("Use the Accept method that takes a MergeRequestMerge")]
     public Models.MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message)
     {
         return Accept(mergeRequestIid, new MergeRequestMerge

--- a/NGitLab.Mock/MergeRequest.cs
+++ b/NGitLab.Mock/MergeRequest.cs
@@ -307,6 +307,7 @@ public sealed class MergeRequest : GitLabObject
             WorkInProgress = WorkInProgress,
             Squash = Squash,
             MergeStatus = "can_be_merged",
+            DetailedMergeStatus = new DynamicEnum<DetailedMergeStatus>(DetailedMergeStatus.Mergeable),
             State = State.ToString(),
             WebUrl = WebUrl,
             HeadPipeline = HeadPipeline?.ToPipelineClient(),

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -125,11 +125,11 @@ public sealed class GitLabTestContext : IDisposable
                 Name = GetUniqueRandomString(),
                 DefaultBranch = defaultBranch,
                 Description = "Test project",
-                IssuesEnabled = true,
-                MergeRequestsEnabled = true,
-                SnippetsEnabled = true,
+                IssuesAccessLevel = "enabled",
+                MergeRequestsAccessLevel = "enabled",
+                SnippetsAccessLevel = "enabled",
                 VisibilityLevel = VisibilityLevel.Internal,
-                WikiEnabled = true,
+                WikiAccessLevel = "enabled",
             };
 
             configure?.Invoke(projectCreate);

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -30,7 +30,7 @@ public class MergeRequestClientTests
 
         await GitLabTestContext.RetryUntilAsync(
                 () => mergeRequestClient[mergeRequest.Iid],
-                mr => string.Equals(mr.MergeStatus, "can_be_merged", StringComparison.Ordinal),
+                mr => mr.DetailedMergeStatus == DetailedMergeStatus.Mergeable,
                 TimeSpan.FromSeconds(120))
             .ConfigureAwait(false);
 

--- a/NGitLab.Tests/PipelineTests.cs
+++ b/NGitLab.Tests/PipelineTests.cs
@@ -11,7 +11,7 @@ using Polly;
 
 namespace NGitLab.Tests;
 
-[Timeout(240_000)]
+[CancelAfter(240_000)]
 public class PipelineTests
 {
     [Test]

--- a/NGitLab.Tests/ProjectsTests.cs
+++ b/NGitLab.Tests/ProjectsTests.cs
@@ -299,10 +299,9 @@ public class ProjectsTests
         Assert.That(context.LastRequest.RequestUri.ToString(), Contains.Substring("per_page=5"));
     }
 
-    [TestCase(false)]
-    [TestCase(true)]
+    [Test]
     [NGitLabRetry]
-    public async Task CreateUpdateDelete(bool initiallySetTagsInsteadOfTopics)
+    public async Task CreateUpdateDelete()
     {
         using var context = await GitLabTestContext.CreateAsync();
         var projectClient = context.Client.Projects;
@@ -310,46 +309,39 @@ public class ProjectsTests
         var project = new ProjectCreate
         {
             Description = "desc",
-            IssuesEnabled = true,
-            MergeRequestsEnabled = true,
+            IssuesAccessLevel = "enabled",
+            MergeRequestsAccessLevel = "enabled",
             Name = "CreateDelete_Test_" + context.GetRandomNumber().ToStringInvariant(),
             NamespaceId = null,
-            SnippetsEnabled = true,
+            SnippetsAccessLevel = "enabled",
             VisibilityLevel = VisibilityLevel.Internal,
-            WikiEnabled = true,
+            WikiAccessLevel = "enabled",
         };
 
-        var expectedTopics = new List<string> { "Tag-1", "Tag-2" };
-        if (initiallySetTagsInsteadOfTopics)
-            project.Tags = expectedTopics;
-        else
-            project.Topics = expectedTopics;
+        project.Topics = ["Tag-1", "Tag-2"];
 
         var createdProject = projectClient.Create(project);
 
         Assert.That(createdProject.Description, Is.EqualTo(project.Description));
-        Assert.That(createdProject.IssuesEnabled, Is.EqualTo(project.IssuesEnabled));
-        Assert.That(createdProject.MergeRequestsEnabled, Is.EqualTo(project.MergeRequestsEnabled));
+        Assert.That(createdProject.IssuesAccessLevel, Is.EqualTo(project.IssuesAccessLevel));
+        Assert.That(createdProject.MergeRequestsAccessLevel, Is.EqualTo(project.MergeRequestsAccessLevel));
         Assert.That(createdProject.Name, Is.EqualTo(project.Name));
         Assert.That(createdProject.VisibilityLevel, Is.EqualTo(project.VisibilityLevel));
-        Assert.That(createdProject.Topics, Is.EquivalentTo(expectedTopics));
-        Assert.That(createdProject.TagList, Is.EquivalentTo(expectedTopics));
+        Assert.That(createdProject.Topics, Is.EquivalentTo(project.Topics));
         Assert.That(createdProject.RepositoryAccessLevel, Is.EqualTo(RepositoryAccessLevel.Enabled));
 
         // Update
-        expectedTopics = ["Tag-3"];
+        var expectedTopics = new List<string> { "Tag-3" };
         var updateOptions = new ProjectUpdate { Visibility = VisibilityLevel.Private, Topics = expectedTopics };
         var updatedProject = projectClient.Update(createdProject.Id.ToStringInvariant(), updateOptions);
         Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Private));
         Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
-        Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
 
         updateOptions.Visibility = VisibilityLevel.Public;
         updateOptions.Topics = null;    // If Topics are null, the project's existing topics will remain
         updatedProject = projectClient.Update(createdProject.Id.ToStringInvariant(), updateOptions);
         Assert.That(updatedProject.VisibilityLevel, Is.EqualTo(VisibilityLevel.Public));
         Assert.That(updatedProject.Topics, Is.EquivalentTo(expectedTopics));
-        Assert.That(updatedProject.TagList, Is.EquivalentTo(expectedTopics));
 
         var updatedProject2 = projectClient.Update(createdProject.PathWithNamespace, new ProjectUpdate { Visibility = VisibilityLevel.Internal });
         Assert.That(updatedProject2.VisibilityLevel, Is.EqualTo(VisibilityLevel.Internal));
@@ -374,8 +366,8 @@ public class ProjectsTests
             Description = "desc",
             DefaultBranch = "foo",
             InitializeWithReadme = true,
-            IssuesEnabled = true,
-            MergeRequestsEnabled = true,
+            IssuesAccessLevel = "enabled",
+            MergeRequestsAccessLevel = "enabled",
             VisibilityLevel = VisibilityLevel.Private,
             Topics = ["t1", "t2"],
             BuildTimeout = (int)TimeSpan.FromMinutes(15).TotalSeconds,
@@ -393,8 +385,8 @@ public class ProjectsTests
             Assert.That(actual.PathWithNamespace, Is.EqualTo($"{user.Username}/{expected.Path}"));
             Assert.That(actual.Description, Is.EqualTo(expected.Description));
             Assert.That(actual.DefaultBranch, Is.EqualTo(expected.DefaultBranch));
-            Assert.That(actual.IssuesEnabled, Is.EqualTo(expected.IssuesEnabled));
-            Assert.That(actual.MergeRequestsEnabled, Is.EqualTo(expected.MergeRequestsEnabled));
+            Assert.That(actual.IssuesAccessLevel, Is.EqualTo(expected.IssuesAccessLevel));
+            Assert.That(actual.MergeRequestsAccessLevel, Is.EqualTo(expected.MergeRequestsAccessLevel));
             Assert.That(actual.VisibilityLevel, Is.EqualTo(expected.VisibilityLevel));
             Assert.That(actual.Topics, Is.EquivalentTo(expected.Topics));
             Assert.That(actual.RepositoryAccessLevel, Is.EqualTo(RepositoryAccessLevel.Enabled));
@@ -601,13 +593,13 @@ public class ProjectsTests
         var createdProject = context.CreateProject(p =>
         {
             p.Description = "desc";
-            p.IssuesEnabled = true;
-            p.MergeRequestsEnabled = true;
+            p.IssuesAccessLevel = "enabled";
+            p.MergeRequestsAccessLevel = "enabled";
             p.Name = "ForkProject_Test_" + context.GetRandomNumber().ToStringInvariant();
             p.NamespaceId = null;
-            p.SnippetsEnabled = true;
+            p.SnippetsAccessLevel = "enabled";
             p.VisibilityLevel = VisibilityLevel.Internal;
-            p.WikiEnabled = true;
+            p.WikiAccessLevel = "enabled";
             p.Topics = ["Tag-1", "Tag-2"];
         });
 

--- a/NGitLab.Tests/TriggerTests.cs
+++ b/NGitLab.Tests/TriggerTests.cs
@@ -9,7 +9,7 @@ public class TriggerTests
 {
     [Test]
     [NGitLabRetry]
-    [Timeout(10000)]
+    [CancelAfter(10000)]
     public async Task Test_can_get_triggers_for_project()
     {
         using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -30,7 +30,7 @@ public interface IMergeRequestClient
 
     MergeRequest CancelMergeWhenPipelineSucceeds(long mergeRequestIid);
 
-    [Obsolete("You should use MergeRequestMerge instead of MergeRequestAccept")]
+    [Obsolete("Use the Accept method that takes a MergeRequestMerge")]
     MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message);
 
     MergeRequest Accept(long mergeRequestIid, MergeRequestMerge message);

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -121,6 +121,7 @@ public class MergeRequestClient : IMergeRequestClient
         .Post()
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/cancel_merge_when_pipeline_succeeds");
 
+    [Obsolete("Use the Accept method that takes a MergeRequestMerge")]
     public MergeRequest Accept(long mergeRequestIid, MergeRequestAccept message) => _api
         .Put().With(message)
         .To<MergeRequest>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/merge");

--- a/NGitLab/Models/DetailedMergeStatus.cs
+++ b/NGitLab/Models/DetailedMergeStatus.cs
@@ -1,14 +1,17 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace NGitLab.Models;
 
 /// <summary>
-/// Values that represent <see href="https://docs.gitlab.com/ee/api/merge_requests.html#merge-status">the 'detailed_merge_status' potential values</see>.
+/// Some of the possible <see href="https://docs.gitlab.com/api/merge_requests/#merge-status">detailed_merge_status</see> values.
 /// </summary>
 public enum DetailedMergeStatus
 {
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "blocked_status")]
     BlockedStatus,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "broken_status")]
     BrokenStatus,
     [EnumMember(Value = "checking")]
@@ -23,6 +26,7 @@ public enum DetailedMergeStatus
     DiscussionsNotResolved,
     [EnumMember(Value = "draft_status")]
     DraftStatus,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "external_status_checks")]
     ExternalStatusChecks,
     [EnumMember(Value = "mergeable")]
@@ -31,9 +35,9 @@ public enum DetailedMergeStatus
     NotApproved,
     [EnumMember(Value = "not_open")]
     NotOpen,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "policies_denied")]
     PoliciesDenied,
-    // Undocumented member
     [EnumMember(Value = "preparing")]
     Preparing,
 }

--- a/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/Models/MergeRequest.cs
@@ -75,6 +75,7 @@ public class MergeRequest
     [JsonPropertyName("merge_when_pipeline_succeeds")]
     public bool MergeWhenPipelineSucceeds { get; set; }
 
+    [Obsolete("Deprecated in GitLab 15.6. Use DetailedMergeStatus instead.")]
     [JsonPropertyName("merge_status")]
     public string MergeStatus { get; set; }
 


### PR DESCRIPTION
- GitLab deprecated `merge_status` in version 15.6, so adapt code to use `detailed_merge_status` instead
- Tag as obsolete the members of the `DetailedMergeStatus` enum that don't have counterparts listed in the GitLab API documentation.
- Modify tests so that they use less obsolete stuff