### PR TITLE
Use MergeRequest.DetailedMergeStatus instead of MergeStatus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
       TestResultsDirectory: ${{github.workspace}}/TestResults
     strategy:
       matrix:
-        # Keep in sync with the version in GitLabDockerContainer.cs
-        # Available tags: https://hub.docker.com/r/gitlab/gitlab-ee/tags
         gitlab:
+          # Keep in sync with the version in GitLabDockerContainer.cs
+          # Available tags: https://hub.docker.com/r/gitlab/gitlab-ee/tags?name=-ee.0
           - "gitlab/gitlab-ee:15.11.9-ee.0"
           - "gitlab/gitlab-ee:16.11.10-ee.0"
           - "gitlab/gitlab-ee:17.0.8-ee.0"

--- a/NGitLab.Mock/MergeRequest.cs
+++ b/NGitLab.Mock/MergeRequest.cs
@@ -307,6 +307,7 @@ public sealed class MergeRequest : GitLabObject
             WorkInProgress = WorkInProgress,
             Squash = Squash,
             MergeStatus = "can_be_merged",
+            DetailedMergeStatus = new DynamicEnum<DetailedMergeStatus>(DetailedMergeStatus.Mergeable),
             State = State.ToString(),
             WebUrl = WebUrl,
             HeadPipeline = HeadPipeline?.ToPipelineClient(),

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -30,7 +30,7 @@ public class MergeRequestClientTests
 
         await GitLabTestContext.RetryUntilAsync(
                 () => mergeRequestClient[mergeRequest.Iid],
-                mr => string.Equals(mr.MergeStatus, "can_be_merged", StringComparison.Ordinal),
+                mr => mr.DetailedMergeStatus == DetailedMergeStatus.Mergeable,
                 TimeSpan.FromSeconds(120))
             .ConfigureAwait(false);
 

--- a/NGitLab.Tests/PipelineTests.cs
+++ b/NGitLab.Tests/PipelineTests.cs
@@ -11,7 +11,7 @@ using Polly;
 
 namespace NGitLab.Tests;
 
-[Timeout(240_000)]
+[CancelAfter(240_000)]
 public class PipelineTests
 {
     [Test]

--- a/NGitLab.Tests/TriggerTests.cs
+++ b/NGitLab.Tests/TriggerTests.cs
@@ -9,7 +9,7 @@ public class TriggerTests
 {
     [Test]
     [NGitLabRetry]
-    [Timeout(10000)]
+    [CancelAfter(10000)]
     public async Task Test_can_get_triggers_for_project()
     {
         using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab/Models/DetailedMergeStatus.cs
+++ b/NGitLab/Models/DetailedMergeStatus.cs
@@ -1,14 +1,17 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 
 namespace NGitLab.Models;
 
 /// <summary>
-/// Values that represent <see href="https://docs.gitlab.com/ee/api/merge_requests.html#merge-status">the 'detailed_merge_status' potential values</see>.
+/// Some of the possible <see href="https://docs.gitlab.com/api/merge_requests/#merge-status">detailed_merge_status</see> values.
 /// </summary>
 public enum DetailedMergeStatus
 {
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "blocked_status")]
     BlockedStatus,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "broken_status")]
     BrokenStatus,
     [EnumMember(Value = "checking")]
@@ -23,6 +26,7 @@ public enum DetailedMergeStatus
     DiscussionsNotResolved,
     [EnumMember(Value = "draft_status")]
     DraftStatus,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "external_status_checks")]
     ExternalStatusChecks,
     [EnumMember(Value = "mergeable")]
@@ -31,9 +35,9 @@ public enum DetailedMergeStatus
     NotApproved,
     [EnumMember(Value = "not_open")]
     NotOpen,
+    [Obsolete("Not part of the GitLab API documentation: https://docs.gitlab.com/api/merge_requests/#merge-status")]
     [EnumMember(Value = "policies_denied")]
     PoliciesDenied,
-    // Undocumented member
     [EnumMember(Value = "preparing")]
     Preparing,
 }

--- a/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/Models/MergeRequest.cs
@@ -75,6 +75,7 @@ public class MergeRequest
     [JsonPropertyName("merge_when_pipeline_succeeds")]
     public bool MergeWhenPipelineSucceeds { get; set; }
 
+    [Obsolete("Deprecated in GitLab 15.6. Use DetailedMergeStatus instead.")]
     [JsonPropertyName("merge_status")]
     public string MergeStatus { get; set; }
 


### PR DESCRIPTION
- GitLab deprecated `merge_status` in version 15.6, so adapt code to use `detailed_merge_status` instead
- Tag as obsolete the members of the `DetailedMergeStatus` enum that don't have counterparts listed in the GitLab API documentation.
- Other minor changes