### PR TITLE
Add support for retrieving the merge request approval state

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NGitLab.Models;
 
 namespace NGitLab.Mock.Clients;
@@ -28,6 +28,11 @@ internal sealed class MergeRequestApprovalClient : ClientBase, IMergeRequestAppr
     }
 
     public void ChangeApprovers(MergeRequestApproversChange approversChange)
+    {
+        throw new NotImplementedException();
+    }
+
+    public MergeRequestApprovalState GetApprovalState()
     {
         throw new NotImplementedException();
     }

--- a/NGitLab/IMergeRequestApprovalClient.cs
+++ b/NGitLab/IMergeRequestApprovalClient.cs
@@ -14,4 +14,6 @@ public interface IMergeRequestApprovalClient
     /// Available only for bot users based on project or group tokens.
     /// </summary>
     void ResetApprovals();
+
+    MergeRequestApprovalState GetApprovalState();
 }

--- a/NGitLab/Impl/MergeRequestApprovalClient.cs
+++ b/NGitLab/Impl/MergeRequestApprovalClient.cs
@@ -14,6 +14,7 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
     private readonly string _approversPath;
     private readonly string _approvePath;
     private readonly string _resetApprovalsPath;
+    private readonly string _approvalStatePath;
 
     public MergeRequestApprovalClient(API api, string projectPath, long mergeRequestIid)
     {
@@ -23,6 +24,7 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
         _approversPath = projectPath + "/merge_requests/" + iid + "/approvers";
         _approvePath = projectPath + "/merge_requests/" + iid + "/approve";
         _resetApprovalsPath = projectPath + "/merge_requests/" + iid + "/reset_approvals";
+        _approvalStatePath = projectPath + "/merge_requests/" + iid + "/approval_state";
     }
 
     public MergeRequestApprovals Approvals => _api.Get().To<MergeRequestApprovals>(_approvalsPath);
@@ -33,4 +35,6 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
     public void ChangeApprovers(MergeRequestApproversChange approversChange) => _api.Put().With(approversChange).To<MergeRequestApproversChange>(_approversPath);
 
     public void ResetApprovals() => _api.Put().Execute(_resetApprovalsPath);
+
+    public MergeRequestApprovalState GetApprovalState() => _api.Get().To<MergeRequestApprovalState>(_approvalStatePath);
 }

--- a/NGitLab/Models/ApprovalRule.cs
+++ b/NGitLab/Models/ApprovalRule.cs
@@ -16,6 +16,21 @@ public sealed class ApprovalRule
     [JsonPropertyName("name")]
     public string Name { get; set; }
 
+    /// <summary>
+    /// The type of the approval rule.
+    /// </summary>
+    [JsonPropertyName("rule_type")]
+    public string RuleType { get; set; }
+
+    /// <summary>
+    /// The eligible approvers for the rule.
+    /// </summary>
+    [JsonPropertyName("eligible_approvers")]
+    public User[] EligibleApprovers { get; set; }
+
+    /// <summary>
+    /// The number of required approvers.
+    /// </summary>
     [JsonPropertyName("approvals_required")]
     public int ApprovalsRequired { get; set; }
 

--- a/NGitLab/Models/MergeRequestApprovals.cs
+++ b/NGitLab/Models/MergeRequestApprovals.cs
@@ -46,3 +46,12 @@ public class MergeRequestApproveRequest
     [JsonPropertyName("approval_password")]
     public string ApprovalPassword { get; set; }
 }
+
+public class MergeRequestApprovalState
+{
+    [JsonPropertyName("approval_rules_overwritten")]
+    public bool ApprovalRulesOverwritten { get; set; }
+
+    [JsonPropertyName("rules")]
+    public ApprovalRule[] Rules { get; set; }
+}

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -401,6 +401,7 @@ NGitLab.IMergeRequestApprovalClient
 NGitLab.IMergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.IMergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.IMergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.IMergeRequestChangeClient
 NGitLab.IMergeRequestChangeClient.MergeRequestChange.get -> NGitLab.Models.MergeRequestChange
@@ -717,6 +718,7 @@ NGitLab.Impl.MergeRequestApprovalClient
 NGitLab.Impl.MergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.Impl.MergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.Impl.MergeRequestApprovalClient.MergeRequestApprovalClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.Impl.MergeRequestClient
@@ -1291,6 +1293,8 @@ NGitLab.Models.ApprovalRule
 NGitLab.Models.ApprovalRule.ApprovalRule() -> void
 NGitLab.Models.ApprovalRule.ApprovalsRequired.get -> int
 NGitLab.Models.ApprovalRule.ApprovalsRequired.set -> void
+NGitLab.Models.ApprovalRule.EligibleApprovers.get -> NGitLab.Models.User[]
+NGitLab.Models.ApprovalRule.EligibleApprovers.set -> void
 NGitLab.Models.ApprovalRule.Groups.get -> NGitLab.Models.Group[]
 NGitLab.Models.ApprovalRule.Groups.set -> void
 NGitLab.Models.ApprovalRule.Name.get -> string
@@ -1299,6 +1303,8 @@ NGitLab.Models.ApprovalRule.ProtectedBranch.get -> NGitLab.Models.Branch[]
 NGitLab.Models.ApprovalRule.ProtectedBranch.set -> void
 NGitLab.Models.ApprovalRule.RuleId.get -> long
 NGitLab.Models.ApprovalRule.RuleId.set -> void
+NGitLab.Models.ApprovalRule.RuleType.get -> string
+NGitLab.Models.ApprovalRule.RuleType.set -> void
 NGitLab.Models.ApprovalRule.Users.get -> NGitLab.Models.User[]
 NGitLab.Models.ApprovalRule.Users.set -> void
 NGitLab.Models.ApprovalRuleCreate
@@ -2906,6 +2912,12 @@ NGitLab.Models.MergeRequestApprovals.UserCanApprove.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserCanApprove.set -> void
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.set -> void
+NGitLab.Models.MergeRequestApprovalState
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.get -> bool
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.set -> void
+NGitLab.Models.MergeRequestApprovalState.MergeRequestApprovalState() -> void
+NGitLab.Models.MergeRequestApprovalState.Rules.get -> NGitLab.Models.ApprovalRule[]
+NGitLab.Models.MergeRequestApprovalState.Rules.set -> void
 NGitLab.Models.MergeRequestApprove
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.get -> string
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.set -> void

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -400,6 +400,7 @@ NGitLab.IMergeRequestApprovalClient
 NGitLab.IMergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.IMergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.IMergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.IMergeRequestChangeClient
 NGitLab.IMergeRequestChangeClient.MergeRequestChange.get -> NGitLab.Models.MergeRequestChange
@@ -716,6 +717,7 @@ NGitLab.Impl.MergeRequestApprovalClient
 NGitLab.Impl.MergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.Impl.MergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.Impl.MergeRequestApprovalClient.MergeRequestApprovalClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.Impl.MergeRequestClient
@@ -1290,6 +1292,8 @@ NGitLab.Models.ApprovalRule
 NGitLab.Models.ApprovalRule.ApprovalRule() -> void
 NGitLab.Models.ApprovalRule.ApprovalsRequired.get -> int
 NGitLab.Models.ApprovalRule.ApprovalsRequired.set -> void
+NGitLab.Models.ApprovalRule.EligibleApprovers.get -> NGitLab.Models.User[]
+NGitLab.Models.ApprovalRule.EligibleApprovers.set -> void
 NGitLab.Models.ApprovalRule.Groups.get -> NGitLab.Models.Group[]
 NGitLab.Models.ApprovalRule.Groups.set -> void
 NGitLab.Models.ApprovalRule.Name.get -> string
@@ -1298,6 +1302,8 @@ NGitLab.Models.ApprovalRule.ProtectedBranch.get -> NGitLab.Models.Branch[]
 NGitLab.Models.ApprovalRule.ProtectedBranch.set -> void
 NGitLab.Models.ApprovalRule.RuleId.get -> long
 NGitLab.Models.ApprovalRule.RuleId.set -> void
+NGitLab.Models.ApprovalRule.RuleType.get -> string
+NGitLab.Models.ApprovalRule.RuleType.set -> void
 NGitLab.Models.ApprovalRule.Users.get -> NGitLab.Models.User[]
 NGitLab.Models.ApprovalRule.Users.set -> void
 NGitLab.Models.ApprovalRuleCreate
@@ -2905,6 +2911,12 @@ NGitLab.Models.MergeRequestApprovals.UserCanApprove.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserCanApprove.set -> void
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.set -> void
+NGitLab.Models.MergeRequestApprovalState
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.get -> bool
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.set -> void
+NGitLab.Models.MergeRequestApprovalState.MergeRequestApprovalState() -> void
+NGitLab.Models.MergeRequestApprovalState.Rules.get -> NGitLab.Models.ApprovalRule[]
+NGitLab.Models.MergeRequestApprovalState.Rules.set -> void
 NGitLab.Models.MergeRequestApprove
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.get -> string
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.set -> void

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -401,6 +401,7 @@ NGitLab.IMergeRequestApprovalClient
 NGitLab.IMergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.IMergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.IMergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.IMergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.IMergeRequestChangeClient
 NGitLab.IMergeRequestChangeClient.MergeRequestChange.get -> NGitLab.Models.MergeRequestChange
@@ -717,6 +718,7 @@ NGitLab.Impl.MergeRequestApprovalClient
 NGitLab.Impl.MergeRequestApprovalClient.Approvals.get -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ApproveMergeRequest(NGitLab.Models.MergeRequestApproveRequest request = null) -> NGitLab.Models.MergeRequestApprovals
 NGitLab.Impl.MergeRequestApprovalClient.ChangeApprovers(NGitLab.Models.MergeRequestApproversChange approversChange) -> void
+NGitLab.Impl.MergeRequestApprovalClient.GetApprovalState() -> NGitLab.Models.MergeRequestApprovalState
 NGitLab.Impl.MergeRequestApprovalClient.MergeRequestApprovalClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
 NGitLab.Impl.MergeRequestApprovalClient.ResetApprovals() -> void
 NGitLab.Impl.MergeRequestClient
@@ -1291,6 +1293,8 @@ NGitLab.Models.ApprovalRule
 NGitLab.Models.ApprovalRule.ApprovalRule() -> void
 NGitLab.Models.ApprovalRule.ApprovalsRequired.get -> int
 NGitLab.Models.ApprovalRule.ApprovalsRequired.set -> void
+NGitLab.Models.ApprovalRule.EligibleApprovers.get -> NGitLab.Models.User[]
+NGitLab.Models.ApprovalRule.EligibleApprovers.set -> void
 NGitLab.Models.ApprovalRule.Groups.get -> NGitLab.Models.Group[]
 NGitLab.Models.ApprovalRule.Groups.set -> void
 NGitLab.Models.ApprovalRule.Name.get -> string
@@ -1299,6 +1303,8 @@ NGitLab.Models.ApprovalRule.ProtectedBranch.get -> NGitLab.Models.Branch[]
 NGitLab.Models.ApprovalRule.ProtectedBranch.set -> void
 NGitLab.Models.ApprovalRule.RuleId.get -> long
 NGitLab.Models.ApprovalRule.RuleId.set -> void
+NGitLab.Models.ApprovalRule.RuleType.get -> string
+NGitLab.Models.ApprovalRule.RuleType.set -> void
 NGitLab.Models.ApprovalRule.Users.get -> NGitLab.Models.User[]
 NGitLab.Models.ApprovalRule.Users.set -> void
 NGitLab.Models.ApprovalRuleCreate
@@ -2906,6 +2912,12 @@ NGitLab.Models.MergeRequestApprovals.UserCanApprove.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserCanApprove.set -> void
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.get -> bool
 NGitLab.Models.MergeRequestApprovals.UserHasApproved.set -> void
+NGitLab.Models.MergeRequestApprovalState
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.get -> bool
+NGitLab.Models.MergeRequestApprovalState.ApprovalRulesOverwritten.set -> void
+NGitLab.Models.MergeRequestApprovalState.MergeRequestApprovalState() -> void
+NGitLab.Models.MergeRequestApprovalState.Rules.get -> NGitLab.Models.ApprovalRule[]
+NGitLab.Models.MergeRequestApprovalState.Rules.set -> void
 NGitLab.Models.MergeRequestApprove
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.get -> string
 NGitLab.Models.MergeRequestApprove.ApprovalPassword.set -> void


### PR DESCRIPTION
Can be used for:

- Checking whether approval rules are overridden
- Retrieving Merge Request-level approval rules
- Getting the approval status of each approval rule