### PR TITLE
Fix Test report members

### DIFF
--- a/NGitLab/Models/TestCases.cs
+++ b/NGitLab/Models/TestCases.cs
@@ -13,8 +13,11 @@ public class TestCases
     [JsonPropertyName("classname")]
     public string Classname { get; set; }
 
+    [JsonPropertyName("file")]
+    public string File { get; set; }
+
     [JsonPropertyName("execution_time")]
-    public int ExecutionTime { get; set; }
+    public double ExecutionTime { get; set; }
 
     [JsonPropertyName("system_output")]
     public string SystemOutput { get; set; }

--- a/NGitLab/Models/TestReport.cs
+++ b/NGitLab/Models/TestReport.cs
@@ -6,7 +6,7 @@ namespace NGitLab.Models;
 public class TestReport
 {
     [JsonPropertyName("total_time")]
-    public int TotalTime { get; set; }
+    public double TotalTime { get; set; }
 
     [JsonPropertyName("total_count")]
     public int TotalCount { get; set; }

--- a/NGitLab/Models/TestSuites.cs
+++ b/NGitLab/Models/TestSuites.cs
@@ -9,7 +9,7 @@ public class TestSuites
     public string Name { get; set; }
 
     [JsonPropertyName("total_time")]
-    public int TotalTime { get; set; }
+    public double TotalTime { get; set; }
 
     [JsonPropertyName("total_count")]
     public int TotalCount { get; set; }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4636,8 +4636,10 @@ NGitLab.Models.TagQuery.TagQuery() -> void
 NGitLab.Models.TestCases
 NGitLab.Models.TestCases.Classname.get -> string
 NGitLab.Models.TestCases.Classname.set -> void
-NGitLab.Models.TestCases.ExecutionTime.get -> int
+NGitLab.Models.TestCases.ExecutionTime.get -> double
 NGitLab.Models.TestCases.ExecutionTime.set -> void
+NGitLab.Models.TestCases.File.get -> string
+NGitLab.Models.TestCases.File.set -> void
 NGitLab.Models.TestCases.Name.get -> string
 NGitLab.Models.TestCases.Name.set -> void
 NGitLab.Models.TestCases.Status.get -> string
@@ -4661,7 +4663,7 @@ NGitLab.Models.TestReport.TestSuites.get -> System.Collections.Generic.IReadOnly
 NGitLab.Models.TestReport.TestSuites.set -> void
 NGitLab.Models.TestReport.TotalCount.get -> int
 NGitLab.Models.TestReport.TotalCount.set -> void
-NGitLab.Models.TestReport.TotalTime.get -> int
+NGitLab.Models.TestReport.TotalTime.get -> double
 NGitLab.Models.TestReport.TotalTime.set -> void
 NGitLab.Models.TestReportSummary
 NGitLab.Models.TestReportSummary.TestSuites.get -> System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.TestSuites>
@@ -4698,7 +4700,7 @@ NGitLab.Models.TestSuites.TestCases.set -> void
 NGitLab.Models.TestSuites.TestSuites() -> void
 NGitLab.Models.TestSuites.TotalCount.get -> int
 NGitLab.Models.TestSuites.TotalCount.set -> void
-NGitLab.Models.TestSuites.TotalTime.get -> int
+NGitLab.Models.TestSuites.TotalTime.get -> double
 NGitLab.Models.TestSuites.TotalTime.set -> void
 NGitLab.Models.TimeStats
 NGitLab.Models.TimeStats.HumanTimeEstimate.get -> string

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4635,8 +4635,10 @@ NGitLab.Models.TagQuery.TagQuery() -> void
 NGitLab.Models.TestCases
 NGitLab.Models.TestCases.Classname.get -> string
 NGitLab.Models.TestCases.Classname.set -> void
-NGitLab.Models.TestCases.ExecutionTime.get -> int
+NGitLab.Models.TestCases.ExecutionTime.get -> double
 NGitLab.Models.TestCases.ExecutionTime.set -> void
+NGitLab.Models.TestCases.File.get -> string
+NGitLab.Models.TestCases.File.set -> void
 NGitLab.Models.TestCases.Name.get -> string
 NGitLab.Models.TestCases.Name.set -> void
 NGitLab.Models.TestCases.Status.get -> string
@@ -4660,7 +4662,7 @@ NGitLab.Models.TestReport.TestSuites.get -> System.Collections.Generic.IReadOnly
 NGitLab.Models.TestReport.TestSuites.set -> void
 NGitLab.Models.TestReport.TotalCount.get -> int
 NGitLab.Models.TestReport.TotalCount.set -> void
-NGitLab.Models.TestReport.TotalTime.get -> int
+NGitLab.Models.TestReport.TotalTime.get -> double
 NGitLab.Models.TestReport.TotalTime.set -> void
 NGitLab.Models.TestReportSummary
 NGitLab.Models.TestReportSummary.TestSuites.get -> System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.TestSuites>
@@ -4697,7 +4699,7 @@ NGitLab.Models.TestSuites.TestCases.set -> void
 NGitLab.Models.TestSuites.TestSuites() -> void
 NGitLab.Models.TestSuites.TotalCount.get -> int
 NGitLab.Models.TestSuites.TotalCount.set -> void
-NGitLab.Models.TestSuites.TotalTime.get -> int
+NGitLab.Models.TestSuites.TotalTime.get -> double
 NGitLab.Models.TestSuites.TotalTime.set -> void
 NGitLab.Models.TimeStats
 NGitLab.Models.TimeStats.HumanTimeEstimate.get -> string

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4636,8 +4636,10 @@ NGitLab.Models.TagQuery.TagQuery() -> void
 NGitLab.Models.TestCases
 NGitLab.Models.TestCases.Classname.get -> string
 NGitLab.Models.TestCases.Classname.set -> void
-NGitLab.Models.TestCases.ExecutionTime.get -> int
+NGitLab.Models.TestCases.ExecutionTime.get -> double
 NGitLab.Models.TestCases.ExecutionTime.set -> void
+NGitLab.Models.TestCases.File.get -> string
+NGitLab.Models.TestCases.File.set -> void
 NGitLab.Models.TestCases.Name.get -> string
 NGitLab.Models.TestCases.Name.set -> void
 NGitLab.Models.TestCases.Status.get -> string
@@ -4661,7 +4663,7 @@ NGitLab.Models.TestReport.TestSuites.get -> System.Collections.Generic.IReadOnly
 NGitLab.Models.TestReport.TestSuites.set -> void
 NGitLab.Models.TestReport.TotalCount.get -> int
 NGitLab.Models.TestReport.TotalCount.set -> void
-NGitLab.Models.TestReport.TotalTime.get -> int
+NGitLab.Models.TestReport.TotalTime.get -> double
 NGitLab.Models.TestReport.TotalTime.set -> void
 NGitLab.Models.TestReportSummary
 NGitLab.Models.TestReportSummary.TestSuites.get -> System.Collections.Generic.IReadOnlyCollection<NGitLab.Models.TestSuites>
@@ -4698,7 +4700,7 @@ NGitLab.Models.TestSuites.TestCases.set -> void
 NGitLab.Models.TestSuites.TestSuites() -> void
 NGitLab.Models.TestSuites.TotalCount.get -> int
 NGitLab.Models.TestSuites.TotalCount.set -> void
-NGitLab.Models.TestSuites.TotalTime.get -> int
+NGitLab.Models.TestSuites.TotalTime.get -> double
 NGitLab.Models.TestSuites.TotalTime.set -> void
 NGitLab.Models.TimeStats
 NGitLab.Models.TimeStats.HumanTimeEstimate.get -> string


### PR DESCRIPTION
Synchronization of test report members with actual JSON data.
Example JSON data for https://gitlab.com/gitlab-org/gitlab/-/pipelines/2115674295:
[https://gitlab.com/api/v4/projects/278964/pipelines/2115674295/test_report](https://gitlab.com/api/v4/projects/278964/pipelines/2115674295/test_report)

```json
{
  "total_time": 3431.672083,
  ...
  "test_suites": [
    {
      "name": "rspec migration pg16",
      "total_time": 118.909637,
      ...
      "test_cases": [
        {
          ...
          "file": "./spec/migrations/20250917131046_queue_clear_resolved_at_for_non_resolved_vulnerabilities_spec.rb",
          "execution_time": 29.227183,
          ...
        },
```