### PR TITLE
Remove further obsolete stuff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,6 @@ updates:
           - "*NUnit*"
         exclude-patterns:
           - "NUnit.Analyzers"
+      misc-dependencies:
+        patterns:
+          - "*"

--- a/NGitLab.Mock/Clients/LabelClient.cs
+++ b/NGitLab.Mock/Clients/LabelClient.cs
@@ -23,17 +23,6 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [Obsolete("Use CreateProjectLabel instead")]
-    public Models.Label Create(LabelCreate label)
-    {
-        return CreateProjectLabel(label.Id, new ProjectLabelCreate
-        {
-            Name = label.Name,
-            Color = label.Color,
-            Description = label.Description,
-        });
-    }
-
     public Models.Label CreateGroupLabel(long groupId, GroupLabelCreate label)
     {
         using (Context.BeginOperationScope())
@@ -66,16 +55,6 @@ internal sealed class LabelClient : ClientBase, ILabelClient
         }
     }
 
-    [Obsolete("Use DeleteProjectLabelAsync instead")]
-    public Models.Label Delete(LabelDelete label)
-    {
-        return DeleteProjectLabel(label.Id, new ProjectLabelDelete
-        {
-            Id = label.Id,
-            Name = label.Name,
-        });
-    }
-
     public Models.Label EditProjectLabel(long projectId, ProjectLabelEdit label)
     {
         using (Context.BeginOperationScope())
@@ -100,18 +79,6 @@ internal sealed class LabelClient : ClientBase, ILabelClient
 
             return l.ToClientLabel();
         }
-    }
-
-    [Obsolete("Use EditProjectLabel instead")]
-    public Models.Label Edit(LabelEdit label)
-    {
-        return EditProjectLabel(label.Id, new ProjectLabelEdit
-        {
-            Name = label.Name,
-            NewName = label.NewName,
-            Color = label.Color,
-            Description = label.Description,
-        });
     }
 
     public Models.Label EditGroupLabel(long groupId, GroupLabelEdit label)
@@ -196,12 +163,6 @@ internal sealed class LabelClient : ClientBase, ILabelClient
             var project = GetProject(projectId, ProjectPermission.View);
             return FindLabel(project.Labels, name)?.ToClientLabel();
         }
-    }
-
-    [Obsolete("Use GetProjectLabel instead")]
-    public Models.Label GetLabel(long projectId, string name)
-    {
-        return GetProjectLabel(projectId, name);
     }
 
     private static Label FindLabel(LabelsCollection collection, string name)

--- a/NGitLab.Mock/Clients/ProjectJobTokenScopeClient.cs
+++ b/NGitLab.Mock/Clients/ProjectJobTokenScopeClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NGitLab.Models;
@@ -8,7 +7,7 @@ namespace NGitLab.Mock.Clients;
 
 internal sealed class ProjectJobTokenScopeClient : ClientBase, IProjectJobTokenScopeClient
 {
-    private static Dictionary<long, JobTokenScope> _projectScopes = [];
+    private static readonly Dictionary<long, JobTokenScope> s_projectScopes = [];
 
     private readonly long _projectId;
 
@@ -16,11 +15,11 @@ internal sealed class ProjectJobTokenScopeClient : ClientBase, IProjectJobTokenS
         : base(context)
     {
         _projectId = Server.AllProjects.FindProject(projectId.ValueAsString()).Id;
-        lock (_projectScopes)
+        lock (s_projectScopes)
         {
-            if (!_projectScopes.ContainsKey(_projectId))
+            if (!s_projectScopes.ContainsKey(_projectId))
             {
-                _projectScopes[_projectId] = new JobTokenScope
+                s_projectScopes[_projectId] = new JobTokenScope
                 {
                     InboundEnabled = true,
                 };
@@ -31,18 +30,18 @@ internal sealed class ProjectJobTokenScopeClient : ClientBase, IProjectJobTokenS
     public async Task<JobTokenScope> GetProjectJobTokenScopeAsync(CancellationToken cancellationToken = default)
     {
         await Task.Yield();
-        lock (_projectScopes)
+        lock (s_projectScopes)
         {
-            return _projectScopes[_projectId];
+            return s_projectScopes[_projectId];
         }
     }
 
     public async Task UpdateProjectJobTokenScopeAsync(JobTokenScope scope, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
-        lock (_projectScopes)
+        lock (s_projectScopes)
         {
-            _projectScopes[_projectId] = scope;
+            s_projectScopes[_projectId] = scope;
         }
     }
 }

--- a/NGitLab/ILabelClient.cs
+++ b/NGitLab/ILabelClient.cs
@@ -45,9 +45,6 @@ public interface ILabelClient
     /// <returns></returns>
     Label GetProjectLabel(long projectId, string name);
 
-    [Obsolete("Use GetProjectLabel instead")]
-    Label GetLabel(long projectId, string name);
-
     /// <summary>
     /// Return a specified label from the group or null;
     /// </summary>
@@ -63,9 +60,6 @@ public interface ILabelClient
     /// <param name="label"></param>
     /// <returns></returns>
     Label CreateProjectLabel(long projectId, ProjectLabelCreate label);
-
-    [Obsolete("Use CreateProjectLabel instead")]
-    Label Create(LabelCreate label);
 
     /// <summary>
     /// Create a new label for a group.
@@ -85,9 +79,6 @@ public interface ILabelClient
     /// <param name="label"></param>
     /// <returns></returns>
     Label EditProjectLabel(long projectId, ProjectLabelEdit label);
-
-    [Obsolete("Use EditProjectLabel instead")]
-    Label Edit(LabelEdit label);
 
     /// <summary>
     /// Edit the contents of an existing label.
@@ -118,7 +109,4 @@ public interface ILabelClient
     /// <param name="labelName">Label Name</param>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Internal requirement to have the CancellationToken optional")]
     Task DeleteProjectLabelAsync(long projectId, string labelName, CancellationToken cancellationToken = default);
-
-    [Obsolete("Use DeleteProjectLabelAsync instead")]
-    Label Delete(LabelDelete label);
 }

--- a/NGitLab/Impl/LabelClient.cs
+++ b/NGitLab/Impl/LabelClient.cs
@@ -51,12 +51,6 @@ public class LabelClient : ILabelClient
         return ForProject(projectId, new LabelQuery() { Search = name }).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
     }
 
-    [Obsolete("Use GetProjectLabel instead")]
-    public Label GetLabel(long projectId, string name)
-    {
-        return GetProjectLabel(projectId, name);
-    }
-
     public Label GetGroupLabel(long groupId, string name)
     {
         return ForGroup(groupId, new LabelQuery() { Search = name }).FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
@@ -65,17 +59,6 @@ public class LabelClient : ILabelClient
     public Label CreateProjectLabel(long projectId, ProjectLabelCreate label)
     {
         return _api.Post().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
-    }
-
-    [Obsolete("Use CreateProjectLabel instead")]
-    public Label Create(LabelCreate label)
-    {
-        return CreateProjectLabel(label.Id, new ProjectLabelCreate
-        {
-            Name = label.Name,
-            Color = label.Color,
-            Description = label.Description,
-        });
     }
 
     public Label CreateGroupLabel(long groupId, GroupLabelCreate label)
@@ -97,18 +80,6 @@ public class LabelClient : ILabelClient
     public Label EditProjectLabel(long projectId, ProjectLabelEdit label)
     {
         return _api.Put().With(label).To<Label>(string.Format(CultureInfo.InvariantCulture, ProjectLabelUrl, projectId));
-    }
-
-    [Obsolete("Use EditProjectLabel instead")]
-    public Label Edit(LabelEdit label)
-    {
-        return EditProjectLabel(label.Id, new ProjectLabelEdit
-        {
-            Name = label.Name,
-            NewName = label.NewName,
-            Color = label.Color,
-            Description = label.Description,
-        });
     }
 
     public Label EditGroupLabel(long groupId, GroupLabelEdit label)
@@ -144,16 +115,6 @@ public class LabelClient : ILabelClient
     public Task DeleteProjectLabelAsync(long projectId, string labelName, CancellationToken cancellationToken = default)
     {
         return _api.Delete().ExecuteAsync($"/projects/{projectId.ToStringInvariant()}/labels/{labelName}", cancellationToken);
-    }
-
-    [Obsolete("Use DeleteProjectLabelAsync instead")]
-    public Label Delete(LabelDelete label)
-    {
-        return DeleteProjectLabel(label.Id, new ProjectLabelDelete
-        {
-            Id = label.Id,
-            Name = label.Name,
-        });
     }
 
     private static string AddLabelParameterQuery(string url, LabelQuery query)

--- a/NGitLab/Impl/RepositoryClient.cs
+++ b/NGitLab/Impl/RepositoryClient.cs
@@ -150,9 +150,7 @@ public class RepositoryClient : IRepositoryClient
 
     private string BuildCompareUrl(CompareQuery query)
     {
-        var from = query.From ?? query.Source;
-        var to = query.To ?? query.Target;
-        var url = _repoPath + $"/compare?from={from}&to={to}";
+        var url = _repoPath + $"/compare?from={query.From}&to={query.To}";
         url = Utils.AddParameter(url, "from_project_id", query.FromProjectId);
         url = Utils.AddParameter(url, "straight", query.Straight);
         url = Utils.AddParameter(url, "unidiff", query.Unidiff);

--- a/NGitLab/Models/CompareQuery.cs
+++ b/NGitLab/Models/CompareQuery.cs
@@ -1,33 +1,19 @@
-﻿using System;
-
-namespace NGitLab.Models;
+﻿namespace NGitLab.Models;
 
 /// <summary>
 /// Query details for comparison of branches/tags/commit hashes
 /// </summary>
-public class CompareQuery
+public class CompareQuery(string source, string target)
 {
-    /// <summary>
-    /// The source for comparison, can be a branch, tag or a commit hash.
-    /// </summary>
-    [Obsolete("Use 'From' instead.")]
-    public string Source { get; set; }
-
     /// <summary>
     /// The most recent reference for comparison, can be a branch, tag or a commit hash.
     /// </summary>
-    public string From { get; set; }
-
-    /// <summary>
-    /// The target for comparison, can be a branch, tag or a commit hash.
-    /// </summary>
-    [Obsolete("Use 'To' instead.")]
-    public string Target { get; set; }
+    public string From { get; set; } = source;
 
     /// <summary>
     /// The reference to compare against, can be a branch, tag or a commit hash.
     /// </summary>
-    public string To { get; set; }
+    public string To { get; set; } = target;
 
     /// <summary>
     /// Comparison method: true for direct comparison between from and to (from..to), false to compare using merge base (from…to)’. Default is false.
@@ -43,12 +29,4 @@ public class CompareQuery
     /// The ID to compare from.
     /// </summary>
     public long? FromProjectId { get; set; }
-
-    public CompareQuery(string source, string target)
-    {
-        Source = source;
-        Target = target;
-        From = source;
-        To = target;
-    }
 }

--- a/NGitLab/Models/CompareQuery.cs
+++ b/NGitLab/Models/CompareQuery.cs
@@ -3,17 +3,17 @@
 /// <summary>
 /// Query details for comparison of branches/tags/commit hashes
 /// </summary>
-public class CompareQuery(string source, string target)
+public class CompareQuery(string from, string to)
 {
     /// <summary>
     /// The most recent reference for comparison, can be a branch, tag or a commit hash.
     /// </summary>
-    public string From { get; set; } = source;
+    public string From { get; set; } = from;
 
     /// <summary>
     /// The reference to compare against, can be a branch, tag or a commit hash.
     /// </summary>
-    public string To { get; set; } = target;
+    public string To { get; set; } = to;
 
     /// <summary>
     /// Comparison method: true for direct comparison between from and to (from..to), false to compare using merge base (from…to)’. Default is false.

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -350,15 +350,12 @@ NGitLab.IJobClient.GetTraceAsync(long jobId, System.Threading.CancellationToken 
 NGitLab.IJobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.IJobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.ILabelClient
-NGitLab.ILabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -367,7 +364,6 @@ NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery
 NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILintClient
 NGitLab.ILintClient.ValidateCIYamlContentAsync(string projectId, string yamlContent, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
@@ -664,15 +660,12 @@ NGitLab.Impl.JobClient.JobClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId 
 NGitLab.Impl.JobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.Impl.JobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.Impl.LabelClient
-NGitLab.Impl.LabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -681,7 +674,6 @@ NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query)
 NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.LabelClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.LintClient
@@ -1686,7 +1678,7 @@ NGitLab.Models.CommitStatusQuery.Sort.init -> void
 NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
-NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.CompareQuery(string from, string to) -> void
 NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1691,12 +1691,8 @@ NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
-NGitLab.Models.CompareQuery.Source.get -> string
-NGitLab.Models.CompareQuery.Source.set -> void
 NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
-NGitLab.Models.CompareQuery.Target.get -> string
-NGitLab.Models.CompareQuery.Target.set -> void
 NGitLab.Models.CompareQuery.To.get -> string
 NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1690,12 +1690,8 @@ NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
-NGitLab.Models.CompareQuery.Source.get -> string
-NGitLab.Models.CompareQuery.Source.set -> void
 NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
-NGitLab.Models.CompareQuery.Target.get -> string
-NGitLab.Models.CompareQuery.Target.set -> void
 NGitLab.Models.CompareQuery.To.get -> string
 NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -349,15 +349,12 @@ NGitLab.IJobClient.GetTraceAsync(long jobId, System.Threading.CancellationToken 
 NGitLab.IJobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.IJobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.ILabelClient
-NGitLab.ILabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -366,7 +363,6 @@ NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery
 NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILintClient
 NGitLab.ILintClient.ValidateCIYamlContentAsync(string projectId, string yamlContent, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
@@ -663,15 +659,12 @@ NGitLab.Impl.JobClient.JobClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId 
 NGitLab.Impl.JobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.Impl.JobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.Impl.LabelClient
-NGitLab.Impl.LabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -680,7 +673,6 @@ NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query)
 NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.LabelClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.LintClient
@@ -1685,7 +1677,7 @@ NGitLab.Models.CommitStatusQuery.Sort.init -> void
 NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
-NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.CompareQuery(string from, string to) -> void
 NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -350,15 +350,12 @@ NGitLab.IJobClient.GetTraceAsync(long jobId, System.Threading.CancellationToken 
 NGitLab.IJobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.IJobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.ILabelClient
-NGitLab.ILabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.ILabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.ILabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.ILabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.ILabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -367,7 +364,6 @@ NGitLab.ILabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery labelQuery
 NGitLab.ILabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery labelQuery) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.ILabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.ILabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.ILintClient
 NGitLab.ILintClient.ValidateCIYamlContentAsync(string projectId, string yamlContent, NGitLab.Models.LintCIOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.LintCI>
@@ -664,15 +660,12 @@ NGitLab.Impl.JobClient.JobClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId 
 NGitLab.Impl.JobClient.RunAction(long jobId, NGitLab.Models.JobAction action) -> NGitLab.Models.Job
 NGitLab.Impl.JobClient.RunActionAsync(long jobId, NGitLab.Models.JobAction action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.Job>
 NGitLab.Impl.LabelClient
-NGitLab.Impl.LabelClient.Create(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(long groupId, NGitLab.Models.GroupLabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateGroupLabel(NGitLab.Models.LabelCreate label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.CreateProjectLabel(long projectId, NGitLab.Models.ProjectLabelCreate label) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.Delete(NGitLab.Models.LabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabel(long projectId, NGitLab.Models.ProjectLabelDelete label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, long labelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 NGitLab.Impl.LabelClient.DeleteProjectLabelAsync(long projectId, string labelName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-NGitLab.Impl.LabelClient.Edit(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(long groupId, NGitLab.Models.GroupLabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditGroupLabel(NGitLab.Models.LabelEdit label) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.EditProjectLabel(long projectId, NGitLab.Models.ProjectLabelEdit label) -> NGitLab.Models.Label
@@ -681,7 +674,6 @@ NGitLab.Impl.LabelClient.ForGroup(long groupId, NGitLab.Models.LabelQuery query)
 NGitLab.Impl.LabelClient.ForProject(long projectId) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.ForProject(long projectId, NGitLab.Models.LabelQuery query) -> System.Collections.Generic.IEnumerable<NGitLab.Models.Label>
 NGitLab.Impl.LabelClient.GetGroupLabel(long groupId, string name) -> NGitLab.Models.Label
-NGitLab.Impl.LabelClient.GetLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.GetProjectLabel(long projectId, string name) -> NGitLab.Models.Label
 NGitLab.Impl.LabelClient.LabelClient(NGitLab.Impl.API api) -> void
 NGitLab.Impl.LintClient
@@ -1686,7 +1678,7 @@ NGitLab.Models.CommitStatusQuery.Sort.init -> void
 NGitLab.Models.CommitStatusQuery.Stage.get -> string
 NGitLab.Models.CommitStatusQuery.Stage.init -> void
 NGitLab.Models.CompareQuery
-NGitLab.Models.CompareQuery.CompareQuery(string source, string target) -> void
+NGitLab.Models.CompareQuery.CompareQuery(string from, string to) -> void
 NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1691,12 +1691,8 @@ NGitLab.Models.CompareQuery.From.get -> string
 NGitLab.Models.CompareQuery.From.set -> void
 NGitLab.Models.CompareQuery.FromProjectId.get -> long?
 NGitLab.Models.CompareQuery.FromProjectId.set -> void
-NGitLab.Models.CompareQuery.Source.get -> string
-NGitLab.Models.CompareQuery.Source.set -> void
 NGitLab.Models.CompareQuery.Straight.get -> bool?
 NGitLab.Models.CompareQuery.Straight.set -> void
-NGitLab.Models.CompareQuery.Target.get -> string
-NGitLab.Models.CompareQuery.Target.set -> void
 NGitLab.Models.CompareQuery.To.get -> string
 NGitLab.Models.CompareQuery.To.set -> void
 NGitLab.Models.CompareQuery.Unidiff.get -> bool?


### PR DESCRIPTION
As we are about to bump the major version anyway, take the opportunity to further clean up things a bit.

Also, define a "misc-dependencies" dependabot group, to collect any remaining dependencies not part of other groups.