### PR TITLE
Fix misc dependencies group so it only captures remaining updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,12 @@ updates:
       misc-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "*Analyzer*"
+          - "Microsoft.*"
+          - "System.*"
+          - "coverlet.collector"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Playwright"
+          - "NSubstitute"
+          - "*NUnit*"


### PR DESCRIPTION
The way the `misc-dependencies` dependabot group was set up, it would capture ALL updates, instead of just those not captured by any of the previous groups. Let's fix that.