### PR TITLE
feat: add implicit conversion on gitlabcollectionresponse<T>

### DIFF
--- a/NGitLab/Impl/GitLabCollectionResponse.cs
+++ b/NGitLab/Impl/GitLabCollectionResponse.cs
@@ -11,4 +11,8 @@ public abstract class GitLabCollectionResponse<T> : IEnumerable<T>, IAsyncEnumer
     public abstract IEnumerator<T> GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IAsyncEnumerable<T> AsAsyncEnumerable() => this;
+
+    public IEnumerable<T> AsEnumerable() => this;
 }

--- a/NGitLab/Impl/GitLabCollectionResponse.cs
+++ b/NGitLab/Impl/GitLabCollectionResponse.cs
@@ -13,6 +13,4 @@ public abstract class GitLabCollectionResponse<T> : IEnumerable<T>, IAsyncEnumer
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public IAsyncEnumerable<T> AsAsyncEnumerable() => this;
-
-    public IEnumerable<T> AsEnumerable() => this;
 }

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -108,6 +108,8 @@ NGitLab.GitLabClient.SystemHooks.get -> NGitLab.ISystemHookClient
 NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
+NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
+NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -109,7 +109,6 @@ NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
 NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
-NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -108,6 +108,8 @@ NGitLab.GitLabClient.SystemHooks.get -> NGitLab.ISystemHookClient
 NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
+NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
+NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -109,7 +109,6 @@ NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
 NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
-NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -108,6 +108,8 @@ NGitLab.GitLabClient.SystemHooks.get -> NGitLab.ISystemHookClient
 NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
+NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
+NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -109,7 +109,6 @@ NGitLab.GitLabClient.Users.get -> NGitLab.IUserClient
 NGitLab.GitLabClient.Version.get -> NGitLab.IVersionClient
 NGitLab.GitLabCollectionResponse<T>
 NGitLab.GitLabCollectionResponse<T>.AsAsyncEnumerable() -> System.Collections.Generic.IAsyncEnumerable<T>
-NGitLab.GitLabCollectionResponse<T>.AsEnumerable() -> System.Collections.Generic.IEnumerable<T>
 NGitLab.GitLabCollectionResponse<T>.GitLabCollectionResponse() -> void
 NGitLab.GitLabException
 NGitLab.GitLabException.ErrorMessage.get -> string


### PR DESCRIPTION
- With .Net 10 and the new AsyncEnumerable (that was before in System.Linq.Async), it seems that on Linq methods (Where, Select, ...), it might not know which method to take (Select(IEnumerable<>) or Select(IAsyncEnumerable<>)
- Adding 2 methods to implicitly convert the Collection


While digging a bit:
- AsEnumerable() exists in System.Linq.Enumerable and should be fully equivalent (no cost, implicit conversion). Might not be needed to add this one explicitely
- ToAsyncEnumerable() exists in System.Linq.AsyncEnumerable, but is made for converting a IEnumerable to a IAsyncEnumerable (involves additional operations like iterating on the collection)
