### PR TITLE
feat: Implement TagClient.GetAsync in NGitLab.Client.Mock

### DIFF
--- a/NGitLab.Mock.Tests/TagTests.cs
+++ b/NGitLab.Mock.Tests/TagTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using NGitLab.Mock.Config;
+using NGitLab.Models;
 using NUnit.Framework;
 
 namespace NGitLab.Mock.Tests;
@@ -27,5 +29,63 @@ public class TagTests
 
         var ex = Assert.ThrowsAsync<GitLabException>(() => tagClient.GetByNameAsync("1.0.1"));
         Assert.That(ex.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Theory]
+    public void GetTaskAsync_CanSortByName([Values] bool useDefault)
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .WithProject("test-project", id: 1, addDefaultUserAsMaintainer: true, configure: project => project
+                .WithCommit("Initial Commit", tags: ["0.0.1"])
+                .WithCommit("Second Tag", tags: ["0.0.2"])
+                .WithCommit("Second Tag", tags: ["not-semver"])
+                .WithCommit("Other Tag", tags: ["0.0.10"]))
+            .BuildServer();
+
+        var client = server.CreateClient();
+        var tagClient = client.GetRepository(1).Tags;
+
+        var query = new TagQuery
+        {
+            OrderBy = useDefault ? null : "name",
+            Sort = "asc",
+        };
+
+        // Act
+        var tags = tagClient.GetAsync(query);
+
+        // Assert
+        Assert.That(tags.Select(t => t.Name), Is.EqualTo(["0.0.1", "0.0.10", "0.0.2", "not-semver"]));
+    }
+
+    [Test]
+    public void GetTagAsync_CanSortByVersion()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("user1", isDefault: true)
+            .WithProject("test-project", id: 1, addDefaultUserAsMaintainer: true, configure: project => project
+                .WithCommit("Initial Commit", tags: ["0.0.1"])
+                .WithCommit("Second Tag", tags: ["0.0.2"])
+                .WithCommit("Second Tag", tags: ["not-semver"])
+                .WithCommit("Other Tag", tags: ["0.0.10"]))
+            .BuildServer();
+
+        var client = server.CreateClient();
+        var tagClient = client.GetRepository(1).Tags;
+
+        var query = new TagQuery
+        {
+            OrderBy = "version",
+            Sort = "asc",
+        };
+
+        // Act
+        var tags = tagClient.GetAsync(query);
+
+        // Assert
+        Assert.That(tags.Select(t => t.Name), Is.EqualTo(["not-semver", "0.0.1", "0.0.2", "0.0.10"]));
     }
 }

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -95,7 +95,7 @@ internal sealed class TagClient : ClientBase, ITagClient
             return GitLabCollectionResponse.Create(result.Select(ToTagClient).ToArray());
         }
 
-        static IEnumerable<LibGit2Sharp.Tag> ApplyQuery(IEnumerable<LibGit2Sharp.Tag> tags, string? orderBy, string? direction)
+        static IEnumerable<LibGit2Sharp.Tag> ApplyQuery(IEnumerable<LibGit2Sharp.Tag> tags, string orderBy, string direction)
         {
             if (string.IsNullOrEmpty(direction))
                 direction = "desc";

--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
+    <PackageReference Include="NuGet.Versioning" Version="7.0.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -13,7 +13,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
-    <PackageReference Include="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/NGitLab.Mock/NGitLab.Mock.csproj
+++ b/NGitLab.Mock/NGitLab.Mock.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
-    <PackageReference Include="NuGet.Versioning" Version="7.0.1" />
+    <PackageReference Include="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Well to be exact, the method was already implemented, but we could not pass in a query without the method crashing. Implemented the behavior as closely as possible to the GitLab's api sorting and filtering