### PR TITLE
fix: Mocked `TagClient.GetAsync(TagQuery query)` must handle searching "^term$"

### DIFF
--- a/NGitLab.Mock.Tests/TagTests.cs
+++ b/NGitLab.Mock.Tests/TagTests.cs
@@ -97,7 +97,8 @@ public class TagTests
             .WithUser("user1", isDefault: true)
             .WithProject("test-project", id: 1, addDefaultUserAsMaintainer: true, configure: project => project
                 .WithCommit("First Tag", tags: ["v0.5"])
-                .WithCommit("Second Tag", tags: ["v0.6"]))
+                .WithCommit("Second Tag", tags: ["v0.5.1"])
+                .WithCommit("Third Tag", tags: ["v0.6"]))
             .BuildServer();
 
         var client = server.CreateClient();
@@ -108,20 +109,21 @@ public class TagTests
             // You can use "^term" and "term$" to find tags that begin and end with "term". No other regular expressions are supported.
             // The search expression is case-insensitive.
             // https://docs.gitlab.com/api/tags/#list-all-project-repository-tags
-            ("^v0.5", 1),
-            ("^v0", 2),
-            ("^v", 2),
-            ("^V", 2),
+            ("^v0.5", 2),
+            ("^v0", 3),
+            ("^v", 3),
+            ("^V", 3),
             ("^v1", 0),
-            ("0.5", 1),
-            ("0", 2),
+            ("0.5", 2),
+            ("0", 3),
             ("6", 1),
-            ("V", 2),
+            ("V", 3),
             ("0.5$", 1),
             (".5$", 1),
             ("\\.5$", 0),
             (".[0-9]$", 0),
             ("0\\.", 0),
+            ("^v0.5$", 1),
         ];
 
         foreach (var (searchExpression, expectedCount) in testCases)

--- a/NGitLab.Mock/Clients/TagClient.cs
+++ b/NGitLab.Mock/Clients/TagClient.cs
@@ -99,14 +99,30 @@ internal sealed class TagClient : ClientBase, ITagClient
             // First, filter by search term if provided
             if (!string.IsNullOrEmpty(query.Search))
             {
-                tags = query.Search switch
+                var search = query.Search;
+                var startsWithCaret = search.StartsWith("^", StringComparison.Ordinal);
+                var endsWithDollar = search.EndsWith("$", StringComparison.Ordinal);
+
+                if (!startsWithCaret && !endsWithDollar)
                 {
-                    string search when search.StartsWith("^", StringComparison.Ordinal) =>
-                        tags.Where(t => t.FriendlyName.StartsWith(search[1..], StringComparison.OrdinalIgnoreCase)),
-                    string search when search.EndsWith("$", StringComparison.Ordinal) =>
-                        tags.Where(t => t.FriendlyName.EndsWith(search[..^1], StringComparison.OrdinalIgnoreCase)),
-                    _ => tags.Where(t => t.FriendlyName.Contains(query.Search, StringComparison.OrdinalIgnoreCase)),
-                };
+                    tags = tags.Where(t => t.FriendlyName.Contains(search, StringComparison.OrdinalIgnoreCase));
+                }
+                else
+                {
+                    // Remove the special characters for the actual search term
+                    if (startsWithCaret)
+                        search = search[1..];
+
+                    if (endsWithDollar)
+                        search = search[..^1];
+
+                    // Search with the appropriate conditions based on the presence of ^ and $
+                    if (startsWithCaret)
+                        tags = tags.Where(t => t.FriendlyName.StartsWith(search, StringComparison.OrdinalIgnoreCase));
+
+                    if (endsWithDollar)
+                        tags = tags.Where(t => t.FriendlyName.EndsWith(search, StringComparison.OrdinalIgnoreCase));
+                }
             }
 
             var orderBy = query.OrderBy?.ToLowerInvariant();

--- a/NGitLab.Tests/TagTests.cs
+++ b/NGitLab.Tests/TagTests.cs
@@ -45,14 +45,21 @@ public class TagTests
         tagClient.Create(new TagCreate
         {
             Name = "v0.5",
-            Message = "Test message",
+            Message = "First tag",
+            Ref = project.DefaultBranch,
+        });
+
+        tagClient.Create(new TagCreate
+        {
+            Name = "v0.5.1",
+            Message = "Second tag",
             Ref = project.DefaultBranch,
         });
 
         tagClient.Create(new TagCreate
         {
             Name = "v0.6",
-            Message = "Test second message",
+            Message = "Third tag",
             Ref = project.DefaultBranch,
         });
 
@@ -61,20 +68,21 @@ public class TagTests
             // You can use "^term" and "term$" to find tags that begin and end with "term". No other regular expressions are supported.
             // The search expression is case-insensitive.
             // https://docs.gitlab.com/api/tags/#list-all-project-repository-tags
-            ("^v0.5", 1),
-            ("^v0", 2),
-            ("^v", 2),
-            ("^V", 2),
+            ("^v0.5", 2),
+            ("^v0", 3),
+            ("^v", 3),
+            ("^V", 3),
             ("^v1", 0),
-            ("0.5", 1),
-            ("0", 2),
+            ("0.5", 2),
+            ("0", 3),
             ("6", 1),
-            ("V", 2),
+            ("V", 3),
             ("0.5$", 1),
             (".5$", 1),
             ("\\.5$", 0),
             (".[0-9]$", 0),
             ("0\\.", 0),
+            ("^v0.5$", 1),
         ];
 
         foreach (var (searchExpression, expectedCount) in testCases)


### PR DESCRIPTION
The recently modified `TagClient.GetAsync(TagQuery query)` mock handled searching for "term", "^term" or "term$", but not "^term$". Fix it.