### PR TITLE
feat: add SquashOption support to ProjectUpdate and mock

### DIFF
--- a/NGitLab.Mock.Tests/ProjectsMockTests.cs
+++ b/NGitLab.Mock.Tests/ProjectsMockTests.cs
@@ -372,6 +372,55 @@ public class ProjectsMockTests
     }
 
     [Test]
+    public async Task UpdateAsync_WhenSquashOptionIsProvided_ItIsUpdated()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .WithProjectOfFullPath("Test/MyProject")
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+        var project = await projectClient.GetAsync("Test/MyProject");
+
+        // Act
+        var updated = await projectClient.UpdateAsync(project.Id, new ProjectUpdate
+        {
+            SquashOption = SquashOption.Always,
+        });
+
+        // Assert
+        Assert.That(updated.SquashOption, Is.EqualTo(SquashOption.Always));
+    }
+
+    [Test]
+    public async Task UpdateAsync_WhenSquashOptionIsNotProvided_ItRetainsExistingValue()
+    {
+        // Arrange
+        using var server = new GitLabConfig()
+            .WithUser("Test", isDefault: true)
+            .WithProjectOfFullPath("Test/MyProject")
+            .BuildServer();
+
+        var projectClient = server.CreateClient().Projects;
+        var project = await projectClient.GetAsync("Test/MyProject");
+
+        await projectClient.UpdateAsync(project.Id, new ProjectUpdate
+        {
+            SquashOption = SquashOption.Never,
+        });
+
+        // Act — update without specifying SquashOption
+        var updated = await projectClient.UpdateAsync(project.Id, new ProjectUpdate
+        {
+            Description = "updated",
+        });
+
+        // Assert
+        Assert.That(updated.SquashOption, Is.EqualTo(SquashOption.Never));
+    }
+
+    [Test]
     public void UpdateAsync_WhenProjectNotFound_ItThrows()
     {
         // Arrange

--- a/NGitLab.Mock/Clients/ProjectClient.cs
+++ b/NGitLab.Mock/Clients/ProjectClient.cs
@@ -383,6 +383,11 @@ internal sealed class ProjectClient : ClientBase, IProjectClient
                 project.Topics = projectUpdate.Topics.Where(t => !string.IsNullOrEmpty(t)).Distinct(StringComparer.Ordinal).ToArray();
             }
 
+            if (projectUpdate.SquashOption.HasValue)
+            {
+                project.SquashOption = projectUpdate.SquashOption.Value;
+            }
+
             return project.ToClientProject(Context.User);
         }
     }

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -165,6 +165,8 @@ public sealed class Project : GitLabObject
 
     public string RunnersToken { get; internal set; }
 
+    public SquashOption SquashOption { get; set; }
+
     public void Remove()
     {
         Group.Projects.Remove(this);
@@ -483,6 +485,7 @@ public sealed class Project : GitLabObject
             Statistics = Statistics,
             TagList = Tags,
             Topics = Topics,
+            SquashOption = new DynamicEnum<SquashOption>(SquashOption),
             Mirror = Mirror,
             MirrorUserId = MirrorUserId,
             MirrorTriggerBuilds = MirrorTriggerBuilds,

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -956,6 +956,8 @@ NGitLab.Mock.Project.Repository.get -> NGitLab.Mock.Repository
 NGitLab.Mock.Project.RepositoryAccessLevel.get -> NGitLab.Models.RepositoryAccessLevel
 NGitLab.Mock.Project.RepositoryAccessLevel.set -> void
 NGitLab.Mock.Project.RunnersToken.get -> string
+NGitLab.Mock.Project.SquashOption.get -> NGitLab.Models.SquashOption
+NGitLab.Mock.Project.SquashOption.set -> void
 NGitLab.Mock.Project.SshUrl.get -> string
 NGitLab.Mock.Project.Statistics.get -> NGitLab.Models.ProjectStatistics
 NGitLab.Mock.Project.Statistics.set -> void

--- a/NGitLab/Models/ProjectUpdate.cs
+++ b/NGitLab/Models/ProjectUpdate.cs
@@ -110,4 +110,7 @@ public sealed class ProjectUpdate
 
     [JsonPropertyName("ci_default_git_depth")]
     public int? CiDefaultGitDepth { get; set; }
+
+    [JsonPropertyName("squash_option")]
+    public SquashOption? SquashOption { get; set; }
 }

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -4066,6 +4066,8 @@ NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.SquashOption.get -> NGitLab.Models.SquashOption?
+NGitLab.Models.ProjectUpdate.SquashOption.set -> void
 NGitLab.Models.ProjectUpdate.TagList.get -> string[]
 NGitLab.Models.ProjectUpdate.TagList.set -> void
 NGitLab.Models.ProjectUpdate.Topics.get -> System.Collections.Generic.List<string>

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4067,6 +4067,8 @@ NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.SquashOption.get -> NGitLab.Models.SquashOption?
+NGitLab.Models.ProjectUpdate.SquashOption.set -> void
 NGitLab.Models.ProjectUpdate.TagList.get -> string[]
 NGitLab.Models.ProjectUpdate.TagList.set -> void
 NGitLab.Models.ProjectUpdate.Topics.get -> System.Collections.Generic.List<string>

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4066,6 +4066,8 @@ NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.SquashOption.get -> NGitLab.Models.SquashOption?
+NGitLab.Models.ProjectUpdate.SquashOption.set -> void
 NGitLab.Models.ProjectUpdate.TagList.get -> string[]
 NGitLab.Models.ProjectUpdate.TagList.set -> void
 NGitLab.Models.ProjectUpdate.Topics.get -> System.Collections.Generic.List<string>

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4067,6 +4067,8 @@ NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.get -> string
 NGitLab.Models.ProjectUpdate.SnippetsAccessLevel.set -> void
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.get -> bool?
 NGitLab.Models.ProjectUpdate.SnippetsEnabled.set -> void
+NGitLab.Models.ProjectUpdate.SquashOption.get -> NGitLab.Models.SquashOption?
+NGitLab.Models.ProjectUpdate.SquashOption.set -> void
 NGitLab.Models.ProjectUpdate.TagList.get -> string[]
 NGitLab.Models.ProjectUpdate.TagList.set -> void
 NGitLab.Models.ProjectUpdate.Topics.get -> System.Collections.Generic.List<string>


### PR DESCRIPTION
* Add `SquashOption` property to `ProjectUpdate` model with JSON serialization
* Add `SquashOption` property to the mock `Project` class
* Handle `SquashOption` in the mock `ProjectClient.Update` method
* Map `SquashOption` through `ToClientProject` using `DynamicEnum<SquashOption>`
* Update PublicAPI.Unshipped.txt for all target frameworks
* Add mock tests verifying SquashOption is applied on update and retained when omitted