### PR TITLE
chore: add perpage argument for groupsclient

### DIFF
--- a/NGitLab.Mock.Tests/GroupsMockTests.cs
+++ b/NGitLab.Mock.Tests/GroupsMockTests.cs
@@ -427,4 +427,21 @@ public class GroupsMockTests
         Assert.That(group.CreatedAt, Is.GreaterThanOrEqualTo(t1));
         Assert.That(group.CreatedAt, Is.LessThanOrEqualTo(t2));
     }
+
+    [Test]
+    public async Task Test_group_page()
+    {
+        using var server = CreateProjectHierarchy();
+        var client = server.CreateClient("user1");
+
+        var result = client.Groups.SearchProjectsAsync("tlg", new GroupProjectsQuery
+        {
+            Page = 3,
+            PerPage = 1,
+            IncludeSubGroups = true,
+        }).ToArray();
+
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0].Name, Is.EqualTo("p3"));
+    }
 }

--- a/NGitLab.Mock/Clients/GroupClient.cs
+++ b/NGitLab.Mock/Clients/GroupClient.cs
@@ -221,6 +221,9 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
 
             var projects = query?.IncludeSubGroups is true ? group.AllProjects : group.Projects;
 
+            var pageIndex = 0;
+            var perPage = query?.PerPage ?? 20;
+
             if (query != null)
             {
                 if (query.Archived != null)
@@ -238,6 +241,11 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
                     projects = projects.Where(project => project.Visibility >= query.Visibility.Value);
                 }
 
+                if (query.Page.HasValue)
+                {
+                    pageIndex = query.Page.Value - 1;
+                }
+
                 if (!string.IsNullOrEmpty(query.Search))
                     throw new NotImplementedException();
 
@@ -246,6 +254,9 @@ internal sealed class GroupClient : ClientBase, IGroupsClient
             }
 
             projects = projects.Where(project => project.CanUserViewProject(Context.User));
+            var lowerBound = pageIndex * perPage;
+
+            projects = projects.Skip(lowerBound);
             return GitLabCollectionResponse.Create(projects.Select(project => project.ToClientProject(Context.User)).ToArray());
         }
     }

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -456,6 +456,28 @@ public class GroupsTests
         Assert.That(projectResult.Id, Is.EqualTo(project.Id));
         Assert.That(projectResult.Archived, Is.True);
     }
+    
+    [Test]
+    [NGitLabRetry]
+    public async Task Test_group_projects_query_page()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var groupClient = context.Client.Groups;
+
+        var group = context.CreateGroup();
+        var project1 = context.CreateProject(group.Id);
+        var project2 = context.CreateProject(group.Id);
+
+        var projects = groupClient.GetProjectsAsync(group.Id, new GroupProjectsQuery
+        {
+            Page = 2,
+            PerPage = 1,
+            Sort = "asc",
+        }).ToArray();
+
+        Assert.That(projects, Has.Length.EqualTo(1));
+        Assert.That(projects[0].Id, Is.EqualTo(project2.Id));
+    }
 
     [Test]
     [NGitLabRetry]
@@ -1192,5 +1214,3 @@ public class GroupsTests
         });
     }
 }
-
-// test

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -1128,6 +1128,7 @@ public class GroupsTests
         });
     }
 
+///sqdsqs
     [Test]
     [NGitLabRetry]
     public async Task Test_page_subgroup_including_descendants_returns_expected_pages()

--- a/NGitLab.Tests/GroupsTests.cs
+++ b/NGitLab.Tests/GroupsTests.cs
@@ -1128,7 +1128,6 @@ public class GroupsTests
         });
     }
 
-///sqdsqs
     [Test]
     [NGitLabRetry]
     public async Task Test_page_subgroup_including_descendants_returns_expected_pages()
@@ -1193,3 +1192,5 @@ public class GroupsTests
         });
     }
 }
+
+// test

--- a/NGitLab/Impl/GroupsClient.cs
+++ b/NGitLab/Impl/GroupsClient.cs
@@ -214,7 +214,7 @@ public class GroupsClient : IGroupsClient
 
     public GitLabCollectionResponse<Project> SearchProjectsAsync(GroupId groupId, GroupProjectsQuery query)
     {
-        var url = CreateGetProjectsUrl(groupId, query);
+        var url = CreateGetProjectsUrl(groupId, query, page: query?.Page, perPage: query?.PerPage);
         return _api.Get().GetAllAsync<Project>(url);
     }
 
@@ -257,7 +257,6 @@ public class GroupsClient : IGroupsClient
         url = Utils.AddParameter(url, "include_subgroups", query.IncludeSubGroups);
         url = Utils.AddParameter(url, "with_custom_attributes", query.WithCustomAttributes);
         url = Utils.AddParameter(url, "with_security_reports", query.WithSecurityReports);
-        url = Utils.AddParameter(url, "per_page", query.PerPage);
         url = Utils.AddOrderBy(url, query.OrderBy, supportKeysetPagination: page is null);
 
         return url;

--- a/NGitLab/Impl/GroupsClient.cs
+++ b/NGitLab/Impl/GroupsClient.cs
@@ -257,6 +257,7 @@ public class GroupsClient : IGroupsClient
         url = Utils.AddParameter(url, "include_subgroups", query.IncludeSubGroups);
         url = Utils.AddParameter(url, "with_custom_attributes", query.WithCustomAttributes);
         url = Utils.AddParameter(url, "with_security_reports", query.WithSecurityReports);
+        url = Utils.AddParameter(url, "per_page", query.PerPage);
         url = Utils.AddOrderBy(url, query.OrderBy, supportKeysetPagination: page is null);
 
         return url;

--- a/NGitLab/Models/GroupProjectsQuery.cs
+++ b/NGitLab/Models/GroupProjectsQuery.cs
@@ -81,4 +81,9 @@ public sealed class GroupProjectsQuery
     /// Specifies how many records per page (GitLab supports a maximum of 100 items per page and defaults to 20).
     /// </summary>
     public int? PerPage { get; set; }
+
+    /// <summary>
+    /// Specifies the start page.
+    /// </summary>
+    public int? Page { get; set; }
 }

--- a/NGitLab/Models/GroupProjectsQuery.cs
+++ b/NGitLab/Models/GroupProjectsQuery.cs
@@ -76,4 +76,9 @@ public sealed class GroupProjectsQuery
     /// Return only projects that have security reports artifacts present in any of their builds. This means “projects with security reports enabled”. Default is false
     /// </summary>
     public bool? WithSecurityReports { get; set; }
+
+    /// <summary>
+    /// Specifies how many records per page (GitLab supports a maximum of 100 items per page and defaults to 20).
+    /// </summary>
+    public int? PerPage { get; set; }
 }

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -2289,6 +2289,10 @@ NGitLab.Models.GroupProjectsQuery.OrderBy.get -> string
 NGitLab.Models.GroupProjectsQuery.OrderBy.set -> void
 NGitLab.Models.GroupProjectsQuery.Owned.get -> bool?
 NGitLab.Models.GroupProjectsQuery.Owned.set -> void
+NGitLab.Models.GroupProjectsQuery.Page.get -> int?
+NGitLab.Models.GroupProjectsQuery.Page.set -> void
+NGitLab.Models.GroupProjectsQuery.PerPage.get -> int?
+NGitLab.Models.GroupProjectsQuery.PerPage.set -> void
 NGitLab.Models.GroupProjectsQuery.Search.get -> string
 NGitLab.Models.GroupProjectsQuery.Search.set -> void
 NGitLab.Models.GroupProjectsQuery.Simple.get -> bool?

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -2290,6 +2290,10 @@ NGitLab.Models.GroupProjectsQuery.OrderBy.get -> string
 NGitLab.Models.GroupProjectsQuery.OrderBy.set -> void
 NGitLab.Models.GroupProjectsQuery.Owned.get -> bool?
 NGitLab.Models.GroupProjectsQuery.Owned.set -> void
+NGitLab.Models.GroupProjectsQuery.Page.get -> int?
+NGitLab.Models.GroupProjectsQuery.Page.set -> void
+NGitLab.Models.GroupProjectsQuery.PerPage.get -> int?
+NGitLab.Models.GroupProjectsQuery.PerPage.set -> void
 NGitLab.Models.GroupProjectsQuery.Search.get -> string
 NGitLab.Models.GroupProjectsQuery.Search.set -> void
 NGitLab.Models.GroupProjectsQuery.Simple.get -> bool?

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2289,6 +2289,10 @@ NGitLab.Models.GroupProjectsQuery.OrderBy.get -> string
 NGitLab.Models.GroupProjectsQuery.OrderBy.set -> void
 NGitLab.Models.GroupProjectsQuery.Owned.get -> bool?
 NGitLab.Models.GroupProjectsQuery.Owned.set -> void
+NGitLab.Models.GroupProjectsQuery.Page.get -> int?
+NGitLab.Models.GroupProjectsQuery.Page.set -> void
+NGitLab.Models.GroupProjectsQuery.PerPage.get -> int?
+NGitLab.Models.GroupProjectsQuery.PerPage.set -> void
 NGitLab.Models.GroupProjectsQuery.Search.get -> string
 NGitLab.Models.GroupProjectsQuery.Search.set -> void
 NGitLab.Models.GroupProjectsQuery.Simple.get -> bool?

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2290,6 +2290,10 @@ NGitLab.Models.GroupProjectsQuery.OrderBy.get -> string
 NGitLab.Models.GroupProjectsQuery.OrderBy.set -> void
 NGitLab.Models.GroupProjectsQuery.Owned.get -> bool?
 NGitLab.Models.GroupProjectsQuery.Owned.set -> void
+NGitLab.Models.GroupProjectsQuery.Page.get -> int?
+NGitLab.Models.GroupProjectsQuery.Page.set -> void
+NGitLab.Models.GroupProjectsQuery.PerPage.get -> int?
+NGitLab.Models.GroupProjectsQuery.PerPage.set -> void
 NGitLab.Models.GroupProjectsQuery.Search.get -> string
 NGitLab.Models.GroupProjectsQuery.Search.set -> void
 NGitLab.Models.GroupProjectsQuery.Simple.get -> bool?


### PR DESCRIPTION
- There is a specific method to get a page on group's projects, but that's limited to 1 page only
- Add Page/PerPage on group project query to be able to skip pages or get results with more results per page