### PR TITLE
Add container registry api support

### DIFF
--- a/NGitLab.Mock/Clients/ContainerRegistryClient.cs
+++ b/NGitLab.Mock/Clients/ContainerRegistryClient.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Mock.Internals;
+using NGitLab.Models;
+using ModelContainerRegistryTag = NGitLab.Models.ContainerRegistryTag;
+using ModelContainerRepository = NGitLab.Models.ContainerRepository;
+
+namespace NGitLab.Mock.Clients;
+
+internal sealed class ContainerRegistryClient(ClientContext context, ProjectId projectId) : ClientBase(context), IContainerRegistryClient
+{
+    public GitLabCollectionResponse<ModelContainerRepository> GetRepositoriesAsync(CancellationToken cancellationToken = default)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(projectId, ProjectPermission.View);
+            var result = project.ContainerRepositories
+                .Select(r => r.ToClientContainerRepository())
+                .ToList();
+            return GitLabCollectionResponse.Create(result);
+        }
+    }
+
+    public GitLabCollectionResponse<ModelContainerRegistryTag> GetTagsAsync(long repositoryId, CancellationToken cancellationToken = default)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(projectId, ProjectPermission.View);
+            var repo = project.ContainerRepositories.FirstOrDefault(r => r.Id == repositoryId)
+                ?? throw GitLabException.NotFound();
+            var result = repo.Tags
+                .Select(t => t.ToClientContainerRegistryTag())
+                .ToList();
+            return GitLabCollectionResponse.Create(result);
+        }
+    }
+
+    public Task DeleteTagAsync(long repositoryId, string tagName, CancellationToken cancellationToken = default)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(projectId, ProjectPermission.Edit);
+            var repo = project.ContainerRepositories.FirstOrDefault(r => r.Id == repositoryId)
+                ?? throw GitLabException.NotFound();
+            repo.Tags.RemoveAll(t => string.Equals(t.Name, tagName, System.StringComparison.Ordinal));
+            return Task.CompletedTask;
+        }
+    }
+
+    public Task DeleteRepositoryAsync(long repositoryId, CancellationToken cancellationToken = default)
+    {
+        using (Context.BeginOperationScope())
+        {
+            var project = GetProject(projectId, ProjectPermission.Edit);
+            var repo = project.ContainerRepositories.FirstOrDefault(r => r.Id == repositoryId)
+                ?? throw GitLabException.NotFound();
+            project.ContainerRepositories.Remove(repo);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/NGitLab.Mock/Clients/GitLabClient.cs
+++ b/NGitLab.Mock/Clients/GitLabClient.cs
@@ -107,4 +107,6 @@ internal sealed class GitLabClient(ClientContext context) : ClientBase(context),
     public IGroupHooksClient GetGroupHooksClient(GroupId groupId) => new GroupHooksClient(Context, groupId);
 
     public IProjectJobTokenScopeClient GetProjectJobTokenScopeClient(ProjectId projectId) => new ProjectJobTokenScopeClient(Context, projectId);
+
+    public IContainerRegistryClient GetContainerRegistry(ProjectId projectId) => new ContainerRegistryClient(Context, projectId);
 }

--- a/NGitLab.Mock/Config/GitLabContainerRepository.cs
+++ b/NGitLab.Mock/Config/GitLabContainerRepository.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace NGitLab.Mock.Config;
+
+/// <summary>
+/// Describe a container repository in a GitLab project
+/// </summary>
+public class GitLabContainerRepository : GitLabObject
+{
+    public string Name { get; set; }
+
+    public List<string> Tags { get; } = [];
+}
+
+public class GitLabContainerRepositoriesCollection : GitLabCollection<GitLabContainerRepository>
+{
+    internal GitLabContainerRepositoriesCollection(GitLabProject parent)
+        : base(parent)
+    {
+    }
+}

--- a/NGitLab.Mock/Config/GitLabHelpers.cs
+++ b/NGitLab.Mock/Config/GitLabHelpers.cs
@@ -618,6 +618,33 @@ public static class GitLabHelpers
     }
 
     /// <summary>
+    /// Add a container repository in project
+    /// </summary>
+    /// <param name="project">Project.</param>
+    /// <param name="name">Repository name.</param>
+    /// <param name="tags">Tag names.</param>
+    public static GitLabProject WithContainerRepository(this GitLabProject project, string name, IEnumerable<string>? tags = null)
+    {
+        return Configure(project, _ =>
+        {
+            var repo = new GitLabContainerRepository
+            {
+                Name = name ?? throw new ArgumentNullException(nameof(name)),
+            };
+
+            if (tags != null)
+            {
+                foreach (var tag in tags)
+                {
+                    repo.Tags.Add(tag);
+                }
+            }
+
+            project.ContainerRepositories.Add(repo);
+        });
+    }
+
+    /// <summary>
     /// Add label in issue (create it if not exists)
     /// </summary>
     /// <param name="issue">Issue.</param>
@@ -1314,6 +1341,11 @@ public static class GitLabHelpers
             CreatePipeline(server, prj, pipeline, aliases);
         }
 
+        foreach (var containerRepository in project.ContainerRepositories)
+        {
+            CreateContainerRepository(prj, containerRepository);
+        }
+
         if (!string.IsNullOrEmpty(project.ClonePath))
         {
             var folderPath = Path.GetDirectoryName(Path.GetFullPath(project.ClonePath));
@@ -1355,6 +1387,21 @@ public static class GitLabHelpers
         };
 
         project.Releases.Add(release);
+    }
+
+    private static void CreateContainerRepository(Project project, GitLabContainerRepository containerRepository)
+    {
+        var repo = new ContainerRepository
+        {
+            Name = containerRepository.Name,
+        };
+
+        foreach (var tag in containerRepository.Tags)
+        {
+            repo.Tags.Add(new ContainerRegistryTagEntry { Name = tag, });
+        }
+
+        project.ContainerRepositories.Add(repo);
     }
 
     private static Commit CreateCommit(GitLabServer server, Project prj, GitLabCommit commit)

--- a/NGitLab.Mock/Config/GitLabProject.cs
+++ b/NGitLab.Mock/Config/GitLabProject.cs
@@ -17,6 +17,7 @@ public class GitLabProject : GitLabObject<GitLabConfig>
         Milestones = new GitLabMilestonesCollection(this);
         Pipelines = new GitLabPipelinesCollection(this);
         Releases = new GitLabReleaseInfoCollection(this);
+        ContainerRepositories = new GitLabContainerRepositoriesCollection(this);
     }
 
     /// <summary>
@@ -64,6 +65,8 @@ public class GitLabProject : GitLabObject<GitLabConfig>
     public GitLabPipelinesCollection Pipelines { get; }
 
     public GitLabReleaseInfoCollection Releases { get; }
+
+    public GitLabContainerRepositoriesCollection ContainerRepositories { get; }
 }
 
 public class GitLabProjectsCollection : GitLabCollection<GitLabProject, GitLabConfig>

--- a/NGitLab.Mock/ContainerRegistryTagEntry.cs
+++ b/NGitLab.Mock/ContainerRegistryTagEntry.cs
@@ -1,0 +1,16 @@
+using NGitLab.Models;
+
+namespace NGitLab.Mock;
+
+public sealed class ContainerRegistryTagEntry
+{
+    public string Name { get; set; }
+
+    public Models.ContainerRegistryTag ToClientContainerRegistryTag()
+    {
+        return new Models.ContainerRegistryTag
+        {
+            Name = Name,
+        };
+    }
+}

--- a/NGitLab.Mock/ContainerRepository.cs
+++ b/NGitLab.Mock/ContainerRepository.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using NGitLab.Models;
+
+namespace NGitLab.Mock;
+
+public sealed class ContainerRepository : GitLabObject
+{
+    public new Project Parent => (Project)base.Parent;
+
+    public long Id { get; set; }
+
+    public string Name { get; set; }
+
+    public List<ContainerRegistryTagEntry> Tags { get; } = [];
+
+    public Models.ContainerRepository ToClientContainerRepository()
+    {
+        return new Models.ContainerRepository
+        {
+            Id = Id,
+            Name = Name,
+            ProjectId = Parent?.Id ?? 0,
+            TagsCount = Tags.Count,
+        };
+    }
+}

--- a/NGitLab.Mock/ContainerRepositoryCollection.cs
+++ b/NGitLab.Mock/ContainerRepositoryCollection.cs
@@ -1,0 +1,9 @@
+namespace NGitLab.Mock;
+
+public sealed class ContainerRepositoryCollection : Collection<ContainerRepository>
+{
+    public ContainerRepositoryCollection(GitLabObject parent)
+        : base(parent)
+    {
+    }
+}

--- a/NGitLab.Mock/Project.cs
+++ b/NGitLab.Mock/Project.cs
@@ -40,6 +40,7 @@ public sealed class Project : GitLabObject
         CommitStatuses = new CommitStatusCollection(this);
         Releases = new ReleaseCollection(this);
         ProtectedBranches = new ProtectedBranchCollection(this);
+        ContainerRepositories = new ContainerRepositoryCollection(this);
         ApprovalsBeforeMerge = 0;
     }
 
@@ -162,6 +163,8 @@ public sealed class Project : GitLabObject
     public ProjectStatistics Statistics { get; set; }
 
     public ProtectedBranchCollection ProtectedBranches { get; }
+
+    public ContainerRepositoryCollection ContainerRepositories { get; }
 
     public string RunnersToken { get; internal set; }
 

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -1381,3 +1381,21 @@ static NGitLab.Mock.TemporaryDirectory.DeleteDirectory(string path) -> void
 static NGitLab.Mock.TemporaryDirectory.DeleteFile(string path) -> void
 static NGitLab.Mock.UserRef.implicit operator NGitLab.Mock.UserRef(NGitLab.Mock.User user) -> NGitLab.Mock.UserRef
 virtual NGitLab.Mock.Collection<T>.Add(T item) -> void
+
+NGitLab.Mock.ContainerRepository
+NGitLab.Mock.ContainerRepository.ContainerRepository() -> void
+NGitLab.Mock.ContainerRepository.Id.get -> long
+NGitLab.Mock.ContainerRepository.Id.set -> void
+NGitLab.Mock.ContainerRepository.Name.get -> string
+NGitLab.Mock.ContainerRepository.Name.set -> void
+NGitLab.Mock.ContainerRepository.Parent.get -> NGitLab.Mock.Project
+NGitLab.Mock.ContainerRepository.Tags.get -> System.Collections.Generic.List<NGitLab.Mock.ContainerRegistryTagEntry>
+NGitLab.Mock.ContainerRepository.ToClientContainerRepository() -> NGitLab.Models.ContainerRepository
+NGitLab.Mock.ContainerRegistryTagEntry
+NGitLab.Mock.ContainerRegistryTagEntry.ContainerRegistryTagEntry() -> void
+NGitLab.Mock.ContainerRegistryTagEntry.Name.get -> string
+NGitLab.Mock.ContainerRegistryTagEntry.Name.set -> void
+NGitLab.Mock.ContainerRegistryTagEntry.ToClientContainerRegistryTag() -> NGitLab.Models.ContainerRegistryTag
+NGitLab.Mock.ContainerRepositoryCollection
+NGitLab.Mock.ContainerRepositoryCollection.ContainerRepositoryCollection(NGitLab.Mock.GitLabObject parent) -> void
+NGitLab.Mock.Project.ContainerRepositories.get -> NGitLab.Mock.ContainerRepositoryCollection

--- a/NGitLab.Mock/PublicAPI.Unshipped.txt
+++ b/NGitLab.Mock/PublicAPI.Unshipped.txt
@@ -1399,3 +1399,12 @@ NGitLab.Mock.ContainerRegistryTagEntry.ToClientContainerRegistryTag() -> NGitLab
 NGitLab.Mock.ContainerRepositoryCollection
 NGitLab.Mock.ContainerRepositoryCollection.ContainerRepositoryCollection(NGitLab.Mock.GitLabObject parent) -> void
 NGitLab.Mock.Project.ContainerRepositories.get -> NGitLab.Mock.ContainerRepositoryCollection
+
+NGitLab.Mock.Config.GitLabContainerRepository
+NGitLab.Mock.Config.GitLabContainerRepository.GitLabContainerRepository() -> void
+NGitLab.Mock.Config.GitLabContainerRepository.Name.get -> string
+NGitLab.Mock.Config.GitLabContainerRepository.Name.set -> void
+NGitLab.Mock.Config.GitLabContainerRepository.Tags.get -> System.Collections.Generic.List<string>
+NGitLab.Mock.Config.GitLabContainerRepositoriesCollection
+NGitLab.Mock.Config.GitLabProject.ContainerRepositories.get -> NGitLab.Mock.Config.GitLabContainerRepositoriesCollection
+static NGitLab.Mock.Config.GitLabHelpers.WithContainerRepository(this NGitLab.Mock.Config.GitLabProject project, string name, System.Collections.Generic.IEnumerable<string> tags = null) -> NGitLab.Mock.Config.GitLabProject

--- a/NGitLab/GitLabClient.cs
+++ b/NGitLab/GitLabClient.cs
@@ -228,4 +228,7 @@ public class GitLabClient : IGitLabClient
 
     public IProjectJobTokenScopeClient GetProjectJobTokenScopeClient(ProjectId projectId)
         => new ProjectJobTokenScopeClient(_api, projectId);
+
+    public IContainerRegistryClient GetContainerRegistry(ProjectId projectId)
+        => new ContainerRegistryClient(_api, projectId);
 }

--- a/NGitLab/IContainerRegistryClient.cs
+++ b/NGitLab/IContainerRegistryClient.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Models;
+
+namespace NGitLab;
+
+public interface IContainerRegistryClient
+{
+    /// <summary>
+    /// Returns all container repositories for the project.
+    /// </summary>
+    GitLabCollectionResponse<ContainerRepository> GetRepositoriesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all tags for the given repository.
+    /// </summary>
+    GitLabCollectionResponse<ContainerRegistryTag> GetTagsAsync(long repositoryId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a single tag from a repository.
+    /// </summary>
+    Task DeleteTagAsync(long repositoryId, string tagName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a repository and all its tags.
+    /// </summary>
+    Task DeleteRepositoryAsync(long repositoryId, CancellationToken cancellationToken = default);
+}

--- a/NGitLab/IGitLabClient.cs
+++ b/NGitLab/IGitLabClient.cs
@@ -108,4 +108,6 @@ public interface IGitLabClient
     IGroupHooksClient GetGroupHooksClient(GroupId groupId);
 
     IProjectJobTokenScopeClient GetProjectJobTokenScopeClient(ProjectId projectId);
+
+    IContainerRegistryClient GetContainerRegistry(ProjectId projectId);
 }

--- a/NGitLab/Impl/ContainerRegistryClient.cs
+++ b/NGitLab/Impl/ContainerRegistryClient.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Extensions;
+using NGitLab.Models;
+
+namespace NGitLab.Impl;
+
+public class ContainerRegistryClient : IContainerRegistryClient
+{
+    private readonly API _api;
+    private readonly string _projectId;
+
+    public ContainerRegistryClient(API api, ProjectId projectId)
+    {
+        _api = api;
+        _projectId = projectId.ValueAsUriParameter();
+    }
+
+    public GitLabCollectionResponse<ContainerRepository> GetRepositoriesAsync(CancellationToken cancellationToken = default)
+        => _api.Get().GetAllAsync<ContainerRepository>($"/projects/{_projectId}/registry/repositories");
+
+    public GitLabCollectionResponse<ContainerRegistryTag> GetTagsAsync(long repositoryId, CancellationToken cancellationToken = default)
+        => _api.Get().GetAllAsync<ContainerRegistryTag>($"/projects/{_projectId}/registry/repositories/{repositoryId.ToStringInvariant()}/tags");
+
+    public Task DeleteTagAsync(long repositoryId, string tagName, CancellationToken cancellationToken = default)
+        => _api.Delete().ExecuteAsync($"/projects/{_projectId}/registry/repositories/{repositoryId.ToStringInvariant()}/tags/{tagName}", cancellationToken);
+
+    public Task DeleteRepositoryAsync(long repositoryId, CancellationToken cancellationToken = default)
+        => _api.Delete().ExecuteAsync($"/projects/{_projectId}/registry/repositories/{repositoryId.ToStringInvariant()}", cancellationToken);
+}

--- a/NGitLab/Models/ContainerRegistryTag.cs
+++ b/NGitLab/Models/ContainerRegistryTag.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace NGitLab.Models;
+
+public class ContainerRegistryTag
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; }
+
+    [JsonPropertyName("location")]
+    public string Location { get; set; }
+
+    [JsonPropertyName("revision")]
+    public string Revision { get; set; }
+
+    [JsonPropertyName("short_revision")]
+    public string ShortRevision { get; set; }
+
+    [JsonPropertyName("digest")]
+    public string Digest { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("total_size")]
+    public long TotalSize { get; set; }
+}

--- a/NGitLab/Models/ContainerRepository.cs
+++ b/NGitLab/Models/ContainerRepository.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace NGitLab.Models;
+
+public class ContainerRepository
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; }
+
+    [JsonPropertyName("project_id")]
+    public long ProjectId { get; set; }
+
+    [JsonPropertyName("location")]
+    public string Location { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("tags_count")]
+    public int TagsCount { get; set; }
+}

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -5230,3 +5230,51 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
+
+NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.IContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.IGitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient.ContainerRegistryClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
+NGitLab.Impl.ContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.Impl.ContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.Models.ContainerRepository
+NGitLab.Models.ContainerRepository.ContainerRepository() -> void
+NGitLab.Models.ContainerRepository.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRepository.CreatedAt.set -> void
+NGitLab.Models.ContainerRepository.Id.get -> long
+NGitLab.Models.ContainerRepository.Id.set -> void
+NGitLab.Models.ContainerRepository.Location.get -> string
+NGitLab.Models.ContainerRepository.Location.set -> void
+NGitLab.Models.ContainerRepository.Name.get -> string
+NGitLab.Models.ContainerRepository.Name.set -> void
+NGitLab.Models.ContainerRepository.Path.get -> string
+NGitLab.Models.ContainerRepository.Path.set -> void
+NGitLab.Models.ContainerRepository.ProjectId.get -> long
+NGitLab.Models.ContainerRepository.ProjectId.set -> void
+NGitLab.Models.ContainerRepository.TagsCount.get -> int
+NGitLab.Models.ContainerRepository.TagsCount.set -> void
+NGitLab.Models.ContainerRegistryTag
+NGitLab.Models.ContainerRegistryTag.ContainerRegistryTag() -> void
+NGitLab.Models.ContainerRegistryTag.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRegistryTag.CreatedAt.set -> void
+NGitLab.Models.ContainerRegistryTag.Digest.get -> string
+NGitLab.Models.ContainerRegistryTag.Digest.set -> void
+NGitLab.Models.ContainerRegistryTag.Location.get -> string
+NGitLab.Models.ContainerRegistryTag.Location.set -> void
+NGitLab.Models.ContainerRegistryTag.Name.get -> string
+NGitLab.Models.ContainerRegistryTag.Name.set -> void
+NGitLab.Models.ContainerRegistryTag.Path.get -> string
+NGitLab.Models.ContainerRegistryTag.Path.set -> void
+NGitLab.Models.ContainerRegistryTag.Revision.get -> string
+NGitLab.Models.ContainerRegistryTag.Revision.set -> void
+NGitLab.Models.ContainerRegistryTag.ShortRevision.get -> string
+NGitLab.Models.ContainerRegistryTag.ShortRevision.set -> void
+NGitLab.Models.ContainerRegistryTag.TotalSize.get -> long
+NGitLab.Models.ContainerRegistryTag.TotalSize.set -> void

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -5231,3 +5231,51 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
+
+NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.IContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.IGitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient.ContainerRegistryClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
+NGitLab.Impl.ContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.Impl.ContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.Models.ContainerRepository
+NGitLab.Models.ContainerRepository.ContainerRepository() -> void
+NGitLab.Models.ContainerRepository.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRepository.CreatedAt.set -> void
+NGitLab.Models.ContainerRepository.Id.get -> long
+NGitLab.Models.ContainerRepository.Id.set -> void
+NGitLab.Models.ContainerRepository.Location.get -> string
+NGitLab.Models.ContainerRepository.Location.set -> void
+NGitLab.Models.ContainerRepository.Name.get -> string
+NGitLab.Models.ContainerRepository.Name.set -> void
+NGitLab.Models.ContainerRepository.Path.get -> string
+NGitLab.Models.ContainerRepository.Path.set -> void
+NGitLab.Models.ContainerRepository.ProjectId.get -> long
+NGitLab.Models.ContainerRepository.ProjectId.set -> void
+NGitLab.Models.ContainerRepository.TagsCount.get -> int
+NGitLab.Models.ContainerRepository.TagsCount.set -> void
+NGitLab.Models.ContainerRegistryTag
+NGitLab.Models.ContainerRegistryTag.ContainerRegistryTag() -> void
+NGitLab.Models.ContainerRegistryTag.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRegistryTag.CreatedAt.set -> void
+NGitLab.Models.ContainerRegistryTag.Digest.get -> string
+NGitLab.Models.ContainerRegistryTag.Digest.set -> void
+NGitLab.Models.ContainerRegistryTag.Location.get -> string
+NGitLab.Models.ContainerRegistryTag.Location.set -> void
+NGitLab.Models.ContainerRegistryTag.Name.get -> string
+NGitLab.Models.ContainerRegistryTag.Name.set -> void
+NGitLab.Models.ContainerRegistryTag.Path.get -> string
+NGitLab.Models.ContainerRegistryTag.Path.set -> void
+NGitLab.Models.ContainerRegistryTag.Revision.get -> string
+NGitLab.Models.ContainerRegistryTag.Revision.set -> void
+NGitLab.Models.ContainerRegistryTag.ShortRevision.get -> string
+NGitLab.Models.ContainerRegistryTag.ShortRevision.set -> void
+NGitLab.Models.ContainerRegistryTag.TotalSize.get -> long
+NGitLab.Models.ContainerRegistryTag.TotalSize.set -> void

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -5230,3 +5230,51 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
+
+NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.IContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.IGitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient.ContainerRegistryClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
+NGitLab.Impl.ContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.Impl.ContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.Models.ContainerRepository
+NGitLab.Models.ContainerRepository.ContainerRepository() -> void
+NGitLab.Models.ContainerRepository.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRepository.CreatedAt.set -> void
+NGitLab.Models.ContainerRepository.Id.get -> long
+NGitLab.Models.ContainerRepository.Id.set -> void
+NGitLab.Models.ContainerRepository.Location.get -> string
+NGitLab.Models.ContainerRepository.Location.set -> void
+NGitLab.Models.ContainerRepository.Name.get -> string
+NGitLab.Models.ContainerRepository.Name.set -> void
+NGitLab.Models.ContainerRepository.Path.get -> string
+NGitLab.Models.ContainerRepository.Path.set -> void
+NGitLab.Models.ContainerRepository.ProjectId.get -> long
+NGitLab.Models.ContainerRepository.ProjectId.set -> void
+NGitLab.Models.ContainerRepository.TagsCount.get -> int
+NGitLab.Models.ContainerRepository.TagsCount.set -> void
+NGitLab.Models.ContainerRegistryTag
+NGitLab.Models.ContainerRegistryTag.ContainerRegistryTag() -> void
+NGitLab.Models.ContainerRegistryTag.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRegistryTag.CreatedAt.set -> void
+NGitLab.Models.ContainerRegistryTag.Digest.get -> string
+NGitLab.Models.ContainerRegistryTag.Digest.set -> void
+NGitLab.Models.ContainerRegistryTag.Location.get -> string
+NGitLab.Models.ContainerRegistryTag.Location.set -> void
+NGitLab.Models.ContainerRegistryTag.Name.get -> string
+NGitLab.Models.ContainerRegistryTag.Name.set -> void
+NGitLab.Models.ContainerRegistryTag.Path.get -> string
+NGitLab.Models.ContainerRegistryTag.Path.set -> void
+NGitLab.Models.ContainerRegistryTag.Revision.get -> string
+NGitLab.Models.ContainerRegistryTag.Revision.set -> void
+NGitLab.Models.ContainerRegistryTag.ShortRevision.get -> string
+NGitLab.Models.ContainerRegistryTag.ShortRevision.set -> void
+NGitLab.Models.ContainerRegistryTag.TotalSize.get -> long
+NGitLab.Models.ContainerRegistryTag.TotalSize.set -> void

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5231,3 +5231,51 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
+
+NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient
+NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.IContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.IGitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient
+NGitLab.Impl.ContainerRegistryClient.ContainerRegistryClient(NGitLab.Impl.API api, NGitLab.Models.ProjectId projectId) -> void
+NGitLab.Impl.ContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.DeleteTagAsync(long repositoryId, string tagName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.ContainerRegistryClient.GetRepositoriesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRepository>
+NGitLab.Impl.ContainerRegistryClient.GetTagsAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.ContainerRegistryTag>
+NGitLab.Models.ContainerRepository
+NGitLab.Models.ContainerRepository.ContainerRepository() -> void
+NGitLab.Models.ContainerRepository.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRepository.CreatedAt.set -> void
+NGitLab.Models.ContainerRepository.Id.get -> long
+NGitLab.Models.ContainerRepository.Id.set -> void
+NGitLab.Models.ContainerRepository.Location.get -> string
+NGitLab.Models.ContainerRepository.Location.set -> void
+NGitLab.Models.ContainerRepository.Name.get -> string
+NGitLab.Models.ContainerRepository.Name.set -> void
+NGitLab.Models.ContainerRepository.Path.get -> string
+NGitLab.Models.ContainerRepository.Path.set -> void
+NGitLab.Models.ContainerRepository.ProjectId.get -> long
+NGitLab.Models.ContainerRepository.ProjectId.set -> void
+NGitLab.Models.ContainerRepository.TagsCount.get -> int
+NGitLab.Models.ContainerRepository.TagsCount.set -> void
+NGitLab.Models.ContainerRegistryTag
+NGitLab.Models.ContainerRegistryTag.ContainerRegistryTag() -> void
+NGitLab.Models.ContainerRegistryTag.CreatedAt.get -> System.DateTime
+NGitLab.Models.ContainerRegistryTag.CreatedAt.set -> void
+NGitLab.Models.ContainerRegistryTag.Digest.get -> string
+NGitLab.Models.ContainerRegistryTag.Digest.set -> void
+NGitLab.Models.ContainerRegistryTag.Location.get -> string
+NGitLab.Models.ContainerRegistryTag.Location.set -> void
+NGitLab.Models.ContainerRegistryTag.Name.get -> string
+NGitLab.Models.ContainerRegistryTag.Name.set -> void
+NGitLab.Models.ContainerRegistryTag.Path.get -> string
+NGitLab.Models.ContainerRegistryTag.Path.set -> void
+NGitLab.Models.ContainerRegistryTag.Revision.get -> string
+NGitLab.Models.ContainerRegistryTag.Revision.set -> void
+NGitLab.Models.ContainerRegistryTag.ShortRevision.get -> string
+NGitLab.Models.ContainerRegistryTag.ShortRevision.set -> void
+NGitLab.Models.ContainerRegistryTag.TotalSize.get -> long
+NGitLab.Models.ContainerRegistryTag.TotalSize.set -> void


### PR DESCRIPTION
Adds `IContainerRegistryClient` with methods to list repositories, list tags, delete a tag, and delete a repository. Includes mock implementation for tests.