### PR TITLE
chore!: Add UnapproveMergeRequest, GetDiffsAsync with unidiff, and draft notes API

### DIFF
--- a/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestApprovalClient.cs
@@ -22,6 +22,11 @@ internal sealed class MergeRequestApprovalClient : ClientBase, IMergeRequestAppr
         throw new NotImplementedException();
     }
 
+    public void UnapproveMergeRequest()
+    {
+        throw new NotImplementedException();
+    }
+
     public void ResetApprovals()
     {
         throw new NotImplementedException();

--- a/NGitLab.Mock/Clients/MergeRequestClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestClient.cs
@@ -256,6 +256,13 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
         return new MergeRequestApprovalClient(Context, _projectId.GetValueOrDefault(), mergeRequestIid);
     }
 
+    public IMergeRequestDraftNoteClient DraftNotes(long mergeRequestIid)
+    {
+        AssertProjectId();
+
+        return new MergeRequestDraftNoteClient(Context);
+    }
+
     public Models.MergeRequest Close(long mergeRequestIid)
     {
         AssertProjectId();
@@ -725,6 +732,11 @@ internal sealed class MergeRequestClient : ClientBase, IMergeRequestClient
     }
 
     public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid)
+    {
+        throw new NotImplementedException();
+    }
+
+    public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid, MergeRequestDiffQuery query)
     {
         throw new NotImplementedException();
     }

--- a/NGitLab.Mock/Clients/MergeRequestDraftNoteClient.cs
+++ b/NGitLab.Mock/Clients/MergeRequestDraftNoteClient.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Models;
+
+namespace NGitLab.Mock.Clients;
+
+internal sealed class MergeRequestDraftNoteClient : ClientBase, IMergeRequestDraftNoteClient
+{
+    public MergeRequestDraftNoteClient(ClientContext context)
+        : base(context)
+    {
+    }
+
+    public IEnumerable<DraftNote> All => throw new NotImplementedException();
+
+    public Task<DraftNote> CreateAsync(DraftNoteCreate draftNote, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task PublishAllAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -238,11 +238,6 @@ public sealed class GitLabTestContext : IDisposable
             configure?.Invoke(g);
         });
 
-    public (Project Project, MergeRequest MergeRequest) CreateMergeRequest(Action<MergeRequestCreate> configure = null, Action<ProjectCreate> configureProject = null)
-    {
-        return CreateMergeRequestAsync(configure, configureProject).GetAwaiter().GetResult();
-    }
-
     public async Task<(Project Project, MergeRequest MergeRequest)> CreateMergeRequestAsync(Action<MergeRequestCreate> configure = null, Action<ProjectCreate> configureProject = null)
     {
         var client = Client;

--- a/NGitLab.Tests/Docker/GitLabTestContext.cs
+++ b/NGitLab.Tests/Docker/GitLabTestContext.cs
@@ -240,6 +240,11 @@ public sealed class GitLabTestContext : IDisposable
 
     public (Project Project, MergeRequest MergeRequest) CreateMergeRequest(Action<MergeRequestCreate> configure = null, Action<ProjectCreate> configureProject = null)
     {
+        return CreateMergeRequestAsync(configure, configureProject).GetAwaiter().GetResult();
+    }
+
+    public async Task<(Project Project, MergeRequest MergeRequest)> CreateMergeRequestAsync(Action<MergeRequestCreate> configure = null, Action<ProjectCreate> configureProject = null)
+    {
         var client = Client;
         var project = CreateProject(configureProject, initializeWithCommits: true);
 
@@ -272,6 +277,16 @@ public sealed class GitLabTestContext : IDisposable
 
         configure?.Invoke(mergeRequestCreate);
         var mr = client.GetMergeRequest(project.Id).Create(mergeRequestCreate);
+
+        // GitLab computes diff data and merge status asynchronously after MR creation.
+        // Wait until the transient states resolve so callers can immediately query diffs or approvals.
+        var mrClient = client.GetMergeRequest(project.Id);
+        mr = await RetryUntilAsync(
+            () => mrClient[mr.Iid],
+            result => result.DetailedMergeStatus != DetailedMergeStatus.Checking &&
+                      result.DetailedMergeStatus != DetailedMergeStatus.Unchecked &&
+                      result.DetailedMergeStatus != DetailedMergeStatus.Preparing,
+            TimeSpan.FromSeconds(60)).ConfigureAwait(false);
 
         return (project, mr);
     }

--- a/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NGitLab.Tests.Docker;
+using NUnit.Framework;
+
+namespace NGitLab.Tests;
+
+public class MergeRequestApprovalClientTests
+{
+    [Test]
+    [NGitLabRetry]
+    public async Task ApproveMergeRequest_and_UnapproveMergeRequest_roundtrip()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var mrClient = context.Client.GetMergeRequest(project.Id);
+        var approvalClient = mrClient.ApprovalClient(mergeRequest.Iid);
+
+        // Approve
+        var approvals = approvalClient.ApproveMergeRequest();
+        Assert.That(approvals, Is.Not.Null);
+        Assert.That(approvals.Approved, Is.True, "MR should be marked as approved after ApproveMergeRequest");
+
+        // Unapprove — should not throw
+        Assert.DoesNotThrow((TestDelegate)(() => approvalClient.UnapproveMergeRequest()));
+
+        // After unapproval the approval state should show no approved-by entries
+        var state = approvalClient.Approvals;
+        Assert.That(state.ApprovedBy, Is.Empty.Or.Null, "No approvers should remain after unapproving");
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task UnapproveMergeRequest_on_unapproved_mr_does_not_throw()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var approvalClient = context.Client.GetMergeRequest(project.Id).ApprovalClient(mergeRequest.Iid);
+
+        // Calling unapprove on an already-unapproved MR should be idempotent (GitLab returns 401 if already unapproved,
+        // but some versions are lenient). We accept both a silent success and a GitLabException.
+        try
+        {
+            approvalClient.UnapproveMergeRequest();
+        }
+        catch (GitLabException)
+        {
+            // Acceptable: GitLab may return an error when the MR was not approved
+        }
+    }
+}

--- a/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Threading.Tasks;
-using NGitLab.Models;
 using NGitLab.Tests.Docker;
 using NUnit.Framework;
 
@@ -22,7 +22,7 @@ public class MergeRequestApprovalClientTests
         Assert.That(approvals.Approved, Is.True, "MR should be marked as approved after ApproveMergeRequest");
 
         // Unapprove — should not throw
-        Assert.DoesNotThrow((TestDelegate)(() => approvalClient.UnapproveMergeRequest()));
+        Assert.DoesNotThrow((Action)(() => approvalClient.UnapproveMergeRequest()));
 
         // After unapproval the approval state should show no approved-by entries
         var state = approvalClient.Approvals;
@@ -31,21 +31,15 @@ public class MergeRequestApprovalClientTests
 
     [Test]
     [NGitLabRetry]
-    public async Task UnapproveMergeRequest_on_unapproved_mr_does_not_throw()
+    public async Task UnapproveMergeRequest_on_unapproved_mr_throws()
     {
+        // Arrange
         using var context = await GitLabTestContext.CreateAsync();
         var (project, mergeRequest) = context.CreateMergeRequest();
         var approvalClient = context.Client.GetMergeRequest(project.Id).ApprovalClient(mergeRequest.Iid);
 
-        // Calling unapprove on an already-unapproved MR should be idempotent (GitLab returns 401 if already unapproved,
-        // but some versions are lenient). We accept both a silent success and a GitLabException.
-        try
-        {
-            approvalClient.UnapproveMergeRequest();
-        }
-        catch (GitLabException)
-        {
-            // Acceptable: GitLab may return an error when the MR was not approved
-        }
+        // Act/Assert
+        Assert.That((Action)(() => approvalClient.UnapproveMergeRequest()), Throws.TypeOf<GitLabException>(),
+            "Unapproving an unapproved MR should throw a GitLabException");
     }
 }

--- a/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestApprovalClientTests.cs
@@ -12,7 +12,7 @@ public class MergeRequestApprovalClientTests
     public async Task ApproveMergeRequest_and_UnapproveMergeRequest_roundtrip()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mrClient = context.Client.GetMergeRequest(project.Id);
         var approvalClient = mrClient.ApprovalClient(mergeRequest.Iid);
 
@@ -35,7 +35,7 @@ public class MergeRequestApprovalClientTests
     {
         // Arrange
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var approvalClient = context.Client.GetMergeRequest(project.Id).ApprovalClient(mergeRequest.Iid);
 
         // Act/Assert

--- a/NGitLab.Tests/MergeRequest/MergeRequestChangesClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestChangesClientTests.cs
@@ -12,7 +12,7 @@ public class MergeRequestChangesClientTests
     public async Task GetChangesOnMergeRequest()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestChanges = mergeRequestClient.Changes(mergeRequest.Iid);
 

--- a/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestClientTests.cs
@@ -17,7 +17,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_api()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         Assert.That(mergeRequestClient[mergeRequest.Iid].Id, Is.EqualTo(mergeRequest.Id), "Test we can get a merge request by IId");
@@ -61,7 +61,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_rebase()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         // Additional commit in default branch, to create divergence
@@ -102,7 +102,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_rebaseasync_skip_ci()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         // Additional commit in default branch, to create divergence
@@ -144,7 +144,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_id_is_not_equal_to_iid()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (_, mergeRequest) = context.CreateMergeRequest();
+        var (_, mergeRequest) = await context.CreateMergeRequestAsync();
         Assert.That(mergeRequest.Iid, Is.Not.EqualTo(mergeRequest.Id));
     }
 
@@ -174,7 +174,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_delete()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         mergeRequestClient.Delete(mergeRequest.Iid);
@@ -194,7 +194,7 @@ public class MergeRequestClientTests
         // https://about.gitlab.com/releases/2021/04/22/gitlab-13-11-released/#removal-of-merge-request-approvers-endpoint-in-favor-of-approval-rules-api
         context.IgnoreTestIfGitLabVersionOutOfRange(VersionRange.Parse("[,13.11)"));
 
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         var approvalClient = mergeRequestClient.ApprovalClient(mergeRequest.Iid);
@@ -223,7 +223,7 @@ public class MergeRequestClientTests
     public async Task Test_get_unassigned_merge_requests()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         var mergeRequests = mergeRequestClient.Get(new MergeRequestQuery { AssigneeId = QueryAssigneeId.None }).ToList();
@@ -238,7 +238,7 @@ public class MergeRequestClientTests
     public async Task Test_get_assigned_merge_requests()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var userId = context.Client.Users.Current.Id;
         mergeRequestClient.Update(mergeRequest.Iid, new MergeRequestUpdate { AssigneeId = userId });
@@ -255,8 +255,8 @@ public class MergeRequestClientTests
     public async Task Test_set_reviewers_merge_requests()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
-        context.CreateMergeRequest(); // Second MR to verify filter returns only one
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
+        await context.CreateMergeRequestAsync(); // Second MR to verify filter returns only one
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var userId = context.Client.Users.Current.Id;
         mergeRequestClient.Update(mergeRequest.Iid, new MergeRequestUpdate { ReviewerIds = new[] { userId } });
@@ -274,7 +274,7 @@ public class MergeRequestClientTests
     public async Task Test_cancel_merge_when_pipeline_succeeds()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         mergeRequest.MergeWhenPipelineSucceeds = true;
@@ -287,7 +287,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_versions()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
 
         var versions = await GitLabTestContext.RetryUntilAsync(
@@ -305,7 +305,7 @@ public class MergeRequestClientTests
     public async Task Test_merge_request_head_pipeline()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var sourceProjectId = await context.Client.Projects.GetByIdAsync(mergeRequest.SourceProjectId, new SingleProjectQuery());
         JobTests.AddGitLabCiFile(context.Client, sourceProjectId, branch: mergeRequest.SourceBranch);
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);

--- a/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
@@ -15,7 +15,7 @@ public class MergeRequestCommentsClientTests
     public async Task AddCommentToMergeRequest_DeprecatedApi()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestComments = mergeRequestClient.Comments(mergeRequest.Iid);
 
@@ -33,7 +33,7 @@ public class MergeRequestCommentsClientTests
     public async Task AddEditCommentToMergeRequest()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestComments = mergeRequestClient.Comments(mergeRequest.Iid);
 
@@ -72,7 +72,7 @@ public class MergeRequestCommentsClientTests
     public async Task AddCommentToMergeRequestOnArchivedProject()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestComments = mergeRequestClient.Comments(mergeRequest.Iid);
 

--- a/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestCommentsClientTests.cs
@@ -56,13 +56,14 @@ public class MergeRequestCommentsClientTests
         Assert.That(editedComment.Body, Is.EqualTo(commentMessageEdit));
         Assert.That(editedComment.CreatedAt, Is.EqualTo(createdAt));
 
-        // Get all
-        var comments = mergeRequestComments.All.ToArray();
+        // 'All' returns all notes, including system notes that GitLab auto-generates (e.g. "changed the merge status to can be merged" or similar state-change events).
+        // Get all non-system notes
+        var comments = mergeRequestComments.All.Where(c => !c.System).ToArray();
         Assert.That(comments, Is.Not.Empty);
 
         // Delete
         mergeRequestComments.Delete(comment.Id);
-        comments = mergeRequestComments.All.ToArray();
+        comments = mergeRequestComments.All.Where(c => !c.System).ToArray();
         Assert.That(comments, Is.Empty);
     }
 

--- a/NGitLab.Tests/MergeRequest/MergeRequestDiffsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDiffsClientTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NGitLab.Tests.Docker;
+using NUnit.Framework;
+
+namespace NGitLab.Tests;
+
+public class MergeRequestDiffsClientTests
+{
+    [Test]
+    [NGitLabRetry]
+    public async Task GetDiffsAsync_returns_changed_files()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var mrClient = context.Client.GetMergeRequest(project.Id);
+
+        var diffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, query: null).ToListAsync();
+
+        Assert.That(diffs, Has.Count.GreaterThan(0), "At least one diff should be returned");
+        Assert.That(diffs[0].OldPath, Is.Not.Null.And.Not.Empty);
+        Assert.That(diffs[0].NewPath, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetDiffsAsync_with_unidiff_returns_changed_files()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var mrClient = context.Client.GetMergeRequest(project.Id);
+
+        var query = new MergeRequestDiffQuery { Unidiff = true };
+        var diffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, query).ToListAsync();
+
+        Assert.That(diffs, Has.Count.GreaterThan(0), "At least one diff should be returned with unidiff=true");
+        Assert.That(diffs[0].OldPath, Is.Not.Null.And.Not.Empty);
+        Assert.That(diffs[0].NewPath, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task GetDiffsAsync_unidiff_format_starts_with_unified_diff_header()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var mrClient = context.Client.GetMergeRequest(project.Id);
+
+        var plainDiffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, query: null).ToListAsync();
+        var unifiedDiffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, new MergeRequestDiffQuery { Unidiff = true }).ToListAsync();
+
+        Assert.That(plainDiffs, Has.Count.EqualTo(unifiedDiffs.Count), "Both queries should return the same number of files");
+
+        // Unified diff format uses "--- a/..." / "+++ b/..." headers; the plain GitLab format does not.
+        var firstUnified = unifiedDiffs[0].Difference;
+        Assert.That(firstUnified, Does.StartWith("---").Or.StartWith("diff --git"),
+            "Unified diff content should start with standard unified-diff markers");
+    }
+}

--- a/NGitLab.Tests/MergeRequest/MergeRequestDiffsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDiffsClientTests.cs
@@ -13,7 +13,7 @@ public class MergeRequestDiffsClientTests
     public async Task GetDiffsAsync_returns_changed_files()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mrClient = context.Client.GetMergeRequest(project.Id);
 
         var diffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, query: null).ToListAsync();
@@ -28,7 +28,7 @@ public class MergeRequestDiffsClientTests
     public async Task GetDiffsAsync_with_unidiff_returns_changed_files()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mrClient = context.Client.GetMergeRequest(project.Id);
 
         var query = new MergeRequestDiffQuery { Unidiff = true };
@@ -44,7 +44,7 @@ public class MergeRequestDiffsClientTests
     public async Task GetDiffsAsync_unidiff_format_starts_with_unified_diff_header()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mrClient = context.Client.GetMergeRequest(project.Id);
 
         var plainDiffs = await mrClient.GetDiffsAsync(mergeRequest.Iid, query: null).ToListAsync();

--- a/NGitLab.Tests/MergeRequest/MergeRequestDiscussionsClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDiscussionsClientTests.cs
@@ -15,7 +15,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task AddDiscussionToMergeRequest_DiscussionCreated()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 
@@ -39,7 +39,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task GetDiscussion_DiscussionFound()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 
@@ -59,7 +59,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task EditCommentFromDiscussion_CommentEdited()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 
@@ -91,7 +91,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task AddDiscussionToMergeRequestOnArchivedProject()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 
@@ -112,7 +112,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task ResolveDiscussion_AllNotesResolved()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 
@@ -138,7 +138,7 @@ public class MergeRequestDiscussionsClientTests
     public async Task DeleteOneNoteFromDiscussion_DiscussionAndNoteDeleted()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mergeRequestClient = context.Client.GetMergeRequest(project.Id);
         var mergeRequestDiscussions = mergeRequestClient.Discussions(mergeRequest.Iid);
 

--- a/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
@@ -29,19 +29,6 @@ public class MergeRequestDraftNoteClientTests
 
     [Test]
     [NGitLabRetry]
-    public async Task All_returns_empty_when_no_draft_notes_exist()
-    {
-        using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
-        var draftNoteClient = context.Client.GetMergeRequest(project.Id).DraftNotes(mergeRequest.Iid);
-
-        var all = draftNoteClient.All.ToList();
-
-        Assert.That(all, Is.Empty, "No draft notes should exist on a fresh merge request");
-    }
-
-    [Test]
-    [NGitLabRetry]
     public async Task PublishAllAsync_publishes_all_draft_notes()
     {
         using var context = await GitLabTestContext.CreateAsync();

--- a/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using System.Threading.Tasks;
+using NGitLab.Models;
+using NGitLab.Tests.Docker;
+using NUnit.Framework;
+
+namespace NGitLab.Tests;
+
+public class MergeRequestDraftNoteClientTests
+{
+    [Test]
+    [NGitLabRetry]
+    public async Task CreateAsync_adds_draft_note_visible_in_All()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var draftNoteClient = context.Client.GetMergeRequest(project.Id).DraftNotes(mergeRequest.Iid);
+
+        var created = await draftNoteClient.CreateAsync(new DraftNoteCreate { Note = "Draft review comment" });
+
+        Assert.That(created, Is.Not.Null);
+        Assert.That(created.Note, Is.EqualTo("Draft review comment"));
+        Assert.That(created.Id, Is.GreaterThan(0));
+
+        var all = draftNoteClient.All.ToList();
+        Assert.That(all, Has.Count.EqualTo(1), "The created draft note should appear in All");
+        Assert.That(all[0].Id, Is.EqualTo(created.Id));
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task All_returns_empty_when_no_draft_notes_exist()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var draftNoteClient = context.Client.GetMergeRequest(project.Id).DraftNotes(mergeRequest.Iid);
+
+        var all = draftNoteClient.All.ToList();
+
+        Assert.That(all, Is.Empty, "No draft notes should exist on a fresh merge request");
+    }
+
+    [Test]
+    [NGitLabRetry]
+    public async Task PublishAllAsync_publishes_all_draft_notes()
+    {
+        using var context = await GitLabTestContext.CreateAsync();
+        var (project, mergeRequest) = context.CreateMergeRequest();
+        var mrClient = context.Client.GetMergeRequest(project.Id);
+        var draftNoteClient = mrClient.DraftNotes(mergeRequest.Iid);
+
+        await draftNoteClient.CreateAsync(new DraftNoteCreate { Note = "First draft" });
+        await draftNoteClient.CreateAsync(new DraftNoteCreate { Note = "Second draft" });
+
+        Assert.That(draftNoteClient.All.Count(), Is.EqualTo(2), "Two draft notes should exist before publishing");
+
+        await draftNoteClient.PublishAllAsync();
+
+        // After publishing, draft notes should be cleared
+        var remaining = draftNoteClient.All.ToList();
+        Assert.That(remaining, Is.Empty, "Draft notes should be gone after PublishAllAsync");
+
+        // The notes should now appear as regular MR notes/discussions
+        var notes = mrClient.Comments(mergeRequest.Iid).All.ToList();
+        Assert.That(notes.Any(n => string.Equals(n.Body, "First draft", System.StringComparison.Ordinal)
+                                || string.Equals(n.Body, "Second draft", System.StringComparison.Ordinal)), Is.True,
+            "Published draft notes should appear as regular comments");
+    }
+}

--- a/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
+++ b/NGitLab.Tests/MergeRequest/MergeRequestDraftNoteClientTests.cs
@@ -13,7 +13,7 @@ public class MergeRequestDraftNoteClientTests
     public async Task CreateAsync_adds_draft_note_visible_in_All()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var draftNoteClient = context.Client.GetMergeRequest(project.Id).DraftNotes(mergeRequest.Iid);
 
         var created = await draftNoteClient.CreateAsync(new DraftNoteCreate { Note = "Draft review comment" });
@@ -32,7 +32,7 @@ public class MergeRequestDraftNoteClientTests
     public async Task PublishAllAsync_publishes_all_draft_notes()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
         var mrClient = context.Client.GetMergeRequest(project.Id);
         var draftNoteClient = mrClient.DraftNotes(mergeRequest.Iid);
 

--- a/NGitLab.Tests/Milestone/MilestoneClientTests.cs
+++ b/NGitLab.Tests/Milestone/MilestoneClientTests.cs
@@ -69,7 +69,7 @@ public class MilestoneClientTests
     public async Task Test_project_milestone_merge_requests()
     {
         using var context = await GitLabTestContext.CreateAsync();
-        var (project, mergeRequest) = context.CreateMergeRequest();
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync();
 
         var milestoneClient = context.Client.GetMilestone(project.Id);
         var milestone = CreateMilestone(context, MilestoneScope.Projects, project.Id, "my-super-milestone");
@@ -87,7 +87,7 @@ public class MilestoneClientTests
     {
         using var context = await GitLabTestContext.CreateAsync();
         var group = context.CreateGroup();
-        var (project, mergeRequest) = context.CreateMergeRequest(configureProject: project => project.NamespaceId = group.Id);
+        var (project, mergeRequest) = await context.CreateMergeRequestAsync(configureProject: project => project.NamespaceId = group.Id);
 
         var milestoneClient = context.Client.GetGroupMilestone(group.Id);
         var milestone = CreateMilestone(context, MilestoneScope.Groups, group.Id, "my-super-milestone");

--- a/NGitLab/IMergeRequestApprovalClient.cs
+++ b/NGitLab/IMergeRequestApprovalClient.cs
@@ -10,6 +10,8 @@ public interface IMergeRequestApprovalClient
 
     MergeRequestApprovals ApproveMergeRequest(MergeRequestApproveRequest request = null);
 
+    void UnapproveMergeRequest();
+
     /// <summary>
     /// Available only for bot users based on project or group tokens.
     /// </summary>

--- a/NGitLab/IMergeRequestClient.cs
+++ b/NGitLab/IMergeRequestClient.cs
@@ -51,6 +51,8 @@ public interface IMergeRequestClient
 
     GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid);
 
+    GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid, MergeRequestDiffQuery query);
+
     IMergeRequestCommentClient Comments(long mergeRequestIid);
 
     IMergeRequestDiscussionClient Discussions(long mergeRequestIid);
@@ -60,6 +62,8 @@ public interface IMergeRequestClient
     IMergeRequestChangeClient Changes(long mergeRequestIid);
 
     IMergeRequestApprovalClient ApprovalClient(long mergeRequestIid);
+
+    IMergeRequestDraftNoteClient DraftNotes(long mergeRequestIid);
 
     IEnumerable<Issue> ClosesIssues(long mergeRequestIid);
 

--- a/NGitLab/IMergeRequestDraftNoteClient.cs
+++ b/NGitLab/IMergeRequestDraftNoteClient.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Models;
+
+namespace NGitLab;
+
+/// <summary>
+/// Client for the GitLab draft notes API:
+/// <c>GET/POST /projects/:id/merge_requests/:iid/draft_notes</c> and
+/// <c>POST /projects/:id/merge_requests/:iid/draft_notes/bulk_publish</c>.
+/// </summary>
+public interface IMergeRequestDraftNoteClient
+{
+    IEnumerable<DraftNote> All { get; }
+
+    Task<DraftNote> CreateAsync(DraftNoteCreate draftNote, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes all draft notes for the merge request in a single request.
+    /// </summary>
+    Task PublishAllAsync(CancellationToken cancellationToken = default);
+}

--- a/NGitLab/Impl/MergeRequestApprovalClient.cs
+++ b/NGitLab/Impl/MergeRequestApprovalClient.cs
@@ -13,6 +13,7 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
     private readonly string _approvalsPath;
     private readonly string _approversPath;
     private readonly string _approvePath;
+    private readonly string _unapprovePath;
     private readonly string _resetApprovalsPath;
     private readonly string _approvalStatePath;
 
@@ -23,6 +24,7 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
         _approvalsPath = projectPath + "/merge_requests/" + iid + "/approvals";
         _approversPath = projectPath + "/merge_requests/" + iid + "/approvers";
         _approvePath = projectPath + "/merge_requests/" + iid + "/approve";
+        _unapprovePath = projectPath + "/merge_requests/" + iid + "/unapprove";
         _resetApprovalsPath = projectPath + "/merge_requests/" + iid + "/reset_approvals";
         _approvalStatePath = projectPath + "/merge_requests/" + iid + "/approval_state";
     }
@@ -31,6 +33,8 @@ public class MergeRequestApprovalClient : IMergeRequestApprovalClient
 
     public MergeRequestApprovals ApproveMergeRequest(MergeRequestApproveRequest request = null)
         => _api.Post().With(request ?? new MergeRequestApproveRequest()).To<MergeRequestApprovals>(_approvePath);
+
+    public void UnapproveMergeRequest() => _api.Post().Execute(_unapprovePath);
 
     public void ChangeApprovers(MergeRequestApproversChange approversChange) => _api.Put().With(approversChange).To<MergeRequestApproversChange>(_approversPath);
 

--- a/NGitLab/Impl/MergeRequestClient.cs
+++ b/NGitLab/Impl/MergeRequestClient.cs
@@ -171,6 +171,17 @@ public class MergeRequestClient : IMergeRequestClient
         return _api.Get().GetAllAsync<Diff>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/diffs");
     }
 
+    public GitLabCollectionResponse<Diff> GetDiffsAsync(long mergeRequestIid, MergeRequestDiffQuery query)
+    {
+        var url = _path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/diffs";
+        if (query?.Unidiff == true)
+        {
+            url = Utils.AddParameter(url, "unidiff", "true");
+        }
+
+        return _api.Get().GetAllAsync<Diff>(url);
+    }
+
     public Task<TimeStats> TimeStatsAsync(long mergeRequestIid, CancellationToken cancellationToken = default)
     {
         return _api.Get().ToAsync<TimeStats>(_path + "/merge_requests/" + mergeRequestIid.ToString(CultureInfo.InvariantCulture) + "/time_stats", cancellationToken);
@@ -183,6 +194,8 @@ public class MergeRequestClient : IMergeRequestClient
     public IMergeRequestCommitClient Commits(long mergeRequestIid) => new MergeRequestCommitClient(_api, _path, mergeRequestIid);
 
     public IMergeRequestApprovalClient ApprovalClient(long mergeRequestIid) => new MergeRequestApprovalClient(_api, _path, mergeRequestIid);
+
+    public IMergeRequestDraftNoteClient DraftNotes(long mergeRequestIid) => new MergeRequestDraftNoteClient(_api, _path, mergeRequestIid);
 
     public IMergeRequestChangeClient Changes(long mergeRequestIid) => new MergeRequestChangeClient(_api, _path, mergeRequestIid);
 

--- a/NGitLab/Impl/MergeRequestDraftNoteClient.cs
+++ b/NGitLab/Impl/MergeRequestDraftNoteClient.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using NGitLab.Models;
+
+namespace NGitLab.Impl;
+
+public class MergeRequestDraftNoteClient : IMergeRequestDraftNoteClient
+{
+    private readonly API _api;
+    private readonly string _draftNotesPath;
+    private readonly string _bulkPublishPath;
+
+    public MergeRequestDraftNoteClient(API api, string projectPath, long mergeRequestIid)
+    {
+        _api = api;
+        var iid = mergeRequestIid.ToString(CultureInfo.InvariantCulture);
+        _draftNotesPath = projectPath + "/merge_requests/" + iid + "/draft_notes";
+        _bulkPublishPath = _draftNotesPath + "/bulk_publish";
+    }
+
+    public IEnumerable<DraftNote> All => _api.Get().GetAll<DraftNote>(_draftNotesPath);
+
+    public Task<DraftNote> CreateAsync(DraftNoteCreate draftNote, CancellationToken cancellationToken = default)
+        => _api.Post().With(draftNote).ToAsync<DraftNote>(_draftNotesPath, cancellationToken);
+
+    public Task PublishAllAsync(CancellationToken cancellationToken = default)
+        => _api.Post().ExecuteAsync(_bulkPublishPath, cancellationToken);
+}

--- a/NGitLab/Models/DraftNote.cs
+++ b/NGitLab/Models/DraftNote.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace NGitLab.Models;
+
+/// <summary>
+/// A draft (unpublished) note on a merge request.
+/// </summary>
+public class DraftNote
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("author_id")]
+    public long AuthorId { get; set; }
+
+    [JsonPropertyName("merge_request_id")]
+    public long MergeRequestId { get; set; }
+
+    [JsonPropertyName("note")]
+    public string Note { get; set; }
+
+    [JsonPropertyName("position")]
+    public Position Position { get; set; }
+}
+
+/// <summary>
+/// Payload for creating a draft note on a merge request.
+/// </summary>
+public class DraftNoteCreate
+{
+    [JsonPropertyName("note")]
+    public string Note { get; set; }
+
+    /// <summary>
+    /// Required for inline (diff) draft notes; omit for general notes.
+    /// </summary>
+    [JsonPropertyName("position")]
+    public Position Position { get; set; }
+}

--- a/NGitLab/Models/MergeRequestDiffQuery.cs
+++ b/NGitLab/Models/MergeRequestDiffQuery.cs
@@ -1,0 +1,13 @@
+namespace NGitLab.Models;
+
+/// <summary>
+/// Query options for <c>GET /projects/:id/merge_requests/:iid/diffs</c>.
+/// </summary>
+public class MergeRequestDiffQuery
+{
+    /// <summary>
+    /// Present diffs in the unified diff format. Default is <see langword="false"/>.
+    /// Requires GitLab 16.5 or later.
+    /// </summary>
+    public bool? Unidiff { get; set; }
+}

--- a/NGitLab/Models/Position.cs
+++ b/NGitLab/Models/Position.cs
@@ -26,8 +26,8 @@ public class Position
     public Sha1? BaseSha { get; set; }
 
     [JsonPropertyName("head_sha")]
-    public Sha1 HeadSha { get; set; }
+    public Sha1? HeadSha { get; set; }
 
     [JsonPropertyName("start_sha")]
-    public Sha1 StartSha { get; set; }
+    public Sha1? StartSha { get; set; }
 }

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -5307,3 +5307,40 @@ NGitLab.Models.ProjectDelete.PermanentlyRemove.get -> bool?
 NGitLab.Models.ProjectDelete.PermanentlyRemove.set -> void
 NGitLab.Models.ProjectDelete.ProjectDelete() -> void
 NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectDelete options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IMergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.IMergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.MergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.Impl.MergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.MergeRequestDraftNoteClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Models.DraftNote
+NGitLab.Models.DraftNote.AuthorId.get -> long
+NGitLab.Models.DraftNote.AuthorId.set -> void
+NGitLab.Models.DraftNote.DraftNote() -> void
+NGitLab.Models.DraftNote.Id.get -> long
+NGitLab.Models.DraftNote.Id.set -> void
+NGitLab.Models.DraftNote.MergeRequestId.get -> long
+NGitLab.Models.DraftNote.MergeRequestId.set -> void
+NGitLab.Models.DraftNote.Note.get -> string
+NGitLab.Models.DraftNote.Note.set -> void
+NGitLab.Models.DraftNote.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNote.Position.set -> void
+NGitLab.Models.DraftNoteCreate
+NGitLab.Models.DraftNoteCreate.DraftNoteCreate() -> void
+NGitLab.Models.DraftNoteCreate.Note.get -> string
+NGitLab.Models.DraftNoteCreate.Note.set -> void
+NGitLab.Models.DraftNoteCreate.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNoteCreate.Position.set -> void
+NGitLab.Models.MergeRequestDiffQuery
+NGitLab.Models.MergeRequestDiffQuery.MergeRequestDiffQuery() -> void
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.get -> bool?
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.set -> void

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -3580,7 +3580,7 @@ NGitLab.Models.PipelineVariable.VariableType.set -> void
 NGitLab.Models.Position
 NGitLab.Models.Position.BaseSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.BaseSha.set -> void
-NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.HeadSha.set -> void
 NGitLab.Models.Position.LineRange.get -> NGitLab.Models.LineRange
 NGitLab.Models.Position.LineRange.set -> void
@@ -3595,7 +3595,7 @@ NGitLab.Models.Position.OldPath.set -> void
 NGitLab.Models.Position.Position() -> void
 NGitLab.Models.Position.PositionType.get -> NGitLab.DynamicEnum<NGitLab.Models.PositionType>
 NGitLab.Models.Position.PositionType.set -> void
-NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.StartSha.set -> void
 NGitLab.Models.PositionType
 NGitLab.Models.PositionType.Image = 1 -> NGitLab.Models.PositionType
@@ -5249,7 +5249,6 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
-
 NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -3581,7 +3581,7 @@ NGitLab.Models.PipelineVariable.VariableType.set -> void
 NGitLab.Models.Position
 NGitLab.Models.Position.BaseSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.BaseSha.set -> void
-NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.HeadSha.set -> void
 NGitLab.Models.Position.LineRange.get -> NGitLab.Models.LineRange
 NGitLab.Models.Position.LineRange.set -> void
@@ -3596,7 +3596,7 @@ NGitLab.Models.Position.OldPath.set -> void
 NGitLab.Models.Position.Position() -> void
 NGitLab.Models.Position.PositionType.get -> NGitLab.DynamicEnum<NGitLab.Models.PositionType>
 NGitLab.Models.Position.PositionType.set -> void
-NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.StartSha.set -> void
 NGitLab.Models.PositionType
 NGitLab.Models.PositionType.Image = 1 -> NGitLab.Models.PositionType
@@ -5250,7 +5250,6 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
-
 NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -5308,3 +5308,40 @@ NGitLab.Models.ProjectDelete.PermanentlyRemove.get -> bool?
 NGitLab.Models.ProjectDelete.PermanentlyRemove.set -> void
 NGitLab.Models.ProjectDelete.ProjectDelete() -> void
 NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectDelete options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IMergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.IMergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.MergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.Impl.MergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.MergeRequestDraftNoteClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Models.DraftNote
+NGitLab.Models.DraftNote.AuthorId.get -> long
+NGitLab.Models.DraftNote.AuthorId.set -> void
+NGitLab.Models.DraftNote.DraftNote() -> void
+NGitLab.Models.DraftNote.Id.get -> long
+NGitLab.Models.DraftNote.Id.set -> void
+NGitLab.Models.DraftNote.MergeRequestId.get -> long
+NGitLab.Models.DraftNote.MergeRequestId.set -> void
+NGitLab.Models.DraftNote.Note.get -> string
+NGitLab.Models.DraftNote.Note.set -> void
+NGitLab.Models.DraftNote.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNote.Position.set -> void
+NGitLab.Models.DraftNoteCreate
+NGitLab.Models.DraftNoteCreate.DraftNoteCreate() -> void
+NGitLab.Models.DraftNoteCreate.Note.get -> string
+NGitLab.Models.DraftNoteCreate.Note.set -> void
+NGitLab.Models.DraftNoteCreate.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNoteCreate.Position.set -> void
+NGitLab.Models.MergeRequestDiffQuery
+NGitLab.Models.MergeRequestDiffQuery.MergeRequestDiffQuery() -> void
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.get -> bool?
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.set -> void

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -5307,3 +5307,40 @@ NGitLab.Models.ProjectDelete.PermanentlyRemove.get -> bool?
 NGitLab.Models.ProjectDelete.PermanentlyRemove.set -> void
 NGitLab.Models.ProjectDelete.ProjectDelete() -> void
 NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectDelete options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IMergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.IMergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.MergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.Impl.MergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.MergeRequestDraftNoteClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Models.DraftNote
+NGitLab.Models.DraftNote.AuthorId.get -> long
+NGitLab.Models.DraftNote.AuthorId.set -> void
+NGitLab.Models.DraftNote.DraftNote() -> void
+NGitLab.Models.DraftNote.Id.get -> long
+NGitLab.Models.DraftNote.Id.set -> void
+NGitLab.Models.DraftNote.MergeRequestId.get -> long
+NGitLab.Models.DraftNote.MergeRequestId.set -> void
+NGitLab.Models.DraftNote.Note.get -> string
+NGitLab.Models.DraftNote.Note.set -> void
+NGitLab.Models.DraftNote.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNote.Position.set -> void
+NGitLab.Models.DraftNoteCreate
+NGitLab.Models.DraftNoteCreate.DraftNoteCreate() -> void
+NGitLab.Models.DraftNoteCreate.Note.get -> string
+NGitLab.Models.DraftNoteCreate.Note.set -> void
+NGitLab.Models.DraftNoteCreate.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNoteCreate.Position.set -> void
+NGitLab.Models.MergeRequestDiffQuery
+NGitLab.Models.MergeRequestDiffQuery.MergeRequestDiffQuery() -> void
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.get -> bool?
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.set -> void

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3580,7 +3580,7 @@ NGitLab.Models.PipelineVariable.VariableType.set -> void
 NGitLab.Models.Position
 NGitLab.Models.Position.BaseSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.BaseSha.set -> void
-NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.HeadSha.set -> void
 NGitLab.Models.Position.LineRange.get -> NGitLab.Models.LineRange
 NGitLab.Models.Position.LineRange.set -> void
@@ -3595,7 +3595,7 @@ NGitLab.Models.Position.OldPath.set -> void
 NGitLab.Models.Position.Position() -> void
 NGitLab.Models.Position.PositionType.get -> NGitLab.DynamicEnum<NGitLab.Models.PositionType>
 NGitLab.Models.Position.PositionType.set -> void
-NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.StartSha.set -> void
 NGitLab.Models.PositionType
 NGitLab.Models.PositionType.Image = 1 -> NGitLab.Models.PositionType
@@ -5249,7 +5249,6 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
-
 NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3581,7 +3581,7 @@ NGitLab.Models.PipelineVariable.VariableType.set -> void
 NGitLab.Models.Position
 NGitLab.Models.Position.BaseSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.BaseSha.set -> void
-NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.HeadSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.HeadSha.set -> void
 NGitLab.Models.Position.LineRange.get -> NGitLab.Models.LineRange
 NGitLab.Models.Position.LineRange.set -> void
@@ -3596,7 +3596,7 @@ NGitLab.Models.Position.OldPath.set -> void
 NGitLab.Models.Position.Position() -> void
 NGitLab.Models.Position.PositionType.get -> NGitLab.DynamicEnum<NGitLab.Models.PositionType>
 NGitLab.Models.Position.PositionType.set -> void
-NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1
+NGitLab.Models.Position.StartSha.get -> NGitLab.Sha1?
 NGitLab.Models.Position.StartSha.set -> void
 NGitLab.Models.PositionType
 NGitLab.Models.PositionType.Image = 1 -> NGitLab.Models.PositionType
@@ -5250,7 +5250,6 @@ virtual NGitLab.Impl.HttpRequestor.ToAsync<T>(string tailAPIUrl, System.Threadin
 virtual NGitLab.RequestOptions.GetResponse(System.Net.HttpWebRequest request) -> System.Net.WebResponse
 virtual NGitLab.RequestOptions.GetResponseAsync(System.Net.HttpWebRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.WebResponse>
 virtual NGitLab.RequestOptions.ShouldRetry(System.Exception ex, int retryNumber) -> bool
-
 NGitLab.GitLabClient.GetContainerRegistry(NGitLab.Models.ProjectId projectId) -> NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient
 NGitLab.IContainerRegistryClient.DeleteRepositoryAsync(long repositoryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5308,3 +5308,40 @@ NGitLab.Models.ProjectDelete.PermanentlyRemove.get -> bool?
 NGitLab.Models.ProjectDelete.PermanentlyRemove.set -> void
 NGitLab.Models.ProjectDelete.ProjectDelete() -> void
 NGitLab.Impl.ProjectClient.DeleteAsync(NGitLab.Models.ProjectId projectId, NGitLab.Models.ProjectDelete options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.IMergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.IMergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.IMergeRequestDraftNoteClient
+NGitLab.IMergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.IMergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Impl.MergeRequestApprovalClient.UnapproveMergeRequest() -> void
+NGitLab.Impl.MergeRequestClient.DraftNotes(long mergeRequestIid) -> NGitLab.IMergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestClient.GetDiffsAsync(long mergeRequestIid, NGitLab.Models.MergeRequestDiffQuery query) -> NGitLab.GitLabCollectionResponse<NGitLab.Models.Diff>
+NGitLab.Impl.MergeRequestDraftNoteClient
+NGitLab.Impl.MergeRequestDraftNoteClient.All.get -> System.Collections.Generic.IEnumerable<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.CreateAsync(NGitLab.Models.DraftNoteCreate draftNote, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<NGitLab.Models.DraftNote>
+NGitLab.Impl.MergeRequestDraftNoteClient.MergeRequestDraftNoteClient(NGitLab.Impl.API api, string projectPath, long mergeRequestIid) -> void
+NGitLab.Impl.MergeRequestDraftNoteClient.PublishAllAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+NGitLab.Models.DraftNote
+NGitLab.Models.DraftNote.AuthorId.get -> long
+NGitLab.Models.DraftNote.AuthorId.set -> void
+NGitLab.Models.DraftNote.DraftNote() -> void
+NGitLab.Models.DraftNote.Id.get -> long
+NGitLab.Models.DraftNote.Id.set -> void
+NGitLab.Models.DraftNote.MergeRequestId.get -> long
+NGitLab.Models.DraftNote.MergeRequestId.set -> void
+NGitLab.Models.DraftNote.Note.get -> string
+NGitLab.Models.DraftNote.Note.set -> void
+NGitLab.Models.DraftNote.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNote.Position.set -> void
+NGitLab.Models.DraftNoteCreate
+NGitLab.Models.DraftNoteCreate.DraftNoteCreate() -> void
+NGitLab.Models.DraftNoteCreate.Note.get -> string
+NGitLab.Models.DraftNoteCreate.Note.set -> void
+NGitLab.Models.DraftNoteCreate.Position.get -> NGitLab.Models.Position
+NGitLab.Models.DraftNoteCreate.Position.set -> void
+NGitLab.Models.MergeRequestDiffQuery
+NGitLab.Models.MergeRequestDiffQuery.MergeRequestDiffQuery() -> void
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.get -> bool?
+NGitLab.Models.MergeRequestDiffQuery.Unidiff.set -> void


### PR DESCRIPTION
Three GitLab API gaps that were missing from NGitLab:

1. `IMergeRequestApprovalClient.UnapproveMergeRequest()`: Reverses a prior approval by the authenticated user.

2. `IMergeRequestClient.GetDiffsAsync(iid, MergeRequestDiffQuery)`: When `MergeRequestDiffQuery.Unidiff` is true, returns diffs in standard unified diff format instead of the default GitLab-specific format.

3. `IMergeRequestClient.DraftNotes(iid)` -> `IMergeRequestDraftNoteClient`: New `IMergeRequestDraftNoteClient` interface and implementation covering:
   - All (GET /draft_notes - list draft notes)
   - CreateAsync (POST /draft_notes)
   - PublishAllAsync (POST /draft_notes/bulk_publish)

All new public symbols are registered in PublicAPI.Unshipped.txt for all TFMs. Mock stubs throw NotImplementedException (consistent with other unimplemented mocks).