### PR TITLE
Add NeedRebase to DetailedMergeStatus enum

### DIFF
--- a/NGitLab/Models/DetailedMergeStatus.cs
+++ b/NGitLab/Models/DetailedMergeStatus.cs
@@ -42,4 +42,6 @@ public enum DetailedMergeStatus
     Preparing,
     [EnumMember(Value = "merge_request_blocked")]
     MergeRequestBlocked,
+    [EnumMember(Value = "need_rebase")]
+    NeedRebase,
 }

--- a/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1804,6 +1804,7 @@ NGitLab.Models.DetailedMergeStatus.DraftStatus = 7 -> NGitLab.Models.DetailedMer
 NGitLab.Models.DetailedMergeStatus.ExternalStatusChecks = 8 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.Mergeable = 9 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.MergeRequestBlocked = 14 -> NGitLab.Models.DetailedMergeStatus
+NGitLab.Models.DetailedMergeStatus.NeedRebase = 15 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotApproved = 10 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotOpen = 11 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.PoliciesDenied = 12 -> NGitLab.Models.DetailedMergeStatus

--- a/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1805,6 +1805,7 @@ NGitLab.Models.DetailedMergeStatus.DraftStatus = 7 -> NGitLab.Models.DetailedMer
 NGitLab.Models.DetailedMergeStatus.ExternalStatusChecks = 8 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.Mergeable = 9 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.MergeRequestBlocked = 14 -> NGitLab.Models.DetailedMergeStatus
+NGitLab.Models.DetailedMergeStatus.NeedRebase = 15 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotApproved = 10 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotOpen = 11 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.PoliciesDenied = 12 -> NGitLab.Models.DetailedMergeStatus

--- a/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1804,6 +1804,7 @@ NGitLab.Models.DetailedMergeStatus.DraftStatus = 7 -> NGitLab.Models.DetailedMer
 NGitLab.Models.DetailedMergeStatus.ExternalStatusChecks = 8 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.Mergeable = 9 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.MergeRequestBlocked = 14 -> NGitLab.Models.DetailedMergeStatus
+NGitLab.Models.DetailedMergeStatus.NeedRebase = 15 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotApproved = 10 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotOpen = 11 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.PoliciesDenied = 12 -> NGitLab.Models.DetailedMergeStatus

--- a/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NGitLab/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1805,6 +1805,7 @@ NGitLab.Models.DetailedMergeStatus.DraftStatus = 7 -> NGitLab.Models.DetailedMer
 NGitLab.Models.DetailedMergeStatus.ExternalStatusChecks = 8 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.Mergeable = 9 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.MergeRequestBlocked = 14 -> NGitLab.Models.DetailedMergeStatus
+NGitLab.Models.DetailedMergeStatus.NeedRebase = 15 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotApproved = 10 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.NotOpen = 11 -> NGitLab.Models.DetailedMergeStatus
 NGitLab.Models.DetailedMergeStatus.PoliciesDenied = 12 -> NGitLab.Models.DetailedMergeStatus


### PR DESCRIPTION
GitLab returns `need_rebase` as a `detailed_merge_status` when an MR has diverged from its target branch and must be rebased before merging. 

https://docs.gitlab.com/api/merge_requests/#merge-status